### PR TITLE
Network Retriever - Diagnose Connection

### DIFF
--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/NetworkStreamRetriever.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/NetworkStreamRetriever.java
@@ -62,16 +62,7 @@ public class NetworkStreamRetriever implements ImageRetrieverInterface {
                     "No camera specified in dataSourceConfig");
         }
         if (!capture.isOpened()) {
-            try {
-                URL urlProtocolTest = new URL((String) camera);
-                InputStream urlReadTest = urlProtocolTest.openStream();
-            } catch (MalformedURLException e) {
-                throw new IllegalArgumentException(this.getClass().getCanonicalName() + ".unknownProtocol: "
-                        + "URL specifies unknown protocol");
-            } catch (java.io.IOException e) {
-                throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".badRead: "
-                        + "URL was unable to be read");
-            }
+            diagnoseConnection();
             throw new IllegalArgumentException(this.getClass().getCanonicalName() + ".notVideoStream: " 
                     + "URL does not represent a video stream");
         }
@@ -93,16 +84,8 @@ public class NetworkStreamRetriever implements ImageRetrieverInterface {
         if (matrix.empty()) {
             matrix.release();
             // Check connection to URL first
-            try {
-                URL urlProtocolTest = new URL((String) camera);
-                InputStream urlReadTest = urlProtocolTest.openStream();
-            } catch (MalformedURLException e) {
-                throw new IllegalArgumentException(this.getClass().getCanonicalName() + ".unknownProtocol: "
-                        + "URL specifies unknown protocol");
-            } catch (java.io.IOException e) {
-                throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".badRead: "
-                        + "URL was unable to be read");
-            }
+            diagnoseConnection();
+            
             // Try to recreate video capture once connection is reestablished 
             capture = new VideoCapture(camera);
             
@@ -196,6 +179,19 @@ public class NetworkStreamRetriever implements ImageRetrieverInterface {
         results.setImage(imageByte);
         results.setTimestamp(captureTime);
         return results;
+    }
+    
+    public void diagnoseConnection() throws ImageAcquisitionException{
+        try {
+            URL urlProtocolTest = new URL((String) camera);
+            InputStream urlReadTest = urlProtocolTest.openStream();
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException(this.getClass().getCanonicalName() + ".unknownProtocol: "
+                    + "URL specifies unknown protocol");
+        } catch (java.io.IOException e) {
+            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".badRead: "
+                    + "URL was unable to be read");
+        }
     }
     
     public void close() {

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/NetworkStreamRetriever.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/NetworkStreamRetriever.java
@@ -92,6 +92,21 @@ public class NetworkStreamRetriever implements ImageRetrieverInterface {
         
         if (matrix.empty()) {
             matrix.release();
+            // Check connection to URL first
+            try {
+                URL urlProtocolTest = new URL((String) camera);
+                InputStream urlReadTest = urlProtocolTest.openStream();
+            } catch (MalformedURLException e) {
+                throw new IllegalArgumentException(this.getClass().getCanonicalName() + ".unknownProtocol: "
+                        + "URL specifies unknown protocol");
+            } catch (java.io.IOException e) {
+                throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".badRead: "
+                        + "URL was unable to be read");
+            }
+            // Try to recreate video capture once connection is reestablished 
+            capture = new VideoCapture(camera);
+            
+            // Otherwise, check to see if camera has closed
             if (!capture.isOpened() ) {
                 capture.release();
                 throw new FatalImageException(this.getClass().getCanonicalName() + ".mainCameraClosed: " 


### PR DESCRIPTION
This is addressing the issue Brett experienced when he was getting the exception "Could not obtain frame from camera + 'rtsp://10.0.0.82:554/12' ".

Added a method diagnoseConnection() in Network Retriever to check the camera's connection, and recreate the video capture once connection is reestablished.