### PR TITLE
Fixing issue with beforeNext(), replaced with a do-while.

### DIFF
--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
@@ -108,12 +108,11 @@ public class JDBC {
             if (!queryResults.next()) { 
                 return null;
             } else {
-                queryResults.beforeFirst();
                 ResultSetMetaData md = queryResults.getMetaData(); 
                 int columns = md.getColumnCount();
                 
                 // Iterate over rows of Result Set and create a map for each row
-                while(queryResults.next()) {
+                do {
                     HashMap row = new HashMap(columns);
                     for (int i=1; i<=columns; ++i) {
                         // Check column type to retrieve data in appropriate manner
@@ -139,10 +138,10 @@ public class JDBC {
                                 row.put(md.getColumnName(i), queryResults.getObject(i));
                                 break;
                         }
-                    }
+                    } 
                     // Add each row map to the list of rows
                     rows.add(row);
-                }
+                } while(queryResults.next());
             }
         } catch (SQLException e) {
             reportSQLError(e);

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
@@ -138,7 +138,7 @@ public class JDBC {
                                 row.put(md.getColumnName(i), queryResults.getObject(i));
                                 break;
                         }
-                    } 
+                    }
                     // Add each row map to the list of rows
                     rows.add(row);
                 } while(queryResults.next());


### PR DESCRIPTION
Closes Issue #101 

Removed beforeNext() method, and changed the while loop to a do-while. This allows us to preserve the first row of data by only moving the cursor at the end of each loop iteration, instead of at the beginning.