### PR TITLE
Add support for overriding values returned by the discovery server.

### DIFF
--- a/opcuaSource/README.md
+++ b/opcuaSource/README.md
@@ -68,6 +68,12 @@ For OPC UA sources, the document contains the following properties
  - `securityPolicy` -- This is the specification (URI) of the security policy to be used to communicate with the OPC UA server. The security policy includes information about how (and whether) signing and encryption is done. The list of security policy URI's can be found in the OPC UA documentation.
  - `monitoredItems` -- This is the list of items to be monitored by the OPC UA source.  More detail can be found below.
 
+Additionally, there are some properties that can be added to deal with unusual situations.
+
+ - `replaceDiscoveredLocalhost` -- If this is set to "true", any endpoints returned by the `discoveryEndpoint` that have a host that is a loopback address will be replaced with the host name from `discoveryEndpoint`. This is useful when the discovery server not configured cooperatively.
+ - `serverEndpointOverride` -- If this is set, any server address returned by the `discoveryEndpoint` will be replaced with this value. Again, this is useful when the discovery server is not configured cooperatively.
+ 
+
 ##### <a id="monitored_items"></a> Monitored Items
 
 The OPC UA source can be configured to monitor items (nodes) within the OPC UA server.  Specifically, the source will watch for data value changes for the nodes listed, reporting changes back to the VANTIQ system in the form of a message from the source.

--- a/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/uaOperations/OpcConstants.java
+++ b/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/uaOperations/OpcConstants.java
@@ -22,6 +22,8 @@ public class OpcConstants {
     public static final String CONFIG_SECURITY_POLICY = "securityPolicy";
     public static final String CONFIG_MESSAGE_SECURITY_MODE = "messageSecurityMode";
     public static final String CONFIG_DISCOVERY_ENDPOINT = "discoveryEndpoint";
+    public static final String CONFIG_SERVER_ENDPOINT = "serverEndpointOverride";
+    public static final String CONFIG_REPLACE_DISCOVERED_LOCALHOST = "replaceDiscoveredLocalhost";
     public static final String CONFIG_STORAGE_DIRECTORY = "storageDirectory";
     public static final String CONFIG_IDENTITY_ANONYMOUS = "identityAnonymous";
     public static final String CONFIG_IDENTITY_CERTIFICATE = "identityCertificate";


### PR DESCRIPTION
Some discovery servers appear to be misconfigured.  They return server
addresses whose host is 'localhost'.  That value is not very useful
if the connector is running on a different node.  We add two (2) ways
to fix that.

1) if `replaceDiscoveredLocalhost` is set to `true` in the source configuration,
the connector will change endpoints set to loopback addresses to point to the
same machine on which the discovery server is running.  This will make them
non-self-relative.

2) If that's not enough, set `serverEndpointOverride` to be the the URL to use
for the server.  After discovery, we'll replace the entire endpoint as
specified by this value.

Also:  Added additional diagnostics about discovery so that we see what
information discovery returns and how we interpret it.  Hopefully, this will
help us sort out misconfigurations more quickly.