### PR TITLE
Naf obj #122

### DIFF
--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -448,8 +448,10 @@ that the identification is accurate, and a `location` containing the coordinates
 and `right` edges of the bounding box for the object. It can also save images with the bounding boxes drawn.  
 
 The standard implementation expects a net trained on 416x416 images, and automatically resizes images to those 
-dimensions. If different dimensions are required, then changing `edu.ml.tensorflow.Config.FRAME_SIZE` to the correct
-dimension will change the dimensions of the image sent to the neural net. The dimensions will still be a square.  
+dimensions. If a `.meta` file is provided, then the input frame size stored in that file, ("height"/"width" fields), will be 
+used. To override the default or `.meta` file frame size, the user can change `edu.ml.tensorflow.Config.FRAME_SIZE` to the 
+desired dimension. This will change the dimensions of the image sent to the neural net. The dimensions will still be a square, 
+as is required by this implementation of the YOLO Processor.
 
 The options are as follows. Remember to prepend "NN" when using an option in a Query.
 

--- a/objectRecognitionSource/build.gradle
+++ b/objectRecognitionSource/build.gradle
@@ -179,6 +179,7 @@ ext.removeUnnecessaryTests = {
 
 configurations {
     oldYoloNames
+    metaTest
 }
 
 ext {
@@ -220,6 +221,9 @@ dependencies {
     oldYoloNames "vantiq.models:coco:1.0@pb"
     oldYoloNames "vantiq.models:coco:1.0@names"
     oldYoloNames "vantiq.models:yolo:1.0@pb"
+    
+    metaTest "vantiq.models:coco:1.1@meta"
+    metaTest "vantiq.models:coco:1.1@pb"
 
 
     // This imports OpenCV if it is needed, and throws an error if OpenCV is needed but not properly setup
@@ -252,10 +256,14 @@ dependencies {
     testCompile project(path:":extjsdk", configuration:"testArtifacts")
 }
 
-task copyModels(type: Copy, dependsOn: configurations.testRuntime) {
+task copyModels(type: Copy, dependsOn: [configurations.testRuntime, configurations.metaTest]) {
     from configurations.testRuntime.find { it.name == "coco-${currentCocoVersion}.pb" },
         configurations.testRuntime.find { it.name == "coco-${currentCocoVersion}.names" },
-        configurations.testRuntime.find { it.name == "coco-${currentCocoVersion}.meta" }
+        configurations.testRuntime.find { it.name == "coco-${currentCocoVersion}.meta" },
+        
+        // Used for testing different height/width from .meta file
+        configurations.metaTest.find { it.name == "coco-1.1.meta" },
+        configurations.metaTest.find { it.name == "coco-1.1.pb" }
 
     into "$buildDir/models/"
 }

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/MetaBasedConfig.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/MetaBasedConfig.java
@@ -1,0 +1,25 @@
+package edu.ml.tensorflow;
+
+import static edu.ml.tensorflow.Config.FRAME_SIZE;
+import static edu.ml.tensorflow.Config.MEAN;
+
+public class MetaBasedConfig {
+    // General config values for YOLO Processor
+    public int frameSize;
+    public float mean;
+    
+    // Flag to decide if we should use .meta frame size, or Config frame size
+    public boolean useMeta;
+    
+    public MetaBasedConfig() {
+        // Check if user has manually changed the default FRAME_SIZE in Config
+        if (FRAME_SIZE == 416) {
+            useMeta = true;
+        } else {
+            useMeta = false;
+        }
+        
+        frameSize = FRAME_SIZE;
+        mean = MEAN;
+    }
+}

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/MetaBasedConfig.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/MetaBasedConfig.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2018 Vantiq, Inc.
+ *
+ * All rights reserved.
+ *
+ * SPDX: MIT
+ */
+
 package edu.ml.tensorflow;
 
 import static edu.ml.tensorflow.Config.FRAME_SIZE;
@@ -9,14 +17,14 @@ public class MetaBasedConfig {
     public float mean;
     
     // Flag to decide if we should use .meta frame size, or Config frame size
-    public boolean useMeta;
+    public boolean useMetaIfAvailable;
     
     public MetaBasedConfig() {
         // Check if user has manually changed the default FRAME_SIZE in Config
         if (FRAME_SIZE == 416) {
-            useMeta = true;
+            useMetaIfAvailable = true;
         } else {
-            useMeta = false;
+            useMetaIfAvailable = false;
         }
         
         frameSize = FRAME_SIZE;

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/MetaBasedConfig.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/MetaBasedConfig.java
@@ -16,7 +16,7 @@ public class MetaBasedConfig {
     public int frameSize;
     public float mean;
     
-    // Flag to decide if we should use .meta frame size, or Config frame size
+    // Flag to decide if we should use .meta frame size, or default Config frame size
     public boolean useMetaIfAvailable;
     
     public MetaBasedConfig() {

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/MetaBasedConfig.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/MetaBasedConfig.java
@@ -9,12 +9,10 @@
 package edu.ml.tensorflow;
 
 import static edu.ml.tensorflow.Config.FRAME_SIZE;
-import static edu.ml.tensorflow.Config.MEAN;
 
 public class MetaBasedConfig {
     // General config values for YOLO Processor
     public int frameSize;
-    public float mean;
     
     // Flag to decide if we should use .meta frame size, or default Config frame size
     public boolean useMetaIfAvailable;
@@ -28,6 +26,5 @@ public class MetaBasedConfig {
         }
         
         frameSize = FRAME_SIZE;
-        mean = MEAN;
     }
 }

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
@@ -43,7 +43,7 @@ public class ObjectDetector {
     private static SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd--HH-mm-ss");
     
     // Getting meta config options for YOLO Processor
-    private MetaBasedConfig metaConfigOptions = new MetaBasedConfig();
+    public MetaBasedConfig metaConfigOptions = new MetaBasedConfig();
     private final float MEAN = metaConfigOptions.mean;
     private int frameSize;
     
@@ -95,7 +95,7 @@ public class ObjectDetector {
                 int frameHeight = (int) ((Map<String,Object>) metaFileMap.get("net")).get("height");
                 int frameWidth = (int) ((Map<String,Object>) metaFileMap.get("net")).get("width");
                 // Check that meta file has appropriate frame size, and that user has not overwritten frame size in Config
-                if (frameHeight == frameWidth && frameHeight % 32 == 0 && metaConfigOptions.useMeta) {
+                if (frameHeight == frameWidth && frameHeight % 32 == 0 && metaConfigOptions.useMetaIfAvailable) {
                     // Set config value to the .meta file's frame size
                     metaConfigOptions.frameSize = frameHeight;
                 }

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
@@ -30,6 +30,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static edu.ml.tensorflow.Config.MEAN;
+
 /**
  * ObjectDetector class to detect objects using pre-trained models with TensorFlow Java API.
  */
@@ -44,7 +46,6 @@ public class ObjectDetector {
     
     // Getting meta config options for YOLO Processor
     public MetaBasedConfig metaConfigOptions = new MetaBasedConfig();
-    private final float MEAN = metaConfigOptions.mean;
     private int frameSize;
     
     private ImageUtil imageUtil;
@@ -377,5 +378,6 @@ public class ObjectDetector {
     @Override
     protected void finalize() {
         close();
+        YOLOClassifier.getInstance(threshold, anchorArray, frameSize).close();
     }
 }

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
@@ -329,7 +329,7 @@ public class ObjectDetector {
         	map.put("confidence", recognition.getConfidence());
         	
         	float scaleX = (float) buffImage.getWidth() / (float) frameSize;
-            float scaleY = (float) buffImage.getHeight() / (float) frameSize;
+        	float scaleY = (float) buffImage.getHeight() / (float) frameSize;
         	
         	HashMap location = new HashMap();
         	location.put("left", recognition.getScaledLocation(scaleX, scaleY).getLeft());

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
@@ -100,7 +100,6 @@ public class ObjectDetector {
                     metaConfigOptions.frameSize = frameHeight;
                 }
             }
-            // 
             this.frameSize = metaConfigOptions.frameSize;
 
             // If label file exists, use it. Otherwise, use the meta file's labels.

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
@@ -46,7 +46,8 @@ public class YOLOClassifier {
                 anchors = anchorArray;
             }
         }
-
+        System.out.println("Grid Size: " + gridSize);
+        System.out.println("Frame Size: " + frameSize);
         return  classifier;
     }
 
@@ -170,6 +171,10 @@ public class YOLOClassifier {
         public int compare(final Recognition recognition1, final Recognition recognition2) {
             return Float.compare(recognition2.getConfidence(), recognition1.getConfidence());
         }
+    }
+    
+    public void close() {
+        classifier = null;
     }
 }
 

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
@@ -46,8 +46,7 @@ public class YOLOClassifier {
                 anchors = anchorArray;
             }
         }
-        System.out.println("Grid Size: " + gridSize);
-        System.out.println("Frame Size: " + frameSize);
+        
         return  classifier;
     }
 

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
@@ -13,8 +13,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
 
-import static edu.ml.tensorflow.Config.FRAME_SIZE;
-
 /**
  * YOLOClassifier class implemented in Java by using the TensorFlow Java API
  * I also used this class in my android sample application here: https://github.com/szaza/android-yolo-v2

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -267,7 +267,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
     }
 
     @Test
-    public void testRealJSONConfig() throws ImageProcessingException, JsonParseException, JsonMappingException, IOException, InterruptedException {
+    public void testRealJSONConfig() throws ImageProcessingException, JsonParseException, JsonMappingException, IOException {
         YoloProcessor ypImageSaver = new YoloProcessor();
         ExtensionServiceMessage msg = createRealConfig(neuralNetJSON1);
         Map config = (Map) msg.getObject();

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -242,7 +242,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         // useMetaIfAvailable flag should be true, since Config Size value is unchanged (default is 416)
         assert ypImageSaver.objectDetector.metaConfigOptions.useMetaIfAvailable == true;
         
-        // Frame Size should be 416 since this is what is included in the meta file
+        // Frame Size should be 608 since this is what is included in the meta file
         assert ypImageSaver.objectDetector.metaConfigOptions.frameSize == 608;
         
         config.remove("metaFile");
@@ -263,7 +263,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
     @Test
     public void testResults() throws ImageProcessingException {
-        verifyProcessing(ypJson, true);
+        verifyProcessing(ypJson, imageResultsAsString);
     }
 
     @Test
@@ -276,7 +276,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         // Config with meta file, label file, pb file, and anchors
         try {
             ypImageSaver.setupImageProcessing(neuralNetConfig, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
-            verifyProcessing(ypImageSaver, true);
+            verifyProcessing(ypImageSaver, imageResultsAsString);
         } catch (Exception e) {
             fail("Should not fail with valid config.");
         } finally {
@@ -292,7 +292,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
         try {
             ypImageSaver.setupImageProcessing(neuralNetConfig, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
-            verifyProcessing(ypImageSaver, true);
+            verifyProcessing(ypImageSaver, imageResultsAsString);
         } catch (Exception e) {
             fail("Should not fail with valid config.");
         } finally {
@@ -308,7 +308,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
         try {
             ypImageSaver.setupImageProcessing(neuralNetConfig, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
-            verifyProcessing(ypImageSaver, true);
+            verifyProcessing(ypImageSaver, imageResultsAsString);
         } catch (Exception e) {
             fail("Should not fail with valid config.");
         } finally {
@@ -324,7 +324,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
         try {
             ypImageSaver.setupImageProcessing(neuralNetConfig, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
-            verifyProcessing(ypImageSaver, true);
+            verifyProcessing(ypImageSaver, imageResultsAsString);
         } catch (Exception e) {
             fail("Should not fail with valid config.");
         } finally {
@@ -347,7 +347,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
         try {
             ypImageSaver.setupImageProcessing(neuralNetConfig, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
-            verifyProcessing(ypImageSaver, false);
+            verifyProcessing(ypImageSaver, imageResultsAsString608);
         } catch (Exception e) {
             fail("Should not fail with valid config.");
         } finally {
@@ -989,21 +989,17 @@ public class TestYoloProcessor extends NeuralNetTestBase {
                     + "         }"
                     + "}";
 
-    List<Map> getExpectedResults(boolean useDefault) throws JsonParseException, JsonMappingException, IOException {
+    List<Map> getExpectedResults(String resultsAsString) throws JsonParseException, JsonMappingException, IOException {
         ObjectMapper m = new ObjectMapper();
-        if (useDefault) {
-            return m.readValue(imageResultsAsString, List.class);
-        } else {
-            return m.readValue(imageResultsAsString608, List.class);
-        }
+        return m.readValue(resultsAsString, List.class);
     }
 
-    void verifyProcessing(YoloProcessor ypImageSaver, boolean useDefault) throws ImageProcessingException {
+    void verifyProcessing(YoloProcessor ypImageSaver, String resultsAsString) throws ImageProcessingException {
         NeuralNetResults results = ypImageSaver.processImage(getTestImage());
         assert results != null;
         assert results.getResults() != null;
         try {
-            resultsEquals(results.getResults(), getExpectedResults(useDefault)); // Will throw assert error with a message when not equivalent
+            resultsEquals(results.getResults(), getExpectedResults(resultsAsString)); // Will throw assert error with a message when not equivalent
         } catch (IOException e) {
             fail("Could not interpret json string" + e.getMessage());
         }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -70,6 +70,9 @@ public class TestYoloProcessor extends NeuralNetTestBase {
     @BeforeClass
     public static void classSetup() {
         ypJson = new YoloProcessor();
+        
+        testAuthToken = "-YyPeih6BkZoQoVa5tUT3cMZ4DXaWs7M6hg26WEdU88=";
+        testVantiqServer = "https://dev.vantiq.com";
 
         Map<String, Object> config = new LinkedHashMap<>();
         config.put("pbFile", PB_FILE);
@@ -221,6 +224,41 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             fail("Should not fail with label and meta file, and anchors.");
         }
 
+    }
+    
+    @Test
+    public void testMetaConfig() {
+        Map config = new LinkedHashMap<>();
+        YoloProcessor ypImageSaver = new YoloProcessor();
+        
+        config.put("pbFile", PB_FILE);
+        config.put("metaFile", META_FILE);
+        try {
+            ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
+        } catch (Exception e) {
+            fail("Should not fail setup.");
+        }
+        
+        // useMetaIfAvailable flag should be true, since Config Size value is unchanged (default is 416)
+        assert ypImageSaver.objectDetector.metaConfigOptions.useMetaIfAvailable == true;
+        
+        // Frame Size should be 416 since this is what is included in the meta file
+        assert ypImageSaver.objectDetector.metaConfigOptions.frameSize == 416;
+        
+        config.remove("metaFile");
+        config.put("labelFile", LABEL_FILE);
+        try {
+            ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
+        } catch (Exception e) {
+            fail("Should not fail setup.");
+        }
+        
+        // useMetaIfAvailable flag should still be true regardless of meta file presence
+        // Since there is no meta file, default value will be used
+        assert ypImageSaver.objectDetector.metaConfigOptions.useMetaIfAvailable == true;
+        
+        // Frame Size should be 416 since this is what is the default
+        assert ypImageSaver.objectDetector.metaConfigOptions.frameSize == 416;
     }
 
     @Test

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -70,9 +70,6 @@ public class TestYoloProcessor extends NeuralNetTestBase {
     @BeforeClass
     public static void classSetup() {
         ypJson = new YoloProcessor();
-        
-        testAuthToken = "-YyPeih6BkZoQoVa5tUT3cMZ4DXaWs7M6hg26WEdU88=";
-        testVantiqServer = "https://dev.vantiq.com";
 
         Map<String, Object> config = new LinkedHashMap<>();
         config.put("pbFile", PB_FILE);


### PR DESCRIPTION
Fixes Issue #122 .

Adds the ability to retrieve the input frame size from the .meta file. If no meta file is provided, then the standard 416 default value is used. For backwards compatibility, the user can still override both the default and the meta file's input frame size by editing the edu.ml.tensorflow.Config.FRAME_SIZE value.

I was unable to write automated tests that check the behavior when the default value is overridden. I was also unable to add tests that demonstrate the behavior if the meta file has invalid height/width values. These were both manually tested and worked as expected.