### PR TITLE
Gradle improvements

### DIFF
--- a/extjsdk/README.md
+++ b/extjsdk/README.md
@@ -24,10 +24,10 @@ dependencies on mvnrepository.com are included.
     *   [org.slf4j:slf4j-api Version 1.7.25](https://mvnrepository.com/artifact/org.slf4j/slf4j-api/1.7.25)
 
 ### Method 2 - .jar with dependencies included
-1.	Clone this repository and navigate to <repo location>/vantiq-extension-sources.
-2.	Call `./gradlew extjsdk:shadowJar` or `gradlew extjsdk:shadowJar` depending on your OS.
-3.	Navigate to <repo location>/vantiq-extension-sources/extjsdk/build/libs
-4.	Copy and connect extjsdk-all.jar to your project.
+1.	Clone this repository and navigate to `<repo location>/vantiq-extension-sources`.
+2.	Run `./gradlew extjsdk:fatJar`.
+3.	Navigate to `<repo location>/vantiq-extension-sources/extjsdk/build/libs`
+4.	Copy and connect extjsdk-fat.jar to your project.
 
 
 ## Logging

--- a/extjsdk/build.gradle
+++ b/extjsdk/build.gradle
@@ -3,13 +3,9 @@ version 'unspecified'
 
 buildscript {
     repositories {jcenter() }
-    dependencies {
-        classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.0'
-    }
 }
 
 apply plugin: 'java'
-apply plugin: 'com.github.johnrengelman.shadow'
 
 sourceCompatibility = 1.8
 
@@ -33,12 +29,7 @@ jar.from(".") {
     into ""
 }
 
-// Copies the README and licenses into the jar
-shadowJar.from(".") {
-    include "README.md"
-    include "LICENSE/*"
-    into ""
-}
+
 
 repositories {
     mavenCentral()
@@ -64,4 +55,18 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
+}
+
+// Create a jar with all dependencies included
+task fatJar(type: Jar) {
+    appendix = 'fat'
+    from sourceSets.main.output
+    from(".") {
+        include "README.md"
+        include "LICENSE/*"
+        into ""
+    }
+    from configurations.runtimeClasspath.
+                findAll( { it.name.endsWith('jar') && !it.name.startsWith('groovy')}).
+                collect( { zipTree(it) })
 }

--- a/extjsdk/build.gradle
+++ b/extjsdk/build.gradle
@@ -26,6 +26,19 @@ ext {
     slf4jApiVersion = '1.7.25'
 }
 
+// Copies the README and licenses into the jar
+jar.from(".") {
+    include "README.md"
+    include "LICENSE/*"
+    into ""
+}
+
+// Copies the README and licenses into the jar
+shadowJar.from(".") {
+    include "README.md"
+    include "LICENSE/*"
+    into ""
+}
 
 repositories {
     mavenCentral()

--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -199,7 +199,7 @@ order, the message of the java exception thrown, the java exception thrown, and 
 of the query that caused the error.  
 
 The messages of exceptions thrown by the standard implementations of NeuralNets and ImageRetrievers will always be in
-the form "<FQCN of the class that spawned the error>.<mini descriptor>: <longer description>".
+the form "&lt;FQCN of the class that spawned the error&gt;.&lt;mini descriptor&gt;: &lt;longer description&gt;".
 
 ## Image Retriever Interface<a name="retrieveInterface" id="retrieveInterface"></a>
 

--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -254,7 +254,7 @@ if `fileLocation` is not set. Queried videos can specify which frame of the vide
 option.  
 
 Errors are thrown whenever an image or video frame cannot be read. Fatal errors are thrown only when a video finishes
-being read when the source setup for constant polling.
+being read when the source is setup for constant polling.
 The options are as follows. Remember to prepend "DS" when using an option in a Query.
 *   fileLocation: Optional. Config and Query. The location of the file to be read. For Config where
     `fileExtension` is "mov", the file must exist at initialization. If this option is not set at Config and the source

--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -254,7 +254,7 @@ if `fileLocation` is not set. Queried videos can specify which frame of the vide
 option.  
 
 Errors are thrown whenever an image or video frame cannot be read. Fatal errors are thrown only when a video finishes
-being read when the source is not setup for to receive Queries.
+being read when the source setup for constant polling.
 The options are as follows. Remember to prepend "DS" when using an option in a Query.
 *   fileLocation: Optional. Config and Query. The location of the file to be read. For Config where
     `fileExtension` is "mov", the file must exist at initialization. If this option is not set at Config and the source

--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -306,7 +306,7 @@ try {
         // starts with:
         // "io.vantiq.extsrc.objectRecognition.imageRetriever.FileRetriever.invalidTargetFrame"
         // when a frame past the end of the video is requested
-        // If this changes or becomes unpredictable, use an else instead with a debug() statement
+        // If this changes or becomes unpredictable, use a log.debug() statement instead of this if statement
         exception(error.code, error.message)
     }
 }
@@ -345,7 +345,7 @@ The timestamp is captured immediately before the copy request is sent. The addit
 
 ## Neural Net Interface<a name="netInterface" id="netInterface"></a>
 
-This is a user written interface that interprets a jpeg encoded image and returns the results in a List of Maps and any
+This is an interface that should interpret a jpeg encoded image and return the results in a List of Maps and any
 other data that the source may need. Settings can be set through configuration or Query messages, and settings may
 differ between the two.
 

--- a/udpSource/build.gradle
+++ b/udpSource/build.gradle
@@ -36,21 +36,18 @@ startScripts{
     }
 }
 
-task copyLogFiles(type: Copy) {
-    from("src/main/resources") 
-    include "log4j2.xml"
-    into "src/dist/logConfig"
-}
-
-task copyDocumentationFiles(type: Copy, dependsOn:copyLogFiles) {
-    from "."
+// Copies the README and licenses into the distribution
+applicationDistribution.from(".") {
     include "README.md"
     include "LICENSE/*"
-    into "src/dist"
+    into ""
 }
 
-distZip.dependsOn copyDocumentationFiles
-distTar.dependsOn copyDocumentationFiles
+// Copies the logger setup into logConfig in the distribution
+applicationDistribution.from("src/main/resources") {
+    include "log4j2.xml"
+    into "logConfig"
+}
 
 dependencies {
    // compile 'extjsdk' // extjsdk.jar must be in


### PR DESCRIPTION
* UDP, extjsdk copy licenses directly into the distribution/jar instead of into src/dist

* The fat-jar for the extjsdk no longer includes  unnecessary groovy files