### PR TITLE
Convert http:// URLs to ws:// URLs instead of wss://

### DIFF
--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -190,16 +190,22 @@ public class ExtensionWebSocketClient {
         if (url == null) {
             throw new IllegalArgumentException("Must give a valid URL to connect to the websocket");
         }
-        
+
+        boolean usesSSL = true;
         // Ensure prepended by wss:// and not http:// or https://
         if (url.startsWith("http://")) {
             url = url.substring("http://".length());
+            usesSSL = false;
         }
         else if (url.startsWith("https://")) {
             url = url.substring("https://".length());
         }
         if (!url.startsWith("ws://") && !url.startsWith("wss://")) {
-            url = "wss://" + url;
+            String prefix = "wss://";
+            if (!usesSSL) {
+                prefix = "ws://";
+            }
+            url = prefix + url;
         }
         
         // Ensure it ends with /api/v{version number}/wsock/websocket

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
@@ -63,15 +63,19 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase{
         
         url = "http://prod.vantiq.com/api/v1/wsock/websocket";
         url = client.validifyUrl(url);
-        assert url.equals("wss://prod.vantiq.com/api/v1/wsock/websocket");
-        
+        assert url.equals("ws://prod.vantiq.com/api/v1/wsock/websocket");
+
+        url = "http://prod.vantiq.com/";
+        url = client.validifyUrl(url);
+        assert url.equals("ws://prod.vantiq.com/api/v1/wsock/websocket");
+
         url = "http://prod.vantiq.com/api/v/wsock/websocket";
         url = client.validifyUrl(url);
-        assert url.equals("wss://prod.vantiq.com/api/v/wsock/websocket/api/v1/wsock/websocket");
-        
+        assert url.equals("ws://prod.vantiq.com/api/v/wsock/websocket/api/v1/wsock/websocket");
+
         url = "http://prod.vantiq.com/api/v47/wsock/websocket";
         url = client.validifyUrl(url);
-        assert url.equals("wss://prod.vantiq.com/api/v47/wsock/websocket");
+        assert url.equals("ws://prod.vantiq.com/api/v47/wsock/websocket");
         
         url = "https://dev.vantiq.com";
         url = client.validifyUrl(url);
@@ -84,6 +88,22 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase{
         url = "dev.vantiq.com";
         url = client.validifyUrl(url);
         assert url.equals("wss://dev.vantiq.com/api/v1/wsock/websocket");
+
+        url = "https://prod.vantiq.com/api/v1/wsock/websocket";
+        url = client.validifyUrl(url);
+        assert url.equals("wss://prod.vantiq.com/api/v1/wsock/websocket");
+
+        url = "https://prod.vantiq.com/";
+        url = client.validifyUrl(url);
+        assert url.equals("wss://prod.vantiq.com/api/v1/wsock/websocket");
+
+        url = "https://prod.vantiq.com/api/v/wsock/websocket";
+        url = client.validifyUrl(url);
+        assert url.equals("wss://prod.vantiq.com/api/v/wsock/websocket/api/v1/wsock/websocket");
+
+        url = "https://prod.vantiq.com/api/v47/wsock/websocket";
+        url = client.validifyUrl(url);
+        assert url.equals("wss://prod.vantiq.com/api/v47/wsock/websocket");
     }
     
     @Test

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecMain.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecMain.java
@@ -24,7 +24,7 @@ public class TestObjRecMain {
     @Before
     public void setup() {
         ObjectRecognitionMain.authToken             = "gcy1hHR39ge2PNCZeiUbYKAev-G7u-KyPh2Ns4gI0Y8=";
-        ObjectRecognitionMain.targetVantiqServer    = "ws://localhost:8080";
+        ObjectRecognitionMain.targetVantiqServer    = "http://localhost:8080";  // Used to be ws:  -- should handle this directly
         ObjectRecognitionMain.modelDirectory        = "models/";
         System.setSecurityManager(new NoExit());
     }


### PR DESCRIPTION
Fixes #76.

If Vantiq URL is http:, use ws: as the replacement.  Otherwise, "tricky"
and unnatural to get to non-SSL websocket implementations.