### PR TITLE
Concurrency fix

### DIFF
--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -508,13 +508,14 @@ public class ExtensionWebSocketClient {
                 }
             }
         }
-        webSocket = null;
-        // TODO better to obtrude null or false?
-        // Make sure anything still using these futures know that they are no longer valid
-        webSocketFuture.obtrudeValue(false);
-        authFuture.obtrudeValue(false);
-        sourceFuture.obtrudeValue(false);
-        initializeFutures();
+        synchronized (this) {
+            webSocket = null;
+            // Make sure anything still using these futures know that they are no longer valid
+            webSocketFuture.obtrudeValue(false);
+            authFuture.obtrudeValue(false);
+            sourceFuture.obtrudeValue(false);
+            initializeFutures();
+        }
         log.info("Websocket closed for source " + sourceName);
     }
 


### PR DESCRIPTION
Fixes the situation in which the EWSC.close() is called (marking all the CompletableFutures as closed) while an auth/config message is still being translated in EWSL.onMessage() (which would mark the CFs as open again), or even worse between the check in onMessage() to see if it's still open and the instruction that sets the CF to open.

For bullet-proofing purposes, is this too paranoid (it's very unlikely and has a small time frame to happen), about right, or not paranoid enough (it's theoretically possible that the connection could reopen and maybe re-auth between the close() and the message finishing translating, but only if the thread is off-CPU for a significant amount of time).