### PR TITLE
Increase log level for SDK;  allow boolean option in config file

### DIFF
--- a/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/uaOperations/OpcUaESClient.java
+++ b/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/uaOperations/OpcUaESClient.java
@@ -150,10 +150,15 @@ public class OpcUaESClient {
         storageDirectory = opcConfig.get(OpcConstants.CONFIG_STORAGE_DIRECTORY) != null
                 ? (String) opcConfig.get(OpcConstants.CONFIG_STORAGE_DIRECTORY) : defaultStorageDirectory;
 
-        if (theConfig.containsKey(OpcConstants.CONFIG_REPLACE_DISCOVERED_LOCALHOST)) {
-            Object replLH = theConfig.get(OpcConstants.CONFIG_REPLACE_DISCOVERED_LOCALHOST);
+        if (opcConfig.containsKey(OpcConstants.CONFIG_REPLACE_DISCOVERED_LOCALHOST)) {
+            Object replLH = opcConfig.get(OpcConstants.CONFIG_REPLACE_DISCOVERED_LOCALHOST);
             if (replLH instanceof String) {
                 replaceLocalhostInDiscoveredEndpoints = replLH.toString().equalsIgnoreCase("true");
+            } else if (replLH instanceof Boolean) {
+                replaceLocalhostInDiscoveredEndpoints = (Boolean) replLH;
+            } else {
+                log.error(ERROR_PREFIX + ".invalid configuration item: " + OpcConstants.CONFIG_REPLACE_DISCOVERED_LOCALHOST
+                        + " -- type must be string or boolean.  Found: " + replLH.getClass().getName());
             }
         }
 

--- a/opcuaSource/src/main/resources/log4j2.xml
+++ b/opcuaSource/src/main/resources/log4j2.xml
@@ -7,10 +7,10 @@
   </Appenders>
   <Loggers>
 
-    <Logger name="org.eclipse.milo" level="WARN"/>
+    <Logger name="org.eclipse.milo" level="DEBUG"/>
     <Logger name="io.netty" level="WARN"/>
     <Logger name="io.vantiq.extsrc.opcua" level="DEBUG"/>
-    <Logger name="io.vantiq.extjsdk" level="info"/>
+    <Logger name="io.vantiq.extjsdk" level="INFO"/>
 
     <Root level="WARN">
       <AppenderRef ref="Console"/>

--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Connection.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Connection.java
@@ -655,6 +655,7 @@ public class Connection extends OpcUaTestBase {
         }
     }
 
+    private static int invocationCount = 0;
     public void makeConnection(boolean runAsync,
                                String secPolicy,
                                String msgSecMode,
@@ -665,14 +666,12 @@ public class Connection extends OpcUaTestBase {
                                boolean useServerAddress,
                                boolean replaceLocalHost) throws ExecutionException {
         HashMap config = new HashMap();
-        Map<String, String> opcConfig = new HashMap<>();
+        Map<String, Object> opcConfig = new HashMap<>();
 
         config.put(OpcConstants.CONFIG_OPC_UA_INFORMATION, opcConfig);
         opcConfig.put(OpcConstants.CONFIG_STORAGE_DIRECTORY, STANDARD_STORAGE_DIRECTORY);
         opcConfig.put(OpcConstants.CONFIG_SECURITY_POLICY, secPolicy);
-        if (replaceLocalHost) {
-            opcConfig.put(OpcConstants.CONFIG_REPLACE_DISCOVERED_LOCALHOST, "true");
-        }
+
         if (msgSecMode != null && !msgSecMode.isEmpty()) {
             opcConfig.put(OpcConstants.CONFIG_MESSAGE_SECURITY_MODE, msgSecMode);
         }
@@ -702,6 +701,20 @@ public class Connection extends OpcUaTestBase {
             if (useServerAddress && Utils.OPC_PUBLIC_SERVER_1.equals(discEP)) {
                 opcConfig.put(OpcConstants.CONFIG_SERVER_ENDPOINT, discEP);
             }
+
+            if (replaceLocalHost) {
+
+                // Here, we'll alternate testing with both Boolean & Text to be maximally flexible
+                // in terms of the JSON configuration. This setting is to deal with erroneous configurations
+                // anyway, so let's not make things any more difficult than we have to.
+
+                if (invocationCount++ % 2 == 0) {
+                    opcConfig.put(OpcConstants.CONFIG_REPLACE_DISCOVERED_LOCALHOST, Boolean.valueOf(true));
+                } else {
+                    opcConfig.put(OpcConstants.CONFIG_REPLACE_DISCOVERED_LOCALHOST, "true");
+                }
+            }
+
             try {
                 performConnection(config, runAsync, startProcessOnly);
             } catch (ExecutionException e) {

--- a/opcuaSource/src/test/resources/log4j2.xml
+++ b/opcuaSource/src/test/resources/log4j2.xml
@@ -7,7 +7,7 @@
   </Appenders>
   <Loggers>
 
-    <Logger name="org.eclipse.milo" level="WARN"/>
+    <Logger name="org.eclipse.milo" level="DEBUG"/>
     <Logger name="io.netty" level="INFO"/>
     <Logger name="io.vantiq.extsrc.opcua" level="DEBUG"/>
     <Logger name="io.vantiq.extjsdk" level="INFO"/>


### PR DESCRIPTION
Set SDK logging to debug to help fix discover some issues.

Allow JSON config document to use boolean true value (in addition to string) for replaceDiscoveredLocalhost