### PR TITLE
Added failures to authentication and source connection. Will also try to make websocket urls valid

### DIFF
--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -167,8 +167,8 @@ public class ExtensionWebSocketClient {
             url = "wss://" + url;
         }
         
-        // Ensure it ends with /api/v1/wsock/websocket
-        if (!url.matches("/api/v[0-9]+/wsock/websocket$")) {
+        // Ensure it ends with /api/v{version number}/wsock/websocket
+        if (!url.matches(".*/api/v[0-9]+/wsock/websocket")) {
          // Sometimes generic urls end with a '/' already, so we only want to add one if it does not already exist
             if (!url.endsWith("/")) { 
                 url = url + "/";

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -148,9 +148,35 @@ public class ExtensionWebSocketClient {
                     .readTimeout(0, TimeUnit.MILLISECONDS)
                     .writeTimeout(0, TimeUnit.MILLISECONDS)
                     .build();
-            WebSocketCall.create(client, new Request.Builder().url(url).build()).enqueue(listener);
+            WebSocketCall.create(client, new Request.Builder()
+                    .url(validifyUrl(url))
+                    .build()).enqueue(listener);
         }
         return webSocketFuture;
+    }
+    
+    private String validifyUrl(String url) {
+        // Ensure prepended by wss:// and not http:// or https://
+        if (url.startsWith("http://")) {
+            url.substring("http://".length(), url.length());
+        }
+        if (url.startsWith("https://")) {
+            url.substring("https://".length(), url.length());
+        }
+        if (!url.startsWith("ws://") && !url.startsWith("wss://")) {
+            url = "wss://" + url;
+        }
+        
+        // Ensure it ends with /api/v1/wsock/websocket
+        if (!url.matches("/api/v[0-9]+/wsock/websocket$")) {
+         // Sometimes generic urls end with a '/' already, so we only want to add one if it does not already exist
+            if (!url.endsWith("/")) { 
+                url = url + "/";
+            }
+            url = url + "api/v1/wsock/websocket";
+        }
+        
+        return url;
     }
 
     /**

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
@@ -331,6 +331,8 @@ public class ExtensionWebSocketListener implements WebSocketListener{
                 if ((int) msg.get("status") == 200 && !client.isAuthed()) {
                     // Forcibly setting in case an error occurred before succeeding
                     client.authFuture.obtrudeValue(true);
+                    // Signal that an authentication has succeeded
+                    client.authSuccess.complete(null);
                 }
                 else {
                     client.authFuture.complete(false);
@@ -339,7 +341,7 @@ public class ExtensionWebSocketListener implements WebSocketListener{
                     this.authHandler.handleMessage(msg);
                 }
                 else {
-                    log.warn("Authorization received with no handler set");
+                    log.warn("Authentication received with no handler set");
                 }
 
             }

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
@@ -271,7 +271,6 @@ public class ExtensionWebSocketListener implements WebSocketListener{
         log.info("WebSocket open");
     }
 
-    private final String CONNECT_ERROR = "io.vantiq.sourcemgr.connectExtension";
     
     /**
      * Translate the received message and pass it on to the related handler. Additionally, updates the client about
@@ -319,12 +318,7 @@ public class ExtensionWebSocketListener implements WebSocketListener{
                 // Is an error message before successful connection to the target source
                 // This is most likely a failure related to a source connection request
                 if (!client.isConnected() && (Integer) msg.get("status") >= 300) {
-                    if (msg.get("body") instanceof Map && ((Map)msg.get("body")).get("code") instanceof String) {
-                        String errorCode = (String) ((Map)msg.get("body")).get("code");
-                        if (errorCode.startsWith(CONNECT_ERROR)) {
-                            client.sourceFuture.complete(false);
-                        }
-                    }
+                    client.sourceFuture.complete(false);
                 }
                 if (this.httpHandler != null) {
                     this.httpHandler.handleMessage(msg);


### PR DESCRIPTION
Failures to connect and to authenticate are now automatically set instead of implicitly relying on the user to handle it. Additionally, EWSClient will now try to make the url for the websocket valid if it is the basic url of the Vantiq server.