### PR TITLE
EWSC no longer reusable

### DIFF
--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -197,8 +197,7 @@ public class ExtensionWebSocketClient {
      */
     protected String validifyUrl(String url) {
         if (url == null) {
-            log.warn("No websocket url given. Using default of 'wss://dev.vantiq.com/api/v1/wsock/websocket'");
-            return "wss://dev.vantiq.com/api/v1/wsock/websocket";
+            throw new IllegalArgumentException("Must give a valid URL to connect to the websocket");
         }
         
         // Ensure prepended by wss:// and not http:// or https://

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
@@ -455,6 +455,32 @@ public class ExtensionWebSocketListener implements WebSocketListener{
     }
 
     /**
+     * Sets this Listener's handlers to the same as {@code listener}. This function is intended to allow handlers to
+     * maintain state even if the parent {@link ExtensionWebSocketClient} is closed due to websocket issues.
+     * 
+     * @param listener  The {@link ExtensionWebSocketListener} to copy the handlers from.
+     */
+    public void useHandlersFromListener(ExtensionWebSocketListener listener) {
+        this.authHandler = listener.authHandler;
+        this.configHandler = listener.configHandler;
+        this.publishHandler = listener.publishHandler;
+        this.httpHandler = listener.httpHandler;
+        this.queryHandler = listener.queryHandler;
+        this.reconnectHandler = listener.reconnectHandler;
+    }
+    
+    /**
+     * Sets this Listener's handlers to the same as the listener of {@code client}. This function is intended to allow 
+     * handlers to maintain state even if the parent {@link ExtensionWebSocketClient} is closed due to websocket issues.
+     * 
+     * @param client    The {@link ExtensionWebSocketClient} to copy the handlers from.
+     */
+    public void useHandlersFromListener(ExtensionWebSocketClient client) {
+        ExtensionWebSocketListener listener = client.getListener();
+        this.useHandlersFromListener(listener);
+    }
+    
+    /**
      * Logs the code and reason for this listener closing.
      *
      * @param code      The WebSocket code for why this listener is closing
@@ -464,6 +490,9 @@ public class ExtensionWebSocketListener implements WebSocketListener{
     public void onClose(int code, String reason) {
         log.info("Closing websocket code: " + code);
         log.debug(reason);
+        if (!client.isClosed()) {
+            client.close();
+        }
     }
 
     /**

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
@@ -524,6 +524,13 @@ public class ExtensionWebSocketListener implements WebSocketListener{
         else {
             log.error("Failure occurred in listener", e);
         }
-        client.close();
+        
+        // The error occurred during an unknown point during execution. We don't have enough information to determine
+        // what caused it, so we will close
+        if (client.isOpen()) { 
+            client.close();
+        } else { // The websocket never opened, so it must be a problem connecting. Mark the failure and let the user handle it
+            client.webSocketFuture.complete(false);
+        }
     }
 }

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
@@ -111,6 +111,7 @@ public class TestExtensionWebSocketClient {
     
     @Test
     public void testConnectToSource() throws InterruptedException {
+        client.webSocketFuture.complete(true);
         client.authFuture.complete(true);
         client.authSuccess.complete(null);
         
@@ -129,6 +130,7 @@ public class TestExtensionWebSocketClient {
         queryData.put("msg", "val");
         queryData.put("val", "msg");
         
+        client.webSocketFuture.complete(true);
         client.sendQueryResponse(200, queryAddress, queryData);
         
         assert socket.compareData("body", queryData);
@@ -146,6 +148,7 @@ public class TestExtensionWebSocketClient {
         queryData[1].put("message", "value");
         queryData[1].put("value", "message");
         
+        client.webSocketFuture.complete(true);
         client.sendQueryResponse(200, queryAddress, queryData);
         
         // The ArrayList creation is necessary since JSON interprets arrays as ArrayList
@@ -160,6 +163,7 @@ public class TestExtensionWebSocketClient {
         String errorMessage = "Message with params {}='p1' {}='param2'.";
         String errorCode = "io.vantiq.extjsdk.ExampleErrorName";
         
+        client.webSocketFuture.complete(true);
         client.sendQueryError(queryAddress, errorCode, errorMessage, params);
         
         assert socket.compareData("headers." + ExtensionServiceMessage.RESPONSE_ADDRESS_HEADER, queryAddress);


### PR DESCRIPTION
No more potential concurrency issues with EWSC closing then quickly reopening, because that is no longer possible.

Additionally, made validifyUrl() default to "wss://dev.vantiq.com/api/v1/wsock/websocket" when passed a null value.