### PR TITLE
Naf obj poll fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,11 +287,11 @@ When creating an OPC UA Extension source, you must first create the OPC UA sourc
   - `verticle` -- the string `service:extensionSource`
   - `config` -- an empty JSON object
 
-To make the source type known to VANTIQ, use the vantiq cli command
+To make the source type known to VANTIQ, use the VANTIQ CLI command _load sourceimpls_.
 
 
 For example, suppose we are creating an extension source of type "EXAMPLE".
-To do so, we would first create the file `exampleImpl.json` with the following contents.
+To do so, we would first create the file `exampleImpl.json` with the following contents:
 
 ```
 {
@@ -302,7 +302,7 @@ To do so, we would first create the file `exampleImpl.json` with the following c
 }
 ```
 
-Then, we would us the VANTIQ CLI to load that source implementation.
+Then, we would use the VANTIQ CLI to load that source implementation.
 
 ```
 vantiq -s <profileName> load sourceimpls exampleImpl.json

--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -137,7 +137,7 @@ The Configuration document may look similar to the following example:
     {
        "objRecConfig": {
           "general": {
-             "pollRate": 3000
+             "pollTime": 3000
           },
           "dataSource": {
              "camera": "http://166.155.71.82:8080/mjpg/video.mjpg",
@@ -155,10 +155,12 @@ The Configuration document may look similar to the following example:
 ### Options Available for General
 At least one of these options must be set for the source to function
 
-*   pollRate: This indicates how often an image should be captured. A positive number represents the number of
+*   pollTime: This indicates how often an image should be captured. A positive number represents the number of
 milliseconds between captures. If the specified time is less than the amount of time it takes to process the image then
 images will be taken as soon as the previous finishes. If this is set to 0, the next image will be captured as soon as
-the previous is sent.
+the previous is sent. 
+    *   (**NOTE:** Previously named "pollRate". For a limited amount of time, both "pollTime" and "pollRate"
+    will be valid General Config options, but in the future only "pollTime" will be supported.)
 *   allowQueries: This option allows Queries to be received when set to `true'
 
 ### Options Available for Data Source

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -303,7 +303,7 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
             }
         };
         
-        // Start polling if pollRate is non-negative
+        // Start polling if pollTime is non-negative
         if (general.get("pollTime") instanceof Integer) {
             polling = (Integer) general.get("pollTime");
             if (polling > 0) {

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -304,7 +304,19 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
         };
         
         // Start polling if pollRate is non-negative
-        if (general.get("pollRate") instanceof Integer) {
+        if (general.get("pollTime") instanceof Integer) {
+            polling = (Integer) general.get("pollTime");
+            if (polling > 0) {
+                int pollRate = polling;
+                source.pollTimer = new Timer("dataCapture");
+                source.pollTimer.schedule(task, 0, pollRate);
+            } else if (polling == 0) {
+                source.pollTimer = new Timer("dataCapture");
+                source.pollTimer.scheduleAtFixedRate(task, 0, 1);
+                // 1 ms will be fast enough unless image gathering, image processing, and data sending combined are
+                // sub millisecond
+            }
+        } else if (general.get("pollRate") instanceof Integer) {
             polling = (Integer) general.get("pollRate");
             if (polling > 0) {
                 int pollRate = polling;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -305,29 +305,21 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
         
         // Start polling if pollTime is non-negative
         if (general.get("pollTime") instanceof Integer) {
-            polling = (Integer) general.get("pollTime");
-            if (polling > 0) {
-                int pollRate = polling;
-                source.pollTimer = new Timer("dataCapture");
-                source.pollTimer.schedule(task, 0, pollRate);
-            } else if (polling == 0) {
-                source.pollTimer = new Timer("dataCapture");
-                source.pollTimer.scheduleAtFixedRate(task, 0, 1);
-                // 1 ms will be fast enough unless image gathering, image processing, and data sending combined are
-                // sub millisecond
-            }
+            polling = (Integer) general.get("pollTime");  
         } else if (general.get("pollRate") instanceof Integer) {
+            // Old, deprecated setting. Use "pollTime" instead of "pollRate".
             polling = (Integer) general.get("pollRate");
-            if (polling > 0) {
-                int pollRate = polling;
-                source.pollTimer = new Timer("dataCapture");
-                source.pollTimer.schedule(task, 0, pollRate);
-            } else if (polling == 0) {
-                source.pollTimer = new Timer("dataCapture");
-                source.pollTimer.scheduleAtFixedRate(task, 0, 1);
-                // 1 ms will be fast enough unless image gathering, image processing, and data sending combined are
-                // sub millisecond
-            }
+        }
+        
+        if (polling > 0) {
+            int pollRate = polling;
+            source.pollTimer = new Timer("dataCapture");
+            source.pollTimer.schedule(task, 0, pollRate);
+        } else if (polling == 0) {
+            source.pollTimer = new Timer("dataCapture");
+            source.pollTimer.scheduleAtFixedRate(task, 0, 1);
+            // 1 ms will be fast enough unless image gathering, image processing, and data sending combined are
+            // sub millisecond
         }
         
         // Setup queries if requested

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -308,6 +308,7 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
             polling = (Integer) general.get("pollTime");  
         } else if (general.get("pollRate") instanceof Integer) {
             // Old, deprecated setting. Use "pollTime" instead of "pollRate".
+            log.warn("Deprecated config option, please use \"pollTime\" instead of \"pollRate\".");
             polling = (Integer) general.get("pollRate");
         }
         

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecConfig.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecConfig.java
@@ -193,7 +193,7 @@ public class TestObjRecConfig {
         general.put("pollTime", 300000);
         sendConfig(conf);
         assertFalse("Should not fail with minimal configuration", configIsFailed());
-        assertTrue("Timer should exist after pollRate set to positive number", nCore.pollTimer != null); 
+        assertTrue("Timer should exist after pollTime set to positive number", nCore.pollTimer != null); 
         
         // Making sure pollRate works (backwards compatibility)
         general.remove("pollTime");

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecConfig.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecConfig.java
@@ -189,6 +189,14 @@ public class TestObjRecConfig {
         sendConfig(conf);
         assertFalse("Should not fail with minimal configuration", configIsFailed());
         
+        // Making sure pollTime works
+        general.put("pollTime", 300000);
+        sendConfig(conf);
+        assertFalse("Should not fail with minimal configuration", configIsFailed());
+        assertTrue("Timer should exist after pollRate set to positive number", nCore.pollTimer != null); 
+        
+        // Making sure pollRate works (backwards compatibility)
+        general.remove("pollTime");
         general.put("pollRate", 300000);
         sendConfig(conf);
         assertFalse("Should not fail with minimal configuration", configIsFailed());


### PR DESCRIPTION
Changing general source config to "pollTime" instead of "pollRate". Backwards compatible with "pollRate".