### PR TITLE
Fix issues with query stalling when opc connection failure

### DIFF
--- a/opcuaSource/build.gradle
+++ b/opcuaSource/build.gradle
@@ -22,6 +22,7 @@ ext {
     logbackVersion = '1.2.3'
     junitVersion = '4.12'
     commonsCliVersion = '1.4'
+    bouncyCastleVersion = '1.54'
 }
 
 repositories {
@@ -40,6 +41,14 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
     compile "commons-cli:commons-cli:${commonsCliVersion}"
     compile "org.eclipse.milo:sdk-client:${eclipseMiloVersion}"
+
+    // To force the inclusion of the bouncy castle provider libraries into the application build,
+    // we must re-declare these on Milo SDK-client's behalf. The dependency declared
+    // in the stack is optional, so it won't be bundled
+    // into the application plugin's opcuaSource.{tar,zip}
+
+    runtime "org.bouncycastle:bcprov-jdk15on:${bouncyCastleVersion}"
+    runtime "org.bouncycastle:bcpkix-jdk15on:${bouncyCastleVersion}"
 
     testCompile group: 'junit', name: 'junit', version: "${junitVersion}"
     testCompile "org.eclipse.milo:client-examples:${eclipseMiloVersion}"

--- a/opcuaSource/build.gradle
+++ b/opcuaSource/build.gradle
@@ -22,7 +22,7 @@ ext {
     logbackVersion = '1.2.3'
     junitVersion = '4.12'
     commonsCliVersion = '1.4'
-    bouncyCastleVersion = '1.54'
+    bouncyCastleVersion = '1.58'
 }
 
 repositories {

--- a/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/uaOperations/OpcUaESClient.java
+++ b/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/uaOperations/OpcUaESClient.java
@@ -178,6 +178,7 @@ public class OpcUaESClient {
     public void connect() throws ExecutionException, OpcExtConfigException, OpcExtRuntimeException {
         try {
             client.connect().get();
+            connected = true;
         } catch (ExecutionException e) {
             if (e.getMessage().equals("java.nio.channels.UnresolvedAddressException")) {
                 // This indicates that the server is not available.  Throw a more useful exception.

--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Connection.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Connection.java
@@ -276,8 +276,7 @@ public class Connection extends OpcUaTestBase {
 
         // Below, we'll traverse the valid combinations.  None's must be paired and are tested elsewhere
         for (SecurityPolicy secPol : serverSecPols) {
-            if (!secPol.equals(SecurityPolicy.None) && !secPol.equals(SecurityPolicy.Aes256_Sha256_RsaPss)) {
-                // TODO: don't know why the Aes256... policy fails, even with BouncyCastle added.
+            if (!secPol.equals(SecurityPolicy.None)) {
                 for (MessageSecurityMode msgSec : serverMsgModes) {
                     if (!msgSec.equals(MessageSecurityMode.None)) {
                         log.info("Attempting sync connection using [{}, {}]", secPol, msgSec);
@@ -350,8 +349,7 @@ public class Connection extends OpcUaTestBase {
 
         // Below, we'll traverse the valid combinations.  None's must be paired and are tested elsewhere
         for (SecurityPolicy secPol : serverSecPols) {
-            if (!secPol.equals(SecurityPolicy.None) && !secPol.equals(SecurityPolicy.Aes256_Sha256_RsaPss)) {
-                // TODO: don't know why the Aes256... policy fails, even with BouncyCastle added.
+            if (!secPol.equals(SecurityPolicy.None)) {
                 for (MessageSecurityMode msgSec : serverMsgModes) {
                     if (!msgSec.equals(MessageSecurityMode.None)) {
 
@@ -394,8 +392,7 @@ public class Connection extends OpcUaTestBase {
 
         // Below, we'll traverse the valid combinations.  None's must be paired and are tested elsewhere
         for (SecurityPolicy secPol : serverSecPols) {
-            if (!secPol.equals(SecurityPolicy.None) && !secPol.equals(SecurityPolicy.Aes256_Sha256_RsaPss)) {
-                // TODO: don't know why the Aes256... policy fails, even with BouncyCastle added.
+            if (!secPol.equals(SecurityPolicy.None)) {
                 for (MessageSecurityMode msgSec : serverMsgModes) {
                     if (!msgSec.equals(MessageSecurityMode.None)) {
 
@@ -454,8 +451,7 @@ public class Connection extends OpcUaTestBase {
 
         // Below, we'll traverse the valid combinations.  None's must be paired and are tested elsewhere
         for (SecurityPolicy secPol : serverSecPols) {
-            if (!secPol.equals(SecurityPolicy.None) && !secPol.equals(SecurityPolicy.Aes256_Sha256_RsaPss)) {
-                // TODO: don't know why the Aes256... policy fails, even with BouncyCastle added.
+            if (!secPol.equals(SecurityPolicy.None)) {
                 for (MessageSecurityMode msgSec : serverMsgModes) {
                     if (!msgSec.equals(MessageSecurityMode.None)) {
 
@@ -500,8 +496,7 @@ public class Connection extends OpcUaTestBase {
         String invalidCreds = "bogus1, bogus2";
         // Below, we'll traverse the valid combinations.  None's must be paired and are tested elsewhere
         for (SecurityPolicy secPol : serverSecPols) {
-            if (!secPol.equals(SecurityPolicy.None) && !secPol.equals(SecurityPolicy.Aes256_Sha256_RsaPss)) {
-                // TODO: don't know why the Aes256... policy fails, even with BouncyCastle added.
+            if (!secPol.equals(SecurityPolicy.None)) {
                 for (MessageSecurityMode msgSec : serverMsgModes) {
                     if (!msgSec.equals(MessageSecurityMode.None)) {
                         log.info("Attempting sync connection using [{}, {}] using username/password: '{}'", secPol, msgSec, invalidCreds);


### PR DESCRIPTION
Fixes #80 
Fixes #81 

Fixes issue where VAIL query would appear to loop/stall when querying an OPC UA Source that had not successfully connected to the OPC UA Server.

Changes packaging of source to include some libraries that were shown as missing in the field.  Unclear if this is the real problem or not (as problem was not reproducible locally), but will help narrow the issue if it doesn't solve it.
