### PR TITLE
Added Confidence Threshold value to Config

### DIFF
--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
@@ -18,13 +18,13 @@ import java.util.PriorityQueue;
  * I also used this class in my android sample application here: https://github.com/szaza/android-yolo-v2
  */
 public class YOLOClassifier {
-    private static float OVERLAP_THRESHOLD;
     private final static double anchors[] = {1.08,1.19,  3.42,4.41,  6.63,11.38,  9.42,5.11,  16.62,10.52};
     private final static int SIZE = 13;
     private final static int MAX_RECOGNIZED_CLASSES = 24;
-    private static float THRESHOLD;
     private final static int MAX_RESULTS = 24;
     private final static int NUMBER_OF_BOUNDING_BOX = 5;
+    private static float threshold;
+    private static float overlapThreshold;
     private static YOLOClassifier classifier;
 
     private YOLOClassifier() {}
@@ -32,8 +32,8 @@ public class YOLOClassifier {
     public static YOLOClassifier getInstance(float thresh) {
         if (classifier == null) {
             classifier = new YOLOClassifier();
-            THRESHOLD = thresh;
-            OVERLAP_THRESHOLD = thresh;
+            threshold = thresh;
+            overlapThreshold = thresh;
         }
 
         return  classifier;
@@ -99,7 +99,7 @@ public class YOLOClassifier {
         for (int i=0; i<boundingBox.getClasses().length; i++) {
             ArgMax.Result argMax = new ArgMax(new SoftMax(boundingBox.getClasses()).getValue()).getResult();
             double confidenceInClass = argMax.getMaxValue() * boundingBox.getConfidence();
-            if (confidenceInClass > THRESHOLD) {
+            if (confidenceInClass > threshold) {
                 predictionQueue.add(new Recognition(argMax.getIndex(), labels.get(argMax.getIndex()), (float) confidenceInClass,
                         new BoxPosition((float) (boundingBox.getX() - boundingBox.getWidth() / 2),
                                 (float) (boundingBox.getY() - boundingBox.getHeight() / 2),
@@ -122,7 +122,7 @@ public class YOLOClassifier {
                 boolean overlaps = false;
                 for (Recognition previousRecognition : recognitions) {
                     overlaps = overlaps || (getIntersectionProportion(previousRecognition.getLocation(),
-                            recognition.getLocation()) > OVERLAP_THRESHOLD);
+                            recognition.getLocation()) > overlapThreshold);
                 }
 
                 if (!overlaps) {

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
@@ -18,12 +18,10 @@ import java.util.PriorityQueue;
  * I also used this class in my android sample application here: https://github.com/szaza/android-yolo-v2
  */
 public class YOLOClassifier {
-//    private final static float OVERLAP_THRESHOLD = 0.5f;
     private static float OVERLAP_THRESHOLD;
     private final static double anchors[] = {1.08,1.19,  3.42,4.41,  6.63,11.38,  9.42,5.11,  16.62,10.52};
     private final static int SIZE = 13;
     private final static int MAX_RECOGNIZED_CLASSES = 24;
-//    private final static float THRESHOLD = 0.5f;
     private static float THRESHOLD;
     private final static int MAX_RESULTS = 24;
     private final static int NUMBER_OF_BOUNDING_BOX = 5;

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
@@ -18,20 +18,24 @@ import java.util.PriorityQueue;
  * I also used this class in my android sample application here: https://github.com/szaza/android-yolo-v2
  */
 public class YOLOClassifier {
-    private final static float OVERLAP_THRESHOLD = 0.5f;
+//    private final static float OVERLAP_THRESHOLD = 0.5f;
+    private static float OVERLAP_THRESHOLD;
     private final static double anchors[] = {1.08,1.19,  3.42,4.41,  6.63,11.38,  9.42,5.11,  16.62,10.52};
     private final static int SIZE = 13;
     private final static int MAX_RECOGNIZED_CLASSES = 24;
-    private final static float THRESHOLD = 0.5f;
+//    private final static float THRESHOLD = 0.5f;
+    private static float THRESHOLD;
     private final static int MAX_RESULTS = 24;
     private final static int NUMBER_OF_BOUNDING_BOX = 5;
     private static YOLOClassifier classifier;
 
     private YOLOClassifier() {}
 
-    public static YOLOClassifier getInstance() {
+    public static YOLOClassifier getInstance(float thresh) {
         if (classifier == null) {
             classifier = new YOLOClassifier();
+            THRESHOLD = thresh;
+            OVERLAP_THRESHOLD = thresh;
         }
 
         return  classifier;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -56,6 +56,7 @@ public class YoloProcessor implements NeuralNetInterface {
     String pbFile = null;
     String labelsFile = null;
     String outputDir = null;
+    float threshold = 0.5f;
     int saveRate = 1;
     
     ObjectDetector objectDetector = null;
@@ -65,7 +66,7 @@ public class YoloProcessor implements NeuralNetInterface {
     public void setupImageProcessing(Map<String, ?> neuralNetConfig, String modelDirectory) throws Exception {
         setup(neuralNetConfig, modelDirectory);
         try {
-            objectDetector = new ObjectDetector(pbFile, labelsFile, outputDir, saveRate);
+            objectDetector = new ObjectDetector(threshold, pbFile, labelsFile, outputDir, saveRate);
         } catch (Exception e) {
             throw new Exception(this.getClass().getCanonicalName() + ".yoloBackendSetupError: " 
                     + "Failed to create new ObjectDetector", e);
@@ -91,6 +92,21 @@ public class YoloProcessor implements NeuralNetInterface {
                    + "Could not find 'pbFile' and/or 'labelFile' in the neuralNet configuration");
        }
        
+       if (neuralNet.get("threshold") instanceof Number) {
+           Number threshNum = (Number) neuralNet.get("threshold");
+           float tempThresh = threshNum.floatValue();
+           if (0 <= tempThresh && tempThresh <= 1) {
+               threshold = tempThresh;
+           } else if (0 <= tempThresh && tempThresh <= 100) {
+               threshold = tempThresh/100;
+           } else {
+               log.warn("The threshold specified in the config is not valid. The threshold was set to its default "
+                       + "value of 0.5");
+           }
+       } else {
+           log.debug("The threshold was not specified in the config. Using default threshold value of 0.5.");
+       }
+              
        // Setup the variables for saving images
        if (neuralNet.get("outputDir") instanceof String) {
            outputDir = (String) neuralNet.get("outputDir");

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecConfig.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecConfig.java
@@ -151,6 +151,37 @@ public class TestObjRecConfig {
     }
     
     @Test
+    public void testInvalidThreshold() {
+        Map conf = minimalConfig();
+        neuralNet.put("threshold", 1000);
+        sendConfig(conf);
+        assertFalse("Should not fail when missing 'neuralNet' configuration", configIsFailed());
+        
+        neuralNet.remove("threshold");
+        neuralNet.put("threshold", -1);
+        sendConfig(conf);
+        assertFalse("Should not fail when missing 'neuralNet' configuration", configIsFailed());
+    }
+    
+    @Test
+    public void testValidThreshold() {
+        Map conf = minimalConfig();
+        neuralNet.put("threshold", 0);
+        sendConfig(conf);
+        assertFalse("Should not fail when missing 'neuralNet' configuration", configIsFailed());
+        
+        neuralNet.remove("threshold");
+        neuralNet.put("threshold", 40);
+        sendConfig(conf);
+        assertFalse("Should not fail when missing 'neuralNet' configuration", configIsFailed());
+        
+        neuralNet.remove("threshold");
+        neuralNet.put("threshold", 0.3);
+        sendConfig(conf);
+        assertFalse("Should not fail when missing 'neuralNet' configuration", configIsFailed());
+    }
+    
+    @Test
     public void testMinimalConfig() {
         nCore.start(5); // Need a client to avoid NPEs on sends
         


### PR DESCRIPTION
Fixes #54 - Threshold can now be specified using the config. If no threshold is specified then the default value of 0.5 is used. 

Config values can be between 0-1 or between 0-100, anything outside of these ranges will prompt a warning that the value was invalid, and the threshold will be set to 0.5.