### PR TITLE
Attempt to fix Connection.testBadConfig on windows.

### DIFF
--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Connection.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Connection.java
@@ -78,7 +78,17 @@ public class Connection extends OpcUaTestBase {
 
         assert client == null;
 
-        opcConfig.put(OpcConstants.CONFIG_STORAGE_DIRECTORY, "/this/directory/should/never/really/and/truly/exist");
+        String osName = System.getProperty("os.name");
+        String fileNameWeCannotCreate = "/this/directory/should/never/really/and/truly/exist";
+        if (osName != null && osName.toLowerCase().contains("windows")) {
+
+            // For windows, we need some different bogus string.  On windows, it's OK to create a top-level
+            // directory whereas on most Unix-based systems (linux, Mac OS) it's not.  So we'll craft a file
+            // name which I think is not creatable...
+
+            fileNameWeCannotCreate = "UtterlyBogusDiskLabelName:\\<?>\\I:\\Cannot:\\Exist:\\Due\\To\\Invalid\\Characters";
+        }
+        opcConfig.put(OpcConstants.CONFIG_STORAGE_DIRECTORY, fileNameWeCannotCreate);
 
         try {
             client = new OpcUaESClient(config);


### PR DESCRIPTION
test currently fails.  The reason for the failure is that the test _should_ fail to create a directory (on purpose).  On Windows, that create doesn't fail, so the something else goes wrong that isn't what's expected.

This changes the test so that on windows, we create a different _impossible to create_ file/directory name (I think) so that the test will behave as expected.