### PR TITLE
Naf obj #127

### DIFF
--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -161,7 +161,13 @@ The Configuration document may look similar to the following example:
              "metaFile": "coco-1.1.meta",
              "pbFile": "coco-1.1.pb",
              "type": "yolo",
-             "threshold": 0.2
+             "threshold": 0.2,
+             "saveImage": "both",
+             "saveRate": 1,
+             "outputDir": "imageOut",
+             "savedResolution": {
+                "longEdge": 400
+             }
           }
        }
     }
@@ -222,6 +228,11 @@ is set to be either "local" or "both".
 captured). If not specified, the value will default to 1 which saves every captured image.
 *   labelImage: Optional. If set to "true", images will be saved with bounding boxes and labels. If set to "false", or if not 
 set at all, the images will be saved with no bounding boxes or labels.
+*   savedResolution: Optional. A map containing options for adjusting the resolution of the saved images.
+    * *Options for savedResolution:*
+    1. longEdge: Optional. Used to resize the saved images. Must be a non-negative integer that is smaller than the long edge 
+    of the image to be saved. This value will become the new long edge dimension, and the short edge will be scaled down to 
+    maintain the same dimension ratio as the original image.
 
 ## Messages from the Source<a name="msgFormat" id="msgFormat"></a>
 

--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -233,6 +233,8 @@ set at all, the images will be saved with no bounding boxes or labels.
     1. longEdge: Optional. Used to resize the saved images. Must be a non-negative integer that is smaller than the long edge 
     of the image to be saved. This value will become the new long edge dimension, and the short edge will be scaled down to 
     maintain the same dimension ratio as the original image.
