### PR TITLE
Created separate Network Retriever from Camera Retriever

### DIFF
--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -104,6 +104,7 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
      */
     final String FILE_RETRIEVER_FQCN        = "io.vantiq.extsrc.objectRecognition.imageRetriever.FileRetriever";
     final String CAMERA_RETRIEVER_FQCN      = "io.vantiq.extsrc.objectRecognition.imageRetriever.CameraRetriever";
+    final String NETWORK_RETRIEVER_FQCN     = "io.vantiq.extsrc.objectRecognition.imageRetriever.NetworkRetriever";
     final String DEFAULT_IMAGE_RETRIEVER    = "io.vantiq.extsrc.objectRecognition.imageRetriever.DefaultRetriever";
     
     /*
@@ -236,6 +237,8 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
                 retrieverType = FILE_RETRIEVER_FQCN;
             } else if (retrieverType.equals("camera")) {
                 retrieverType = CAMERA_RETRIEVER_FQCN;
+            } else if (retrieverType.equals("network")) {
+                retrieverType = NETWORK_RETRIEVER_FQCN;
             } else if (retrieverType.equals("default")) {
                 retrieverType = DEFAULT_IMAGE_RETRIEVER;
             }


### PR DESCRIPTION
Separate class that extends the ImageRetriever Interface, used to ingest network cameras and run frames through the given Neural Net.

Add "type"="network" and "camera"="_urlToVid_" in  VANTIQ Config "dataSource" field in order to access this retriever