### PR TITLE
Make GRID_SIZE equal to FRAME_SIZE/32

### DIFF
--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -446,7 +446,7 @@ that the identification is accurate, and a `location` containing the coordinates
 and `right` edges of the bounding box for the object. It can also save images with the bounding boxes drawn.  
 
 The standard implementation expects a net trained on 416x416 images, and automatically resizes images to those 
-dimensions. If different dimensions are required, then changing `edu.ml.tensorflow.Config.SIZE` to the correct
+dimensions. If different dimensions are required, then changing `edu.ml.tensorflow.Config.FRAME_SIZE` to the correct
 dimension will change the dimensions of the image sent to the neural net. The dimensions will still be a square.  
 
 The options are as follows. Remember to prepend "NN" when using an option in a Query.

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/Config.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/Config.java
@@ -5,6 +5,6 @@ package edu.ml.tensorflow;
  */
 public interface Config {
     // Params used for image processing
-    public int SIZE = 416; // Edited so that it can be accessed from anywhere
+    public int FRAME_SIZE = 416; // Edited so that it can be accessed from anywhere
     float MEAN = 255f;
 }

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 import static edu.ml.tensorflow.Config.MEAN;
-import static edu.ml.tensorflow.Config.SIZE;
+import static edu.ml.tensorflow.Config.FRAME_SIZE;
 
 /**
  * ObjectDetector class to detect objects using pre-trained models with TensorFlow Java API.
@@ -282,7 +282,7 @@ public class ObjectDetector {
                                                     graphBuilder.constant("input", new byte[0]), 3),
                                             Float.class),
                                     graphBuilder.constant("make_batch", 0)),
-                            graphBuilder.constant("size", new int[]{SIZE, SIZE})),
+                            graphBuilder.constant("size", new int[]{FRAME_SIZE, FRAME_SIZE})),
                     graphBuilder.constant("scale", MEAN));
         normalizerInputName = "input";
         normalizerOutputName = output.op().name();
@@ -317,8 +317,8 @@ public class ObjectDetector {
         	map.put("label", recognition.getTitle());
         	map.put("confidence", recognition.getConfidence());
         	
-        	float scaleX = (float) buffImage.getWidth() / (float) SIZE;
-            float scaleY = (float) buffImage.getHeight() / (float) SIZE;
+        	float scaleX = (float) buffImage.getWidth() / (float) FRAME_SIZE;
+            float scaleY = (float) buffImage.getHeight() / (float) FRAME_SIZE;
         	
         	HashMap location = new HashMap();
         	location.put("left", recognition.getScaledLocation(scaleX, scaleY).getLeft());

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
@@ -13,13 +13,15 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
 
+import static edu.ml.tensorflow.Config.FRAME_SIZE;
+
 /**
  * YOLOClassifier class implemented in Java by using the TensorFlow Java API
  * I also used this class in my android sample application here: https://github.com/szaza/android-yolo-v2
  */
 public class YOLOClassifier {
     private final static float OVERLAP_THRESHOLD = 0.5f;
-    private final static int SIZE = 13;
+    private final static int GRID_SIZE = FRAME_SIZE/32;
     private final static int MAX_RECOGNIZED_CLASSES = 24;
     private final static int MAX_RESULTS = 24;
     public final static int NUMBER_OF_BOUNDING_BOX = 5;
@@ -56,7 +58,7 @@ public class YOLOClassifier {
      * @return the number of classes
      */
     public int getOutputSizeByShape(Tensor<Float> result) {
-        return (int) (result.shape()[3] * Math.pow(SIZE,2));
+        return (int) (result.shape()[3] * Math.pow(GRID_SIZE,2));
     }
 
     /**
@@ -68,13 +70,13 @@ public class YOLOClassifier {
      * @return a list of recognition objects
      */
     public List<Recognition> classifyImage(final float[] tensorFlowOutput, final List<String> labels) {
-        int numClass = (int) (tensorFlowOutput.length / (Math.pow(SIZE,2) * NUMBER_OF_BOUNDING_BOX) - 5);
-        BoundingBox[][][] boundingBoxPerCell = new BoundingBox[SIZE][SIZE][NUMBER_OF_BOUNDING_BOX];
+        int numClass = (int) (tensorFlowOutput.length / (Math.pow(GRID_SIZE,2) * NUMBER_OF_BOUNDING_BOX) - 5);
+        BoundingBox[][][] boundingBoxPerCell = new BoundingBox[GRID_SIZE][GRID_SIZE][NUMBER_OF_BOUNDING_BOX];
         PriorityQueue<Recognition> priorityQueue = new PriorityQueue(MAX_RECOGNIZED_CLASSES, new RecognitionComparator());
 
         int offset = 0;
-        for (int cy=0; cy<SIZE; cy++) {        // SIZE * SIZE cells
-            for (int cx=0; cx<SIZE; cx++) {
+        for (int cy=0; cy<GRID_SIZE; cy++) {        // SIZE * SIZE cells
+            for (int cx=0; cx<GRID_SIZE; cx++) {
                 for (int b=0; b<NUMBER_OF_BOUNDING_BOX; b++) {   // 5 bounding boxes per each cell
                     boundingBoxPerCell[cx][cy][b] = getModel(tensorFlowOutput, cx, cy, b, numClass, offset);
                     calculateTopPredictions(boundingBoxPerCell[cx][cy][b], priorityQueue, labels);

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
@@ -75,7 +75,7 @@ public class YOLOClassifier {
         PriorityQueue<Recognition> priorityQueue = new PriorityQueue(MAX_RECOGNIZED_CLASSES, new RecognitionComparator());
 
         int offset = 0;
-        for (int cy=0; cy<GRID_SIZE; cy++) {        // SIZE * SIZE cells
+        for (int cy=0; cy<GRID_SIZE; cy++) {        // GRID_SIZE * GRID_SIZE cells
             for (int cx=0; cx<GRID_SIZE; cx++) {
                 for (int b=0; b<NUMBER_OF_BOUNDING_BOX; b++) {   // 5 bounding boxes per each cell
                     boundingBoxPerCell[cx][cy][b] = getModel(tensorFlowOutput, cx, cy, b, numClass, offset);

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
@@ -35,8 +35,8 @@ public class ImageUtil {
      * @param recognitions  list of recognized objects
      */
     public BufferedImage labelImage(BufferedImage bufferedImage, final List<Recognition> recognitions) {
-        float scaleX = (float) bufferedImage.getWidth() / (float) Config.SIZE;
-        float scaleY = (float) bufferedImage.getHeight() / (float) Config.SIZE;
+        float scaleX = (float) bufferedImage.getWidth() / (float) Config.FRAME_SIZE;
+        float scaleY = (float) bufferedImage.getHeight() / (float) Config.FRAME_SIZE;
         Graphics2D graphics = (Graphics2D) bufferedImage.getGraphics();
 
         for (Recognition recognition: recognitions) {

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -30,7 +30,7 @@ import io.vantiq.client.Vantiq;
  * with the bounding boxes drawn.
  * <br>
  * The standard implementation expects a net trained on 416x416 images, and automatically resizes images to those
- * dimensions. If different dimensions are required, then changing {@code edu.ml.tensorflow.Config.SIZE} to the correct
+ * dimensions. If different dimensions are required, then changing {@code edu.ml.tensorflow.Config.FRAME_SIZE} to the correct
  * dimension will change the dimensions of the image sent to the neural net. The dimensions will still be a square.
  * <br>
  * Unique settings are: 


### PR DESCRIPTION
* Changed names of "SIZE" values in YOLOClassifier and ObjectDetector to be GRID_SIZE and FRAME_SIZE respectively.
* Made GRID_SIZE equal to dividing FRAME_SIZE by 32.