+        *   **NOTE:** We do not support enlarging images. This feature can be used *only* to resize images to smaller 
+        dimensions.
 
 ## Messages from the Source<a name="msgFormat" id="msgFormat"></a>
 

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
@@ -65,29 +65,29 @@ public class ImageUtil {
             try {
                 IOUtil.createDirIfNotExists(new File(outputDir));
                 if (longEdge == 0) {
-                    ImageIO.write(image,"jpg", new File(outputDir + File.separator + target));
+                    ImageIO.write(image, "jpg", new File(outputDir + File.separator + target));
                 } else {
                     int width = image.getWidth();
                     int height = image.getHeight();
                     if (longEdge > Math.max(width, height)) {
                         LOGGER.error("The longEdge value is too large, resizing cannot enlarge the original image. "
                                 + "Original image resolution will not be changed");
-                        ImageIO.write(image,"jpg", new File(outputDir + File.separator + target));
+                        ImageIO.write(image, "jpg", new File(outputDir + File.separator + target));
                         longEdge = 0;
                     } else {
                         if (width > height) {
                             double ratio = (double) longEdge/width;
                             int newHeight = (int) (height * ratio);
                             BufferedImage resizedImage = resizeImage(longEdge, newHeight, image);
-                            ImageIO.write(resizedImage,"jpg", new File(outputDir + File.separator + target));
+                            ImageIO.write(resizedImage, "jpg", new File(outputDir + File.separator + target));
                         } else if (height > width) {
                             double ratio = (double) longEdge/height;
                             int newWidth = (int) (width * ratio);
                             BufferedImage resizedImage = resizeImage(newWidth, longEdge, image);
-                            ImageIO.write(resizedImage,"jpg", new File(outputDir + File.separator + target));
+                            ImageIO.write(resizedImage, "jpg", new File(outputDir + File.separator + target));
                         } else {
                             BufferedImage resizedImage = resizeImage(longEdge, longEdge, image);
-                            ImageIO.write(resizedImage,"jpg", new File(outputDir + File.separator + target));
+                            ImageIO.write(resizedImage, "jpg", new File(outputDir + File.separator + target));
                         }
                     }
                 }
@@ -124,22 +124,22 @@ public class ImageUtil {
                         if (longEdge > Math.max(width, height)) {
                             LOGGER.error("The longEdge value is too large, resizing cannot enlarge the original image. "
                                     + "Original image resolution will not be changed");
-                            ImageIO.write(image,"jpg", imgFile);
+                            ImageIO.write(image, "jpg", imgFile);
                             longEdge = 0;
                         } else {
                             if (width > height) {
                                 double ratio = (double) longEdge/width;
                                 int newHeight = (int) (height * ratio);
                                 BufferedImage resizedImage = resizeImage(longEdge, newHeight, image);
-                                ImageIO.write(resizedImage,"jpg", imgFile);
+                                ImageIO.write(resizedImage, "jpg", imgFile);
                             } else if (height > width) {
                                 double ratio = (double) longEdge/height;
                                 int newWidth = (int) (width * ratio);
                                 BufferedImage resizedImage = resizeImage(newWidth, longEdge, image);
-                                ImageIO.write(resizedImage,"jpg", imgFile);
+                                ImageIO.write(resizedImage, "jpg", imgFile);
                             } else {
                                 BufferedImage resizedImage = resizeImage(longEdge, longEdge, image);
-                                ImageIO.write(resizedImage,"jpg", imgFile);
+                                ImageIO.write(resizedImage, "jpg", imgFile);
                             }
                         }
                     }

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
@@ -31,7 +31,7 @@ public class ImageUtil {
     public int longEdge = 0;
 
     /**
-     * Label image with classes and predictions given by the ThensorFLow
+     * Label image with classes and predictions given by the TensorFLow YOLO Implementation
      * @param image         buffered image to label
      * @param recognitions  list of recognized objects
      */
@@ -67,29 +67,8 @@ public class ImageUtil {
                 if (longEdge == 0) {
                     ImageIO.write(image, "jpg", new File(outputDir + File.separator + target));
                 } else {
-                    int width = image.getWidth();
-                    int height = image.getHeight();
-                    if (longEdge > Math.max(width, height)) {
-                        LOGGER.error("The longEdge value is too large, resizing cannot enlarge the original image. "
-                                + "Original image resolution will not be changed");
-                        ImageIO.write(image, "jpg", new File(outputDir + File.separator + target));
-                        longEdge = 0;
-                    } else {
-                        if (width > height) {
-                            double ratio = (double) longEdge/width;
-                            int newHeight = (int) (height * ratio);
-                            BufferedImage resizedImage = resizeImage(longEdge, newHeight, image);
-                            ImageIO.write(resizedImage, "jpg", new File(outputDir + File.separator + target));
-                        } else if (height > width) {
-                            double ratio = (double) longEdge/height;
-                            int newWidth = (int) (width * ratio);
-                            BufferedImage resizedImage = resizeImage(newWidth, longEdge, image);
-                            ImageIO.write(resizedImage, "jpg", new File(outputDir + File.separator + target));
-                        } else {
-                            BufferedImage resizedImage = resizeImage(longEdge, longEdge, image);
-                            ImageIO.write(resizedImage, "jpg", new File(outputDir + File.separator + target));
-                        }
-                    }
+                    BufferedImage resizedImage = resizeImage(image);
+                    ImageIO.write(resizedImage, "jpg", new File(outputDir + File.separator + target));
                 }
                 fileToUpload = new File(outputDir + File.separator + target);
             } catch (IOException e) {
@@ -119,29 +98,8 @@ public class ImageUtil {
                     if (longEdge == 0) {
                         ImageIO.write(image, "jpg", imgFile);
                     } else {
-                        int width = image.getWidth();
-                        int height = image.getHeight();
-                        if (longEdge > Math.max(width, height)) {
-                            LOGGER.error("The longEdge value is too large, resizing cannot enlarge the original image. "
-                                    + "Original image resolution will not be changed");
-                            ImageIO.write(image, "jpg", imgFile);
-                            longEdge = 0;
-                        } else {
-                            if (width > height) {
-                                double ratio = (double) longEdge/width;
-                                int newHeight = (int) (height * ratio);
-                                BufferedImage resizedImage = resizeImage(longEdge, newHeight, image);
-                                ImageIO.write(resizedImage, "jpg", imgFile);
-                            } else if (height > width) {
-                                double ratio = (double) longEdge/height;
-                                int newWidth = (int) (width * ratio);
-                                BufferedImage resizedImage = resizeImage(newWidth, longEdge, image);
-                                ImageIO.write(resizedImage, "jpg", imgFile);
-                            } else {
-                                BufferedImage resizedImage = resizeImage(longEdge, longEdge, image);
-                                ImageIO.write(resizedImage, "jpg", imgFile);
-                            }
-                        }
+                        BufferedImage resizedImage = resizeImage(image);
+                        ImageIO.write(resizedImage, "jpg", imgFile);
                     }
                     vantiq.upload(imgFile, 
                             "image/jpeg", 
@@ -171,12 +129,42 @@ public class ImageUtil {
     
     /**
      * A function used to resize the original captured image, if requested.
-     * @param width     The resized width of the image to be saved.
-     * @param height    The resized height of the image to be saved.
      * @param image     The original image to be resized.
      * @return          The resized image.
      */
-    public BufferedImage resizeImage(int width, int height, BufferedImage image) {
+    public BufferedImage resizeImage(BufferedImage image) {
+        BufferedImage resizedImage;
+        int width = image.getWidth();
+        int height = image.getHeight();
+        if (longEdge > Math.max(width, height)) {
+            LOGGER.trace("The longEdge value is too large, resizing cannot enlarge the original image. "
+                    + "Original image resolution will not be changed");
+            return image;
+        } else {
+            if (width > height) {
+                double ratio = (double) longEdge/width;
+                int newHeight = (int) (height * ratio);
+                resizedImage = resizeHelper(longEdge, newHeight, image);
+            } else if (height > width) {
+                double ratio = (double) longEdge/height;
+                int newWidth = (int) (width * ratio);
+                resizedImage = resizeHelper(newWidth, longEdge, image);
+            } else {
+                resizedImage = resizeHelper(longEdge, longEdge, image);
+            }
+        }
+        
+        return resizedImage;
+    }
+    
+    /**
+     * A helper function that resizes the image, called by resizeImage()
+     * @param width     The new width of the resized image.
+     * @param height    The new height of the resized image.
+     * @param image     The original image to be resized.
+     * @return          The resized image.
+     */
+    public BufferedImage resizeHelper(int width, int height, BufferedImage image) {
         BufferedImage resizedImage = new BufferedImage(width, height, image.getType());
         Graphics2D g2d = resizedImage.createGraphics();
         g2d.drawImage(image, 0, 0, width, height, null);

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -209,6 +209,9 @@ public class YoloProcessor implements NeuralNetInterface {
                    } else {
                        imageUtil.longEdge = longEdge;
                    }
+               } else {
+                   log.debug("The longEdge option was not set, or was improperly set. This option must be a non-negative integer. "
+                           + "Saved image resolution will not be changed.");
                }
            } else {
                log.debug("No savedResolution was specified, or savedResolution was invalid. The savedResolution option must be a map.");

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -198,6 +198,21 @@ public class YoloProcessor implements NeuralNetInterface {
                vantiq = new io.vantiq.client.Vantiq(server);
                vantiq.setAccessToken(authToken);
            }
+           
+           // Check if any resolution configurations have been set
+           if (neuralNet.get("savedResolution") instanceof Map) {
+               Map savedResolution = (Map) neuralNet.get("savedResolution");
+               if (savedResolution.get("longEdge") instanceof Integer) {
+                   int longEdge = (Integer) savedResolution.get("longEdge");
+                   if (longEdge < 0) {
+                       log.error("The config value for longEdge must be a non-negative integer. Saved image resolution will not be changed.");
+                   } else {
+                       imageUtil.longEdge = longEdge;
+                   }
+               }
+           } else {
+               log.debug("No savedResolution was specified, or savedResolution was invalid. The savedResolution option must be a map.");
+           }
            imageUtil.outputDir = outputDir;
            imageUtil.vantiq = vantiq;
            imageUtil.saveImage = true;

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -578,11 +578,6 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         config.put("savedResolution", savedResolution);
         checkInvalidResizing(config);
         
-        // The longEdge is not a number which is not allowed, should not do any resizing
-        savedResolution.put("longEdge", "jibberish");
-        config.put("savedResolution", savedResolution);
-        checkInvalidResizing(config);
-        
         // The savedResolution is not a map which is not allowed, should not do any resizing
         config.put("savedResolution", "jibberish");
         checkInvalidResizing(config);


### PR DESCRIPTION
Fixes Issue #127 

Adds the ability to specify "savedResolution" options in the source configuration. This field contains an option called "longEdge", which is used to resize the saved image. The longEdge must be a non-negative integer that is smaller than the long edge of the original image. The saved image will be resized according to the longEdge value, and maintain the same dimension ratio as the original image.

The tests utilize the vantiq.download feature to check the dimensions for both locally saved and VANTIQ saved images.

This feature has not been added to the query parameters yet. It will be added as part of the work required for Issue #126 .