### PR TITLE
Fixes #53

### DIFF
--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
@@ -245,8 +245,18 @@ public class ExtensionWebSocketListener implements WebSocketListener{
             log.warn("Failed to interpret WebSocket message as Map.", e);
             return;
         }
-        log.debug("Map of the received message: {}", msg);
         
+        //Check to see if we should use log with Debug, or with Error
+        if (msg.containsKey("status")) {
+            int statusCheck = (Integer) msg.get("status");
+            if (statusCheck >= 300) {
+                log.error("Map of the received message: {}", msg);
+            } else {
+                log.debug("Map of the received message: {}", msg);
+            }
+        } else {
+            log.debug("Map of the received message: {}", msg);
+        }
         
         // Now we figure out which handler should receive the message
         


### PR DESCRIPTION
Fixes #53 - Added a check to see what the status in return message is. If status >= 300, then use _log.error_, otherwise use _log.debug_.