### PR TITLE
Add operation/protocol support for RECONNECT_REQUIRED operation.

### DIFF
--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionServiceMessage.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionServiceMessage.java
@@ -23,6 +23,7 @@ public class ExtensionServiceMessage {
     public static final String OP_PUBLISH = "publish";
     public static final String OP_NOTIFICATION = "notification";
     public static final String OP_QUERY = "query";
+    public static final String OP_RECONNECT_REQUIRED = "reconnectRequired";
     public static final MediaType CONTENT_TYPE_JSON = MediaType.parse("application/json; charset=utf-8");
     public static final String RETURN_HEADER = "REPLY_ADDR_HEADER";
     public static final String REPLY_ADDRESS = "X-Reply-Address";


### PR DESCRIPTION
This will be sent if the extension source manager deactivates
the source -- which happens when the config changes (amongst other times).

Proper response is to reconnect.  The WebSocket session is undisturbed by this
case, although the session is no longer associated with the source.