### PR TITLE
Clarity improvements for EWSL's Handlers and getting from ExtensionServiceMessage and Response

### DIFF
--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionServiceMessage.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionServiceMessage.java
@@ -152,7 +152,7 @@ public class ExtensionServiceMessage {
      * @throws IllegalArgumentException if the msg parameter with neither a Map nor an ExtensionServiceMessage
      *
      */
-    public static String extractReplyAddress(Object msg) {
+    public static String extractQueryAddressFromMaybeMap(Object msg) {
         String repAddr = null;
         Object maybeRepAddr = null;
         if (msg instanceof Map) {
@@ -170,6 +170,24 @@ public class ExtensionServiceMessage {
         } else {
             throw new IllegalArgumentException("extractReplyAddress requires either a Map or ExtensionServiceMessage; received " + msg.getClass().getName());
         }
+        if (maybeRepAddr instanceof String) {
+            repAddr = (String) maybeRepAddr;
+        }
+        return repAddr;
+    }
+    
+    /**
+     * Extract reply address from a message.
+     *
+     * @param msg Message from which to extract the reply address
+     * @return String The reply address (or null if absent).
+     */
+    public String extractQueryAddress() {
+        String repAddr = null;
+        Object maybeRepAddr = null;
+
+        maybeRepAddr = this.messageHeaders.get(ExtensionServiceMessage.ORIGIN_ADDRESS_LOCATION);
+
         if (maybeRepAddr instanceof String) {
             repAddr = (String) maybeRepAddr;
         }

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionServiceMessage.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionServiceMessage.java
@@ -25,8 +25,8 @@ public class ExtensionServiceMessage {
     public static final String OP_QUERY = "query";
     public static final String OP_RECONNECT_REQUIRED = "reconnectRequired";
     public static final MediaType CONTENT_TYPE_JSON = MediaType.parse("application/json; charset=utf-8");
-    public static final String ORIGIN_ADDRESS_LOCATION = "REPLY_ADDR_HEADER";
-    public static final String RESPONSE_ADDRESS_LOCATION = "X-Reply-Address";
+    public static final String ORIGIN_ADDRESS_HEADER = "REPLY_ADDR_HEADER";
+    public static final String RESPONSE_ADDRESS_HEADER = "X-Reply-Address";
     public static final String PROPERTY_MESSAGE_HEADERS = "messageHeaders";
 
     public String address;
@@ -152,42 +152,24 @@ public class ExtensionServiceMessage {
      * @throws IllegalArgumentException if the msg parameter with neither a Map nor an ExtensionServiceMessage
      *
      */
-    public static String extractQueryAddressFromMaybeMap(Object msg) {
+    public static String extractReplyAddress(Object msg) {
         String repAddr = null;
         Object maybeRepAddr = null;
         if (msg instanceof Map) {
             Map msgMap = (Map) msg;
             Object maybeMap = msgMap.get(ExtensionServiceMessage.PROPERTY_MESSAGE_HEADERS);
             if (maybeMap instanceof Map) {
-                maybeRepAddr = ((Map) msgMap.get(ExtensionServiceMessage.PROPERTY_MESSAGE_HEADERS)).get(ExtensionServiceMessage.ORIGIN_ADDRESS_LOCATION);
+                maybeRepAddr = ((Map) msgMap.get(ExtensionServiceMessage.PROPERTY_MESSAGE_HEADERS)).get(ExtensionServiceMessage.ORIGIN_ADDRESS_HEADER);
                 if (maybeRepAddr != null && maybeRepAddr instanceof String) {
                     repAddr = (String) maybeRepAddr;
                 }
             }
         } else if (msg instanceof ExtensionServiceMessage) {
             ExtensionServiceMessage esm = (ExtensionServiceMessage) msg;
-            maybeRepAddr = esm.messageHeaders.get(ExtensionServiceMessage.ORIGIN_ADDRESS_LOCATION);
+            maybeRepAddr = esm.messageHeaders.get(ExtensionServiceMessage.ORIGIN_ADDRESS_HEADER);
         } else {
             throw new IllegalArgumentException("extractReplyAddress requires either a Map or ExtensionServiceMessage; received " + msg.getClass().getName());
         }
-        if (maybeRepAddr instanceof String) {
-            repAddr = (String) maybeRepAddr;
-        }
-        return repAddr;
-    }
-    
-    /**
-     * Extract reply address from a message.
-     *
-     * @param msg Message from which to extract the reply address
-     * @return String The reply address (or null if absent).
-     */
-    public String extractQueryAddress() {
-        String repAddr = null;
-        Object maybeRepAddr = null;
-
-        maybeRepAddr = this.messageHeaders.get(ExtensionServiceMessage.ORIGIN_ADDRESS_LOCATION);
-
         if (maybeRepAddr instanceof String) {
             repAddr = (String) maybeRepAddr;
         }

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -223,7 +223,7 @@ public class ExtensionWebSocketClient {
     public void sendQueryResponse(int httpCode, String replyAddress, Map body){
         Response response = new Response()
                 .status(httpCode)
-                .addHeader(ExtensionServiceMessage.REPLY_ADDRESS, replyAddress)
+                .addHeader(ExtensionServiceMessage.RESPONSE_ADDRESS_LOCATION, replyAddress)
                 .body(body);
         send(response);
     }
@@ -241,7 +241,7 @@ public class ExtensionWebSocketClient {
     public void sendQueryResponse(int httpCode, String replyAddress, Map[] body) {
         Response response = new Response()
                 .status(httpCode)
-                .addHeader(ExtensionServiceMessage.REPLY_ADDRESS, replyAddress)
+                .addHeader(ExtensionServiceMessage.RESPONSE_ADDRESS_LOCATION, replyAddress)
                 .body(body);
         send(response);
     }
@@ -466,41 +466,6 @@ public class ExtensionWebSocketClient {
         log.info("Websocket closed for source " + sourceName);
     }
 
-    /**
-     * Extract reply address from a message.
-     *
-     * This is a utility method that examines the various forms a message may take and
-     * extracts the reply address if present.
-     *
-     * @param msg Message from which to extract the reply address
-     * @return String The reply address (or null if absent from msg).
-     *
-     * @throws IllegalArgumentException if the msg parameter with neither a Map nor an ExtensionServiceMessage
-     *
-     */
-    public static String extractReplyAddress(Object msg) {
-        String repAddr = null;
-        Object maybeRepAddr = null;
-        if (msg instanceof Map) {
-            Map msgMap = (Map) msg;
-            Object maybeMap = msgMap.get(ExtensionServiceMessage.PROPERTY_MESSAGE_HEADERS);
-            if (maybeMap instanceof Map) {
-                maybeRepAddr = ((Map) msgMap.get(ExtensionServiceMessage.PROPERTY_MESSAGE_HEADERS)).get(ExtensionServiceMessage.RETURN_HEADER);
-                if (maybeRepAddr != null && maybeRepAddr instanceof String) {
-                    repAddr = (String) maybeRepAddr;
-                }
-            }
-        } else if (msg instanceof ExtensionServiceMessage) {
-            ExtensionServiceMessage esm = (ExtensionServiceMessage) msg;
-            maybeRepAddr = esm.messageHeaders.get(ExtensionServiceMessage.RETURN_HEADER);
-        } else {
-            throw new IllegalArgumentException("extractReplyAddress requires either a Map or ExtensionServiceMessage; received " + msg.getClass().getName());
-        }
-        if (maybeRepAddr instanceof String) {
-            repAddr = (String) maybeRepAddr;
-        }
-        return repAddr;
-    }
 
     /**
      * Set the {@link Handler} for any standard Http response that are received after authentication has completed

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -227,7 +227,7 @@ public class ExtensionWebSocketClient {
     public void sendQueryResponse(int httpCode, String replyAddress, Map body){
         Response response = new Response()
                 .status(httpCode)
-                .addHeader(ExtensionServiceMessage.RESPONSE_ADDRESS_LOCATION, replyAddress)
+                .addHeader(ExtensionServiceMessage.RESPONSE_ADDRESS_HEADER, replyAddress)
                 .body(body);
         send(response);
     }
@@ -245,7 +245,7 @@ public class ExtensionWebSocketClient {
     public void sendQueryResponse(int httpCode, String replyAddress, Map[] body) {
         Response response = new Response()
                 .status(httpCode)
-                .addHeader(ExtensionServiceMessage.RESPONSE_ADDRESS_LOCATION, replyAddress)
+                .addHeader(ExtensionServiceMessage.RESPONSE_ADDRESS_HEADER, replyAddress)
                 .body(body);
         send(response);
     }
@@ -578,19 +578,5 @@ public class ExtensionWebSocketClient {
      */
     public void setReconnectHandler(Handler<ExtensionServiceMessage> reconnectHandler) {
         this.listener.setReconnectHandler(reconnectHandler);
-    }
-    /**
-     * Set a {@link Handler} for all messages received. When set
-     * this handler keeps all other handlers and related logic from firing. Setting this before a successful connection
-     * will stop the connected {@link ExtensionWebSocketClient} from functioning correctly by keeping it from recording
-     * successful connections and authorizations. As such, this must be used only when A) you want to decouple
-     * this listener from {@link ExtensionWebSocketClient} or B) the client has already successfully authed.
-     * <p>
-     * The handler will receive a {@link Map} of the message received
-     *
-     * @param overrideHandler   {@link Handler} that deals with every message received from the Vantiq server
-     */
-    public void setOverrideHandler(Handler<Map<String,Object>> overrideHandler) {
-        this.listener.setOverrideHandler(overrideHandler);
     }
 }

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -479,7 +479,7 @@ public class ExtensionWebSocketClient {
      *
      * @param httpHandler   {@link Handler} that deals with Http responses
      */
-    public void setHttpHandler(Handler<Map> httpHandler) {
+    public void setHttpHandler(Handler<Response> httpHandler) {
         this.listener.setHttpHandler(httpHandler);
     }
     /**
@@ -494,7 +494,7 @@ public class ExtensionWebSocketClient {
      * @param publishHandler    {@link Handler} that deals with any publishes from a source without its own publish
      *                          {@link Handler}
      */
-    public void setPublishHandler(Handler<Map> publishHandler) {
+    public void setPublishHandler(Handler<ExtensionServiceMessage> publishHandler) {
         this.listener.setPublishHandler(publishHandler);
     }
     /**
@@ -511,7 +511,7 @@ public class ExtensionWebSocketClient {
      * @param queryHandler   {@link Handler} that deals with any queries from a source without its own query
      *                       {@link Handler}
      */
-    public void setQueryHandler(Handler<Map> queryHandler) {
+    public void setQueryHandler(Handler<ExtensionServiceMessage> queryHandler) {
         this.listener.setQueryHandler(queryHandler);
     }
     /**
@@ -527,7 +527,7 @@ public class ExtensionWebSocketClient {
      * @param configHandler {@link Handler} that deals with any configurations from a source without its own
      *                      configuration {@link Handler}
      */
-    public void setConfigHandler(Handler<Map> configHandler) {
+    public void setConfigHandler(Handler<ExtensionServiceMessage> configHandler) {
         this.listener.setConfigHandler(configHandler);
     }
     /**
@@ -541,7 +541,7 @@ public class ExtensionWebSocketClient {
      *
      * @param authHandler   {@link Handler} that deals with the results of authentication messages
      */
-    public void setAuthHandler(Handler<Map> authHandler) {
+    public void setAuthHandler(Handler<Response> authHandler) {
         this.listener.setAuthHandler(authHandler);
     }
     /**
@@ -554,7 +554,7 @@ public class ExtensionWebSocketClient {
      * 
      * @param reconnectHandler
      */
-    public void setReconnectHandler(Handler<Map> reconnectHandler) {
+    public void setReconnectHandler(Handler<ExtensionServiceMessage> reconnectHandler) {
         this.listener.setReconnectHandler(reconnectHandler);
     }
     /**
@@ -568,7 +568,7 @@ public class ExtensionWebSocketClient {
      *
      * @param overrideHandler   {@link Handler} that deals with every message received from the Vantiq server
      */
-    public void setOverrideHandler(Handler<Map> overrideHandler) {
+    public void setOverrideHandler(Handler<Map<String,Object>> overrideHandler) {
         this.listener.setOverrideHandler(overrideHandler);
     }
 }

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -163,6 +163,10 @@ public class ExtensionWebSocketClient {
                     .url(validifyUrl(url))
                     .build()).enqueue(listener);
         }
+        return getWebsocketConnectionFuture();
+    }
+    
+    public CompletableFuture<Boolean> getWebsocketConnectionFuture() {
         return webSocketFuture;
     }
     
@@ -333,7 +337,7 @@ public class ExtensionWebSocketClient {
             // receive the results
             doAuthentication();
         }
-        return authFuture;
+        return getAuthenticationFuture();
     }
 
     /**
@@ -357,6 +361,15 @@ public class ExtensionWebSocketClient {
             // receive the results
             doAuthentication();
         }
+        return getAuthenticationFuture();
+    }
+    
+    /**
+     * 
+     * @return      A {@link CompletableFuture} that will return true when the authentication succeeds, or false
+     *              when the WebSocket connection fails before authentication can occur.
+     */
+    public CompletableFuture<Boolean> getAuthenticationFuture() {
         return authFuture;
     }
 
@@ -388,6 +401,15 @@ public class ExtensionWebSocketClient {
             // receive the results
             doConnectionToSource();
         }
+        return getSourceConnectionFuture();
+    }
+    
+    /**
+     * 
+     * @return  A {@link CompletableFuture} that will return true when a connection succeeds, or false when
+     *          either the WebSocket connection or authentication fails before the source can connect.
+     */
+    public CompletableFuture<Boolean> getSourceConnectionFuture() {
         return sourceFuture;
     }
     

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
@@ -119,7 +119,7 @@ public class ExtensionWebSocketListener implements WebSocketListener{
                 log.debug("Full message: " + msg);
                 // Prepare a response with an empty body, so that the query doesn't wait for a timeout
                 Object[] body = {msg.getSourceName()};
-                client.sendQueryError(ExtensionServiceMessage.extractReplyAddress(msg),
+                client.sendQueryError(msg.extractQueryAddress(),
                         "Unset Handler",
                         "No handler has been set for source {0}",
                         body);

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/Response.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/Response.java
@@ -31,7 +31,7 @@ import java.util.HashMap;
 
 public class Response {
     public int status;
-    public Map headers;
+    public Map<String,String> headers;
     public Object body;
     public String contentType;
 
@@ -55,5 +55,47 @@ public class Response {
     public Response addHeader(String name, String value) {
         headers.put(name, value);
         return this;
+    }
+    
+    public String getHeader(String name) {
+        return this.headers.get(name);
+    }
+    
+    public Object getBody() {
+        return this.body;
+    }
+    
+    public int getStatus() {
+        return this.status;
+    }
+    
+    public String getContentType() {
+        return this.contentType;
+    }
+
+    @Override
+    public String toString() {
+        return this.asMap().toString();
+    }
+    
+    public static Response fromMap(Map<String,Object> m) {
+        Response resp = new Response();
+        if (m.get("body") instanceof Object) resp.body = m.get("body");
+        if (m.get("status") instanceof Integer) resp.status = (int) m.get("status");
+        if (m.get("headers") instanceof Map) resp.headers = (Map) m.get("headers");
+        if (m.get("contentType") instanceof String) resp.contentType = (String) m.get("contentType");
+        
+        return resp;
+    }
+    
+    public Map<String,Object> asMap() {
+        Map<String, Object> m = new HashMap<>();
+        
+        if (this.body != null) m.put("body", this.body);
+        if (this.status != 0) m.put("status", this.status);
+        if (this.headers != null) m.put("headers", this.headers);
+        if (this.contentType != null) m.put("contentType", this.contentType);
+        
+        return m;
     }
 }

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
@@ -132,7 +132,7 @@ public class TestExtensionWebSocketClient {
         client.sendQueryResponse(200, queryAddress, queryData);
         
         assert socket.compareData("body", queryData);
-        assert socket.compareData("headers." + ExtensionServiceMessage.REPLY_ADDRESS, queryAddress);
+        assert socket.compareData("headers." + ExtensionServiceMessage.RESPONSE_ADDRESS_LOCATION, queryAddress);
         assert socket.compareData("status", 200);
     }
     
@@ -150,7 +150,7 @@ public class TestExtensionWebSocketClient {
         
         // The ArrayList creation is necessary since JSON interprets arrays as ArrayList
         assert socket.compareData("body", new ArrayList<Map>(Arrays.asList(queryData)));
-        assert socket.compareData("headers." + ExtensionServiceMessage.REPLY_ADDRESS, queryAddress);
+        assert socket.compareData("headers." + ExtensionServiceMessage.RESPONSE_ADDRESS_LOCATION, queryAddress);
         assert socket.compareData("status", 200);
     }
     
@@ -162,7 +162,7 @@ public class TestExtensionWebSocketClient {
         
         client.sendQueryError(queryAddress, errorCode, errorMessage, params);
         
-        assert socket.compareData("headers." + ExtensionServiceMessage.REPLY_ADDRESS, queryAddress);
+        assert socket.compareData("headers." + ExtensionServiceMessage.RESPONSE_ADDRESS_LOCATION, queryAddress);
         assert socket.compareData("status", 400);
         // The ArrayList creation is necessary since JSON interprets arrays as ArrayList
         assert socket.compareData("body.parameters", new ArrayList<String>(Arrays.asList(params)));

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
@@ -132,7 +132,7 @@ public class TestExtensionWebSocketClient {
         client.sendQueryResponse(200, queryAddress, queryData);
         
         assert socket.compareData("body", queryData);
-        assert socket.compareData("headers." + ExtensionServiceMessage.RESPONSE_ADDRESS_LOCATION, queryAddress);
+        assert socket.compareData("headers." + ExtensionServiceMessage.RESPONSE_ADDRESS_HEADER, queryAddress);
         assert socket.compareData("status", 200);
     }
     
@@ -150,7 +150,7 @@ public class TestExtensionWebSocketClient {
         
         // The ArrayList creation is necessary since JSON interprets arrays as ArrayList
         assert socket.compareData("body", new ArrayList<Map>(Arrays.asList(queryData)));
-        assert socket.compareData("headers." + ExtensionServiceMessage.RESPONSE_ADDRESS_LOCATION, queryAddress);
+        assert socket.compareData("headers." + ExtensionServiceMessage.RESPONSE_ADDRESS_HEADER, queryAddress);
         assert socket.compareData("status", 200);
     }
     
@@ -162,7 +162,7 @@ public class TestExtensionWebSocketClient {
         
         client.sendQueryError(queryAddress, errorCode, errorMessage, params);
         
-        assert socket.compareData("headers." + ExtensionServiceMessage.RESPONSE_ADDRESS_LOCATION, queryAddress);
+        assert socket.compareData("headers." + ExtensionServiceMessage.RESPONSE_ADDRESS_HEADER, queryAddress);
         assert socket.compareData("status", 400);
         // The ArrayList creation is necessary since JSON interprets arrays as ArrayList
         assert socket.compareData("body.parameters", new ArrayList<String>(Arrays.asList(params)));


### PR DESCRIPTION
* Added getters for the most useful elements of ExtSvcMsg and Response
* EWSListener Handlers are now of type ExtSvcMsg or Response, with the exception of the override Handler
* Added getters for the CompletableFutures in EWSClient, so they can be accessed without requesting a message sent
* Renamed the constants for the query addresses. (I think they're a bit clearer now, but still not quite clear. Tell me if you have any thoughts on how to make them better.)
* Relocated extractReplyAddress to ExtSvcMsg, since it seems like it might fit better there