### PR TITLE
Update to gradle 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,12 +9,13 @@ buildscript {
 }
 
 plugins {
+    id 'io.franzbecker.gradle-lombok' version '1.14' apply false
     id 'pl.allegro.tech.build.axion-release' version '1.6.0'
     id 'jacoco'
 }
 
-task wrapper(type: Wrapper) {
-    gradleVersion = '3.5'
+wrapper {
+    gradleVersion = '5.0'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 
@@ -42,7 +43,7 @@ ext {
     eclipseMiloVersion = '0.2.1'
 }
 
-\
+
 // Add idea support in root project to get around bug in Scala plugin
 apply plugin: 'idea'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/objectRecognitionSource/build.gradle
+++ b/objectRecognitionSource/build.gradle
@@ -100,6 +100,12 @@ applicationDistribution.from("src/main/resources") {
     into "logConfig"
 }
 
+test {
+    // set heap size for the test JVM(s)
+    minHeapSize = "2048m"
+    maxHeapSize = "2048m"
+}
+
 tasks.withType(Test) {
     def os = org.gradle.internal.os.OperatingSystem.current()
     if (os.isWindows()) {

--- a/opcuaSource/build.gradle
+++ b/opcuaSource/build.gradle
@@ -1,6 +1,3 @@
-group 'io.vantiq'
-version 'unspecified'
-
 buildscript {
     repositories { jcenter() }
     dependencies {
@@ -8,10 +5,16 @@ buildscript {
     }
 }
 
-apply plugin: 'java'
-apply plugin: 'application'
-apply plugin: 'idea'
-apply plugin: 'eclipse'
+plugins {
+    id 'io.franzbecker.gradle-lombok'
+    id 'java'
+    id 'application'
+    id 'idea'
+    id 'eclipse'
+}
+
+group 'io.vantiq'
+version 'unspecified'
 
 sourceCompatibility = 1.8
 
@@ -23,6 +26,8 @@ ext {
     junitVersion = '4.12'
     commonsCliVersion = '1.4'
     bouncyCastleVersion = '1.58'
+    slf4jApiVersion = '1.7.25'
+    log4jSlfImplVersion = '2.11.0'
 }
 
 repositories {
@@ -30,13 +35,14 @@ repositories {
     jcenter()
 }
 
+
 dependencies {
     // compile files('../extjsdk/build/libs/extjsdk-all.jar')
     compile project(":extjsdk")
 
     compile "org.projectlombok:lombok:${lombokVersion}"
-    compile "org.slf4j:slf4j-api:1.7.25"
-    compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.0"
+    compile "org.slf4j:slf4j-api:${slf4jApiVersion}"
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4jSlfImplVersion}"
 
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
     compile "commons-cli:commons-cli:${commonsCliVersion}"


### PR DESCRIPTION
Fixes #116

Moves build environment up to gradle 5.  Assuming you are, as recommended, using the gradle wrapper, this should be transparent.