### PR TITLE
Fixed issue with loggers being incorrectly named

### DIFF
--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -107,7 +107,7 @@ public class ExtensionWebSocketClient {
      */
     public ExtensionWebSocketClient (String sourceName) {
         this.sourceName = sourceName;
-        log = LoggerFactory.getLogger(this.getClass() + "#" + sourceName);
+        log = LoggerFactory.getLogger(this.getClass().getCanonicalName() + "#" + sourceName);
         listener = new ExtensionWebSocketListener(this);
     }
 

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
@@ -88,7 +88,7 @@ public class ExtensionWebSocketListener implements WebSocketListener{
      */
     public ExtensionWebSocketListener(ExtensionWebSocketClient client) {
         this.client = client;
-        log = LoggerFactory.getLogger(this.getClass() + "#" + client.getSourceName());
+        log = LoggerFactory.getLogger(this.getClass().getCanonicalName() + "#" + client.getSourceName());
         initializeDefaultHandlers();
     }
 


### PR DESCRIPTION
Loggers for the extjsdk were named incorrectly, so they couldn't be identified with logback/log4j.