### PR TITLE
Naf query image #126

### DIFF
--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -279,6 +279,95 @@ Options available for all Queries (not prepended by anything) are:
     instead of only the objects recognized. Note that the data will be the sole occupant of a 1-element array when
     received, instead of being immediately available as a JSON object. This is because Query results are mandated
     to be arrays. Default is false.
+    
+Unique query capabilities available for the YOLO Processor are:
+
+*   **NOTE:** All YOLO Processor queries must have an "operation" parameter specified. If this parameter is not specified, it 
+will be set to the default value, "processNextFrame".
+
+*   **Upload images to VANTIQ:**
+    *   The user can specify an image, or multiple images to be uploaded to VANTIQ as a document. The images will be those 
+    that are saved in the output directory, which is defined in the source configuration.
+    *   Parameters:
+        *   "operation": Required. Must be set to "upload".
+        *   *Only one of the following two values *MUST* be specified, or a query error will be returned. If both values are 
+        specified, the imageName value will be used. (For optimal use, only set one of these values.)*
+            *   "imageName": A string value representing the name of the file to be uploaded. If set to "all", then all images 
+            in the output directory will be uploaded.
+            *   "imageDate": A list containing two strings, a start date and an end date. All locally saved images falling 
+            between the start and end date, (inclusive), will be uploaded. Dates must be formatted in the following 
+            manner: "yyyy-MM-dd--HH-mm-ss".
+        *   "savedResolution": Optional. This value can be set in the exact same way as it is set in the source configuration. 
+        If it is defined here as a query parameter, it will override the value set in the source configuration.
+    
+*   **Delete locally saved images:**
+    *   The user can specify one, or multiple locally saved images to be deleted. The images will be those 
+    that are saved in the output directory, which is defined in the source configuration.
+    *   Parameters:
+        *   "operation": Required. Must be set to "delete".
+        *   *Only one of the following two values *MUST* be specified, or a query error will be returned. If both values are 
+        specified, the imageName value will be used. (For optimal use, only set one of these values.)*
+            *   "imageName": A string value representing the name of the file to be deleted. If set to "all", then all images 
+            in the output directory will be deleted.
+            *   "imageDate": A list containing two strings, a start date and an end date. All locally saved images falling 
+            between the start and end date, (inclusive), will be deleted. Dates must be formatted in the following 
+            manner: "yyyy-MM-dd--HH-mm-ss".
+
+*   **Process a single frame from the camera defined in the source configuration:**
+    *   Parameters:
+        *   "operation": Required. Must be set to "processNextFrame".
+        *   "NNsaveImage": Optional. This value can be set exactly like the "saveImage" value in the source configuration.
+        *   "NNoutputDir": Optional. This value can be set exactly like the "outputDir" value in the source configuration.
+        *   "NNfileName": Optional. A string representing the unique name used to save the file. If not specified, the file 
+        will be named using the standard <yyyy-MM-dd--HH-mm-ss.jpg> value.
+    
+**EXAMPLE QUERIES**:
+
+*   Upload Query using imageName:
+```
+SELECT * FROM SOURCE Camera1 AS results WITH
+    	operation:"upload",
+    	imageName:"2019-02-08--10-33-36.jpg",
+    	savedResolution: {longEdge=600}
+```
+
+*   Upload Query using imageDate:
+```
+SELECT * FROM SOURCE Camera1 AS results WITH
+    	operation:"upload",
+    	imageDate:["2019-02-08--10-33-36", "2019-02-08--10-34-06"]
+```
+
+*   Delete Query using imageName:
+```
+SELECT * FROM SOURCE Camera1 AS results WITH
+    	operation:"delete",
+    	imageName:"all"
+```
+
+*   Delete Query using imageDate:
+```
+SELECT * FROM SOURCE Camera1 AS results WITH
+    	operation:"delete",
+    	imageDate:["2019-02-08--10-33-36", "2019-02-08--10-34-06"]
+```
+
+*   Process Next Frame Query:
+```
+SELECT * FROM SOURCE Camera1 AS results WITH
+        operation:"processNextFrame",
+    	NNsaveImage:"local",
+    	NNoutputDir:"testDir",
+    	NNfileName:"testFile"
+```
+
+*   Process Next Frame Query without specifying operation *(not recommended)*:
+```
+SELECT * FROM SOURCE Camera1 AS results WITH
+    	NNsaveImage:"local",
+    	NNoutputDir:"testDir",
+    	NNfileName:"testFile"
+```
 
 ### Error Messages
 

--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -353,7 +353,7 @@ SELECT * FROM SOURCE Camera1 AS results WITH
     	imageName:"2019-02-08--10-33-36.jpg"
 ```
 
-*   Delete Query using imageDate to save everything after a certain date:
+*   Delete Query using imageDate to delete everything after a certain date:
 ```
 SELECT * FROM SOURCE Camera1 AS results WITH
     	operation:"delete",

--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -286,8 +286,8 @@ Unique query capabilities available for the YOLO Processor are as follows:
 it will be set to the default value, "processNextFrame".
 
 *   **Upload images to VANTIQ:**
-    *   The user can specify an image, or multiple images to be uploaded to VANTIQ as a document. The images will be those 
-    that are saved in the output directory, which is defined in the source configuration.
+    *   The user can specify an image or a set of images specified by their date & time to be uploaded to VANTIQ as a 
+    document. The images will be those that are saved in the output directory, which is defined in the source configuration.
     *   Parameters:
         *   "operation": Required. Must be set to "upload".
         *   *You should specify exactly one of the following two values. If neither is specified, a query error will be 
@@ -299,14 +299,16 @@ it will be set to the default value, "processNextFrame".
                 *   To select all images *before* or *after* a certain date, the "-" value can be used as one of the date 
                 strings in the list. For example, the following would save all dates *before* the given date: 
                     *   \["-", yourEndDate\]. 
-                *   To select *all files* in the output directory, one could use the following value for imageDate: 
+                *   To select *all files* in the output directory, one must use the following value for imageDate: 
                     *   \["-", "-"\].
-        *   "savedResolution": Optional. This value can be set in the exact same way as it is set in the source configuration. 
-        If it is defined here as a query parameter, it will override the value set in the source configuration.
+        *   "savedResolution": Optional. This value can be set in the same way as it is set in the source configuration. If it 
+        is defined here as a query parameter, it will override the value set in the source configuration, otherwise the source 
+        configuration value will be used. The setting cannot be larger than that provided in the source configuration (since 
+        that defines how the images are saved).
     
 *   **Delete locally saved images:**
-    *   The user can specify one, or multiple locally saved images to be deleted. The images will be those 
-    that are saved in the output directory, which is defined in the source configuration.
+    *   The user can specify an image or a set of images specified by their date & time to be deleted. The images will be 
+    those that are saved in the output directory, which is defined in the source configuration.
     *   Parameters:
         *   "operation": Required. Must be set to "delete".
         *   *You should specify exactly one of the following two values. If neither is specified, a query error will be 
@@ -318,7 +320,7 @@ it will be set to the default value, "processNextFrame".
                 *   To select all images *before* or *after* a certain date, the "-" value can be used as one of the date 
                 strings in the list. For example, the following would save all dates *before* the given date: 
                     *   \["-", yourEndDate\]. 
-                *   To select *all files* in the output directory, one could use the following value for imageDate: 
+                *   To select *all files* in the output directory, one must use the following value for imageDate: 
                     *   \["-", "-"\].
 
 *   **Process a single frame from the camera defined in the source configuration:**
@@ -358,6 +360,13 @@ SELECT * FROM SOURCE Camera1 AS results WITH
 SELECT * FROM SOURCE Camera1 AS results WITH
     	operation:"delete",
     	imageDate:["2019-02-08--10-33-36", "-"]
+```
+
+*   Delete Query using imageDate to delete all images:
+```
+SELECT * FROM SOURCE Camera1 AS results WITH
+    	operation:"delete",
+    	imageDate:["-", "-"]
 ```
 
 *   Process Next Frame Query:

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
@@ -127,6 +127,7 @@ public class ObjectDetector {
                 }
             }
             this.imageUtil = imageUtil;
+            imageUtil.frameSize = this.frameSize;
             this.vantiq = vantiq;
             this.labelImage = labelImage;
             this.sourceName = sourceName;
@@ -215,6 +216,7 @@ public class ObjectDetector {
                 imageUtil.outputDir = outputDir;
                 imageUtil.vantiq = vantiq;
                 imageUtil.sourceName = sourceName;
+                imageUtil.frameSize = frameSize;
                 if (fileName == null) {
                     fileName = format.format(now) + ".jpg";
                 } else if (!fileName.endsWith(".jpg") && !fileName.endsWith(".jpeg")) {

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
@@ -28,6 +28,7 @@ public class ImageUtil {
     public Vantiq vantiq = null; // Added to allow image saving with VANTIQ
     public String sourceName = null;
     public Boolean saveImage;
+    public int frameSize;
     public int longEdge = 0;
 
     /**
@@ -36,8 +37,8 @@ public class ImageUtil {
      * @param recognitions  list of recognized objects
      */
     public BufferedImage labelImage(BufferedImage bufferedImage, final List<Recognition> recognitions) {
-        float scaleX = (float) bufferedImage.getWidth() / (float) Config.FRAME_SIZE;
-        float scaleY = (float) bufferedImage.getHeight() / (float) Config.FRAME_SIZE;
+        float scaleX = (float) bufferedImage.getWidth() / (float) frameSize;
+        float scaleY = (float) bufferedImage.getHeight() / (float) frameSize;
         Graphics2D graphics = (Graphics2D) bufferedImage.getGraphics();
 
         for (Recognition recognition: recognitions) {

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
@@ -29,6 +29,7 @@ public class ImageUtil {
     public String sourceName = null;
     public Boolean saveImage;
     public int frameSize;
+    public Boolean queryResize = false;
     public int longEdge = 0;
 
     /**
@@ -59,6 +60,7 @@ public class ImageUtil {
      * and erroring out if it disappears in the interim 
      * @param image     The image to save
      * @param target    The name of the file to be written
+     * @throws IOException 
      */
     public void saveImage(final BufferedImage image, final String target) {
         File fileToUpload = null;
@@ -78,20 +80,7 @@ public class ImageUtil {
         }
         if (vantiq != null) {
             if (fileToUpload != null) {
-                vantiq.upload(fileToUpload, 
-                        "image/jpeg", 
-                        "objectRecognition/" + sourceName + '/' + target,
-                        new BaseResponseHandler() {
-                            @Override public void onSuccess(Object body, Response response) {
-                                super.onSuccess(body, response);
-                                LOGGER.trace("Content Location = " + this.getBodyAsJsonObject().get("content"));
-                            }
-                            
-                            @Override public void onError(List<VantiqError> errors, Response response) {
-                                super.onError(errors, response);
-                                LOGGER.error("Errors uploading image with VANTIQ SDK: " + errors);
-                            }
-                });
+                uploadImage(fileToUpload, target);
             } else {
                 try {
                     File imgFile = File.createTempFile("tmp", ".jpg");
@@ -102,29 +91,79 @@ public class ImageUtil {
                         BufferedImage resizedImage = resizeImage(image);
                         ImageIO.write(resizedImage, "jpg", imgFile);
                     }
-                    vantiq.upload(imgFile, 
-                            "image/jpeg", 
-                            "objectRecognition/" + sourceName + '/'  + target,
-                            new BaseResponseHandler() {
-                                @Override public void onSuccess(Object body, Response response) {
-                                    super.onSuccess(body, response);
-                                    LOGGER.trace("Content Location = " + this.getBodyAsJsonObject().get("content"));
-                                    if(imgFile.delete()) { 
-                                        LOGGER.trace("Temp file deleted successfully"); 
-                                    } else { 
-                                        LOGGER.warn("Failed to delete temp file"); 
-                                    } 
-                                }
-                                
-                                @Override public void onError(List<VantiqError> errors, Response response) {
-                                    super.onError(errors, response);
-                                    LOGGER.error("Errors uploading image with VANTIQ SDK: " + errors);
-                                }
-                    });
+                    uploadImage(imgFile, target);
                 } catch (IOException e) {
                     LOGGER.error("Unable to save image {}", target, e);
                 }
             }
+        }
+    }
+    
+    /**
+     * A method used to upload images to VANTIQ, using the VANTIQ SDK
+     * @param imgFile   The file to be uploaded. If not specified to save locally, this file will be deleted.
+     * @param target    The name of the file to be uploaded.
+     * @throws IOException 
+     */
+    public void uploadImage(File imgFile, String target) {
+        if (queryResize) {
+            try {
+                BufferedImage resizedImage = resizeImage(ImageIO.read(imgFile));
+                File tmpFile = File.createTempFile("tmp", ".jpg");
+                tmpFile.deleteOnExit();
+                ImageIO.write(resizedImage, "jpg", tmpFile);
+                vantiq.upload(tmpFile, 
+                        "image/jpeg", 
+                        "objectRecognition/" + sourceName + '/'  + target,
+                        new BaseResponseHandler() {
+                            @Override public void onSuccess(Object body, Response response) {
+                                super.onSuccess(body, response);
+                                LOGGER.trace("Content Location = " + this.getBodyAsJsonObject().get("content"));
+                                
+                                if (outputDir == null) {
+                                    deleteImage(imgFile);
+                                }
+                            }
+                            
+                            @Override public void onError(List<VantiqError> errors, Response response) {
+                                super.onError(errors, response);
+                                LOGGER.error("Errors uploading image with VANTIQ SDK: " + errors);
+                            }
+                });
+            } catch (IOException e) {
+                LOGGER.error("An error occured while reading the locally saved image file. " + e.getMessage());
+            }
+        } else {
+            vantiq.upload(imgFile, 
+                    "image/jpeg", 
+                    "objectRecognition/" + sourceName + '/'  + target,
+                    new BaseResponseHandler() {
+                        @Override public void onSuccess(Object body, Response response) {
+                            super.onSuccess(body, response);
+                            LOGGER.trace("Content Location = " + this.getBodyAsJsonObject().get("content"));
+                            
+                            if (outputDir == null) {
+                                deleteImage(imgFile);
+                            }
+                        }
+                        
+                        @Override public void onError(List<VantiqError> errors, Response response) {
+                            super.onError(errors, response);
+                            LOGGER.error("Errors uploading image with VANTIQ SDK: " + errors);
+                        }
+            });
+        }
+    }
+    
+    /**
+     * A method used to delete locally saved images.
+     * @param imgFile  The file to be deleted.
+     */
+    public void deleteImage(File imgFile) {
+        if(imgFile.delete()) {
+            LOGGER.trace("File was successfully deleted.");
+        } else {
+            LOGGER.error("Failed to delete file");
         }
     }
     

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
@@ -1,6 +1,5 @@
 package edu.ml.tensorflow.util;
 
-import edu.ml.tensorflow.Config;
 import edu.ml.tensorflow.model.BoxPosition;
 import edu.ml.tensorflow.model.Recognition;
 import io.vantiq.client.BaseResponseHandler;

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
@@ -60,7 +60,6 @@ public class ImageUtil {
      * and erroring out if it disappears in the interim 
      * @param image     The image to save
      * @param target    The name of the file to be written
-     * @throws IOException 
      */
     public void saveImage(final BufferedImage image, final String target) {
         File fileToUpload = null;
@@ -103,7 +102,6 @@ public class ImageUtil {
      * A method used to upload images to VANTIQ, using the VANTIQ SDK
      * @param imgFile   The file to be uploaded. If not specified to save locally, this file will be deleted.
      * @param target    The name of the file to be uploaded.
-     * @throws IOException 
      */
     public void uploadImage(File imgFile, String target) {
         if (queryResize) {

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -98,17 +98,17 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
                 // Get value of operation if it was set, otherwise set to default
                 String operation;
                 if (request.get("operation") instanceof String) {
-                    operation = (String) request.get("operation");
+                    operation = request.get("operation").toString().toLowerCase();
                 } else {
-                    operation = "processNextFrame";
+                    operation = "processnextframe";
                 }
                 
                 // Check value of operation, proceed accordingly
-                if (operation.equalsIgnoreCase("upload")) {
+                if (operation.equals("upload")) {
                     source.uploadLocalImages(request, replyAddress);
-                } else if (operation.equalsIgnoreCase("delete")) {
+                } else if (operation.equals("delete")) {
                     source.deleteLocalImages(request, replyAddress);
-                } else if (operation.equalsIgnoreCase("processNextFrame")) {
+                } else if (operation.equals("processnextframe")) {
                     // Read, process, and send the image
                     ImageRetrieverResults data = source.retrieveImage(message);
                     if (data != null) {

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -221,7 +221,7 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
         
         // Identify the type of neural net
         String neuralNetType = DEFAULT_NEURAL_NET;
-        if (neuralNetConfig.get("type") instanceof String) {
+        if (neuralNetConfig.get(NeuralNetInterface.TYPE_ENTRY) instanceof String) {
             neuralNetType = (String) neuralNetConfig.get("type");
             if (neuralNetType.equals("yolo")) {
                 neuralNetType = YOLO_PROCESSOR_FQCN;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -94,25 +94,30 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
                 
                 Map<String, ?> request = (Map<String, ?>) message.getObject();
                 String replyAddress = ExtensionServiceMessage.extractReplyAddress(message);
+                
+                // Get value of operation if it was set, otherwise set to default
+                String operation;
                 if (request.get("operation") instanceof String) {
-                    String operation = (String) request.get("operation");
-                    if (operation.equalsIgnoreCase("upload")) {
-                        source.uploadLocalImages(request, replyAddress);
-                    } else if (operation.equalsIgnoreCase("delete")) {
-                        source.deleteLocalImages(request, replyAddress);
-                    } else {
-                        // Read, process, and send the image
-                        ImageRetrieverResults data = source.retrieveImage(message);
-                        if (data != null) {
-                            source.sendDataFromImage(data, message);
-                        }
-                    }
+                    operation = (String) request.get("operation");
                 } else {
+                    operation = "processNextFrame";
+                }
+                
+                // Check value of operation, proceed accordingly
+                if (operation.equalsIgnoreCase("upload")) {
+                    source.uploadLocalImages(request, replyAddress);
+                } else if (operation.equalsIgnoreCase("delete")) {
+                    source.deleteLocalImages(request, replyAddress);
+                } else if (operation.equalsIgnoreCase("processNextFrame")) {
                     // Read, process, and send the image
                     ImageRetrieverResults data = source.retrieveImage(message);
                     if (data != null) {
                         source.sendDataFromImage(data, message);
                     }
+                } else {
+                    client.sendQueryError(replyAddress, "io.vantiq.extsrc.objectRecognition.invalidImageRequest", 
+                            "Request specified an invalid 'operation'. The 'operation' value can be set to 'upload', 'delete', "
+                            + "or 'proccessNextFrame'.", null);
                 }
             }
         };

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -9,6 +9,7 @@
 
 package io.vantiq.extsrc.objectRecognition;
 
+import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
@@ -92,10 +93,27 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
                             "Request must be a map", null);
                 }
                 
-                // Read, process, and send the image
-                ImageRetrieverResults data = source.retrieveImage(message);
-                if (data != null) {
-                    source.sendDataFromImage(data, message);
+                Map<String, ?> request = (Map<String, ?>) message.getObject();
+                String replyAddress = ExtensionServiceMessage.extractReplyAddress(message);
+                if (request.get("operation") instanceof String) {
+                    String operation = (String) request.get("operation");
+                    if (operation.equalsIgnoreCase("upload")) {
+                        source.uploadLocalImages(request, replyAddress);
+                    } else if (operation.equalsIgnoreCase("delete")) {
+                        source.deleteLocalImages(request, replyAddress);
+                    } else {
+                        // Read, process, and send the image
+                        ImageRetrieverResults data = source.retrieveImage(message);
+                        if (data != null) {
+                            source.sendDataFromImage(data, message);
+                        }
+                    }
+                } else {
+                    // Read, process, and send the image
+                    ImageRetrieverResults data = source.retrieveImage(message);
+                    if (data != null) {
+                        source.sendDataFromImage(data, message);
+                    }
                 }
             }
         };

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -234,6 +234,9 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
             log.debug("No neural net type specified. Trying for default of '{}'", DEFAULT_NEURAL_NET);
         }
         
+        // Setting the outputDir value for the core, (null if it does not exist)
+        source.outputDir = (String) neuralNetConfig.get(NeuralNetInterface.OUTPUT_DIRECTORY_ENTRY);
+        
         // Create the neural net
         NeuralNetInterface neuralNet = getNeuralNet(neuralNetType);
         if (neuralNet == null) {

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -9,7 +9,6 @@
 
 package io.vantiq.extsrc.objectRecognition;
 
-import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -555,7 +555,6 @@ public class ObjectRecognitionCore {
        File imgDirectory = new File(imageDir);
        File[] directoryListing;
        directoryListing = imgDirectory.listFiles(filter);
-       
        if (directoryListing != null) {
            for (File fileToUpload : directoryListing) {
                imageUtil.uploadImage(fileToUpload, fileToUpload.getName());

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -465,16 +465,7 @@ public class ObjectRecognitionCore {
        // Examining parameters, and creating filters if necessary
        
        if (imageName != null) {
-           // If imageName is "all", then upload all images in the directory
-           if (imageName.equals("all")) {
-               dateRange.add(null);
-               dateRange.add(null);
-               useFilter = true;
-               
-           // Otherwise, upload the one image matching the imageName.
-           } else {
-               useFilter = false;
-           }
+           useFilter = false;
        } else if (imageDate != null) {
            for (String date : imageDate) {
                if (date.equals("-")) {
@@ -607,7 +598,7 @@ public class ObjectRecognitionCore {
    }
    
    /**
-    * A helper function called by deleteLocalImages, used if imageName or imageDate is set to "all"
+    * A helper function called by deleteLocalImages, used when multiple files need to be deleted
     * @param imageDir    The name of the image directory
     * @param imageUtil   The instantiated ImageUtil class containing the method to delete
     * @param filter      The filter used if a dateRange was selected, otherwise null

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -433,7 +433,7 @@ public class ObjectRecognitionCore {
            imageDate = (List<String>) request.get("imageDate");
            if (imageDate.size() != 2) {
                client.sendQueryError(replyAddress, "io.vantiq.extsrc.objectRecognition.invalidQueryRequest", 
-                       "The imageDate value was a list with more than two elements. Must be a list containing only "
+                       "The imageDate value did not contain exactly two elements. Must be a list containing only "
                        + "[<yourStartDate>, <yourEndDate>].", null);
                return;
            }
@@ -592,7 +592,7 @@ public class ObjectRecognitionCore {
            imageDate = (List<String>) request.get("imageDate");
            if (imageDate.size() != 2) {
                client.sendQueryError(replyAddress, "io.vantiq.extsrc.objectRecognition.invalidQueryRequest", 
-                       "The imageDate value was a list with more than two elements. Must be a list containing only "
+                       "The imageDate value did not contain exactly two elements. Must be a list containing only "
                        + "[<yourStartDate>, <yourEndDate>].", null);
                return;
            }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -59,7 +59,7 @@ public class ObjectRecognitionCore {
     Timer                   pollTimer       = null;
     ImageRetrieverInterface imageRetriever  = null;
     
-    ObjectRecognitionConfigHandler  objRecConfigHandler;
+    ObjectRecognitionConfigHandler objRecConfigHandler;
     
     // vars for internal use
     ExtensionWebSocketClient    client      = null;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetInterface.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetInterface.java
@@ -19,6 +19,7 @@ import io.vantiq.extsrc.objectRecognition.exception.ImageProcessingException;
  */
 public interface NeuralNetInterface {
     static final String OUTPUT_DIRECTORY_ENTRY = "outputDir";
+    static final String TYPE_ENTRY = "type";
     
     /**
      * Setup the neural net for image processing.

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetInterface.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetInterface.java
@@ -18,6 +18,7 @@ import io.vantiq.extsrc.objectRecognition.exception.ImageProcessingException;
  * An interface for the neural net that will process the image and return a List of data representing the objects found.
  */
 public interface NeuralNetInterface {
+    static final String OUTPUT_DIRECTORY_ENTRY = "outputDir";
     
     /**
      * Setup the neural net for image processing.

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/query/DateRangeFilter.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/query/DateRangeFilter.java
@@ -21,17 +21,7 @@ public class DateRangeFilter implements FilenameFilter {
     public boolean accept(File dir, String name) {
         try {
             Date fName = format.parse(name);
-            System.out.print(name);
-            if (beforeDate == null) {
-                System.out.print("Before Date == null");
-            } else if (!fName.after(beforeDate)) {
-                System.out.print("Name is not after 'before date'");
-            } else if (afterDate == null) {
-                System.out.print("After Date == null");
-            } else if (!fName.before(afterDate)) {
-                System.out.print("Name is not before 'after date'");
-            }
-            return ((beforeDate == null) || !fName.after(beforeDate)) && ((afterDate == null) || !fName.before(afterDate));
+            return ((beforeDate == null) || !fName.before(beforeDate)) && ((afterDate == null) || !fName.after(afterDate));
         } catch (ParseException e) {
             return false;
         }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/query/DateRangeFilter.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/query/DateRangeFilter.java
@@ -20,6 +20,7 @@ public class DateRangeFilter implements FilenameFilter {
     @Override
     public boolean accept(File dir, String name) {
         try {
+            name = name.replaceAll("\\s*\\([^\\)]*\\)\\s*", " ");
             Date fName = format.parse(name);
             return ((beforeDate == null) || !fName.before(beforeDate)) && ((afterDate == null) || !fName.after(afterDate));
         } catch (ParseException e) {

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/query/DateRangeFilter.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/query/DateRangeFilter.java
@@ -1,0 +1,40 @@
+package io.vantiq.extsrc.objectRecognition.query;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+public class DateRangeFilter implements FilenameFilter {
+    Date beforeDate = null;
+    Date afterDate = null;
+    SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd--HH-mm-ss");
+    
+    public DateRangeFilter(List<Date> dateRange) {
+        beforeDate = dateRange.get(0);
+        afterDate = dateRange.get(1);
+    }
+
+    @Override
+    public boolean accept(File dir, String name) {
+        try {
+            Date fName = format.parse(name);
+            System.out.print(name);
+            if (beforeDate == null) {
+                System.out.print("Before Date == null");
+            } else if (!fName.after(beforeDate)) {
+                System.out.print("Name is not after 'before date'");
+            } else if (afterDate == null) {
+                System.out.print("After Date == null");
+            } else if (!fName.before(afterDate)) {
+                System.out.print("Name is not before 'after date'");
+            }
+            return ((beforeDate == null) || !fName.after(beforeDate)) && ((afterDate == null) || !fName.before(afterDate));
+        } catch (ParseException e) {
+            return false;
+        }
+    }
+
+}

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
@@ -42,25 +42,30 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     static final String OUTPUT_DIR = System.getProperty("buildDir") + "/resources/out";
     static final String NOT_FOUND_CODE = "io.vantiq.resource.not.found";
     
+    static final String IMAGE_1_DATE = "2019-02-05--02-35-10";
     static final Map<String,String> IMAGE_1 = new LinkedHashMap<String,String>() {{
         put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-10.jpg");
-        put("date", "2019-02-05--02-35-10");
+        put("date", IMAGE_1_DATE);
     }};
+    static final String IMAGE_2_DATE = "2019-02-05--02-35-13";
     static final Map<String,String> IMAGE_2 = new LinkedHashMap<String,String>() {{
         put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-13.jpg");
-        put("date", "2019-02-05--02-35-13");
+        put("date", IMAGE_2_DATE);
     }};
+    static final String IMAGE_3_DATE = "2019-02-05--02-35-16";
     static final Map<String,String> IMAGE_3 = new LinkedHashMap<String,String>() {{
         put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-16.jpg");
-        put("date", "2019-02-05--02-35-16");
+        put("date", IMAGE_3_DATE);
     }};
+    static final String IMAGE_4_DATE = "2019-02-05--02-35-19";
     static final Map<String,String> IMAGE_4 = new LinkedHashMap<String,String>() {{
         put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-19.jpg");
-        put("date", "2019-02-05--02-35-19");
+        put("date", IMAGE_4_DATE);
     }};
+    static final String IMAGE_5_DATE = "2019-02-05--02-35-22";
     static final Map<String,String> IMAGE_5 = new LinkedHashMap<String,String>() {{
         put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-22.jpg");
-        put("date", "2019-02-05--02-35-22");
+        put("date", IMAGE_5_DATE);
     }};
     
     static final String START_DATE = IMAGE_2.get("date");
@@ -158,7 +163,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_2.get("filename"));
         checkNotUploadToVantiq(IMAGE_3.get("filename"));
         checkNotUploadToVantiq(IMAGE_4.get("filename"));
-        checkNotUploadToVantiq(IMAGE_5.get("filename"));  
+        checkNotUploadToVantiq(IMAGE_5.get("filename"));
         
         // Using wrong type for imageDir
         request.put("imageDir", 5);
@@ -170,7 +175,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_2.get("filename"));
         checkNotUploadToVantiq(IMAGE_3.get("filename"));
         checkNotUploadToVantiq(IMAGE_4.get("filename"));
-        checkNotUploadToVantiq(IMAGE_5.get("filename")); 
+        checkNotUploadToVantiq(IMAGE_5.get("filename"));
         
         // Forgetting to include either imageName or imageDate
         request.put("imageDir", OUTPUT_DIR);
@@ -183,7 +188,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_2.get("filename"));
         checkNotUploadToVantiq(IMAGE_3.get("filename"));
         checkNotUploadToVantiq(IMAGE_4.get("filename"));
-        checkNotUploadToVantiq(IMAGE_5.get("filename")); 
+        checkNotUploadToVantiq(IMAGE_5.get("filename"));
         
         // Using wrong type for imageName
         request.put("imageName", 5);
@@ -195,7 +200,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_2.get("filename"));
         checkNotUploadToVantiq(IMAGE_3.get("filename"));
         checkNotUploadToVantiq(IMAGE_4.get("filename"));
-        checkNotUploadToVantiq(IMAGE_5.get("filename")); 
+        checkNotUploadToVantiq(IMAGE_5.get("filename"));
         
         // Using wrong type for imageDate
         request.remove("imageName");
@@ -208,7 +213,74 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_2.get("filename"));
         checkNotUploadToVantiq(IMAGE_3.get("filename"));
         checkNotUploadToVantiq(IMAGE_4.get("filename"));
-        checkNotUploadToVantiq(IMAGE_5.get("filename")); 
+        checkNotUploadToVantiq(IMAGE_5.get("filename"));
+        
+        // Using an imageDate list that is null
+        List<String> invalidImageDates = null;
+        request.put("imageDate", invalidImageDates);
+        core.uploadLocalImages(request, null);
+        
+        // Checking that images were not uploaded to VANTIQ
+        Thread.sleep(1000);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"));
+        checkNotUploadToVantiq(IMAGE_2.get("filename"));
+        checkNotUploadToVantiq(IMAGE_3.get("filename"));
+        checkNotUploadToVantiq(IMAGE_4.get("filename"));
+        checkNotUploadToVantiq(IMAGE_5.get("filename"));
+        
+        // Using an imageDate list that has no values
+        invalidImageDates = new ArrayList<String>();
+        core.uploadLocalImages(request, null);
+        
+        // Checking that images were not uploaded to VANTIQ
+        Thread.sleep(1000);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"));
+        checkNotUploadToVantiq(IMAGE_2.get("filename"));
+        checkNotUploadToVantiq(IMAGE_3.get("filename"));
+        checkNotUploadToVantiq(IMAGE_4.get("filename"));
+        checkNotUploadToVantiq(IMAGE_5.get("filename"));
+        
+        // Using an imageDate list that contains non-dates
+        invalidImageDates.add("Not a date");
+        invalidImageDates.add("Also not a date");
+        request.put("imageDate", invalidImageDates);
+        core.uploadLocalImages(request, null);
+        
+        // Checking that images were not uploaded to VANTIQ
+        Thread.sleep(1000);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"));
+        checkNotUploadToVantiq(IMAGE_2.get("filename"));
+        checkNotUploadToVantiq(IMAGE_3.get("filename"));
+        checkNotUploadToVantiq(IMAGE_4.get("filename"));
+        checkNotUploadToVantiq(IMAGE_5.get("filename"));
+        
+        // Using an imageDate list with only one date
+        invalidImageDates.clear();
+        invalidImageDates.add(IMAGE_1_DATE);
+        request.put("imageDate", invalidImageDates);
+        core.uploadLocalImages(request, null);
+        
+        // Checking that images were not uploaded to VANTIQ
+        Thread.sleep(1000);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"));
+        checkNotUploadToVantiq(IMAGE_2.get("filename"));
+        checkNotUploadToVantiq(IMAGE_3.get("filename"));
+        checkNotUploadToVantiq(IMAGE_4.get("filename"));
+        checkNotUploadToVantiq(IMAGE_5.get("filename"));
+        
+        // Using an imageDate list with more than two dates
+        invalidImageDates.add(IMAGE_2_DATE);
+        invalidImageDates.add(IMAGE_3_DATE);
+        request.put("imageDate", invalidImageDates);
+        core.uploadLocalImages(request, null);
+        
+        // Checking that images were not uploaded to VANTIQ
+        Thread.sleep(1000);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"));
+        checkNotUploadToVantiq(IMAGE_2.get("filename"));
+        checkNotUploadToVantiq(IMAGE_3.get("filename"));
+        checkNotUploadToVantiq(IMAGE_4.get("filename"));
+        checkNotUploadToVantiq(IMAGE_5.get("filename"));
     }
     
     @Test
@@ -255,6 +327,48 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         request.remove("imageName");
         request.put("imageDate", 5);
         core.deleteLocalImages(request, null);
+        
+        dList = d.listFiles();
+        assert dList.length == 5;
+        
+        // Using an imageDate list that is null
+        List<String> invalidImageDates = null;
+        request.put("imageDate", invalidImageDates);
+        core.uploadLocalImages(request, null);
+        
+        dList = d.listFiles();
+        assert dList.length == 5;
+        
+        // Using an imageDate list that has no values
+        invalidImageDates = new ArrayList<String>();
+        core.uploadLocalImages(request, null);
+        
+        dList = d.listFiles();
+        assert dList.length == 5;
+        
+        // Using an imageDate list that contains non-dates
+        invalidImageDates.add("Not a date");
+        invalidImageDates.add("Also not a date");
+        request.put("imageDate", invalidImageDates);
+        core.uploadLocalImages(request, null);
+        
+        dList = d.listFiles();
+        assert dList.length == 5;
+        
+        // Using an imageDate list with only one date
+        invalidImageDates.clear();
+        invalidImageDates.add(IMAGE_1_DATE);
+        request.put("imageDate", invalidImageDates);
+        core.uploadLocalImages(request, null);
+        
+        dList = d.listFiles();
+        assert dList.length == 5;
+        
+        // Using an imageDate list with more than two dates
+        invalidImageDates.add(IMAGE_2_DATE);
+        invalidImageDates.add(IMAGE_3_DATE);
+        request.put("imageDate", invalidImageDates);
+        core.uploadLocalImages(request, null);
         
         dList = d.listFiles();
         assert dList.length == 5;

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
@@ -71,7 +71,9 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     
     
     @BeforeClass
-    public static void setup() {        
+    public static void setup() {
+        testAuthToken="-YyPeih6BkZoQoVa5tUT3cMZ4DXaWs7M6hg26WEdU88=";
+        testVantiqServer="https://dev.vantiq.com";
         core = new NoSendORCore(SOURCE_NAME, testAuthToken, testVantiqServer, MODEL_DIRECTORY);
         core.start(10);
         
@@ -307,8 +309,12 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         
         Map<String, Object> request = new LinkedHashMap<>();
+        List<String> imageDate = new ArrayList<String>();
+        imageDate.add("-");
+        imageDate.add("-");
         request.put("imageDir", OUTPUT_DIR);
-        request.put("imageDate", "all");
+        request.put("imageDate", imageDate);
+        
         
         core.uploadLocalImages(request, null);
                 
@@ -327,28 +333,14 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         
         Map<String, Object> request = new LinkedHashMap<>();
-        // Specifying the dateRange as "none"
+        List<String> imageDate = new ArrayList<String>();
+        imageDate.add(START_DATE);
+        imageDate.add(START_DATE);
         request.put("imageDir", OUTPUT_DIR);
-        request.put("imageDate", START_DATE);
-        request.put("dateRange", "none");
+        request.put("imageDate", imageDate);
         
         core.uploadLocalImages(request, null);
                 
-        // Checking that all images were uploaded to VANTIQ
-        Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_2.get("filename"));
-        
-        // Checking that none of the other images were uploaded to VANTIQ
-        checkNotUploadToVantiq(IMAGE_1.get("filename"));
-        checkNotUploadToVantiq(IMAGE_3.get("filename"));
-        checkNotUploadToVantiq(IMAGE_4.get("filename"));
-        checkNotUploadToVantiq(IMAGE_5.get("filename"));
-        
-        // Removing the dateRange value, should default to the same behavior
-        request.remove("dateRange");
-        
-        core.uploadLocalImages(request, null);
-        
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
         checkUploadToVantiq(IMAGE_2.get("filename"));
@@ -366,9 +358,11 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         
         Map<String, Object> request = new LinkedHashMap<>();
+        List<String> imageDate = new ArrayList<String>();
+        imageDate.add("-");
+        imageDate.add(START_DATE);
         request.put("imageDir", OUTPUT_DIR);
-        request.put("imageDate", START_DATE);
-        request.put("dateRange", "before");
+        request.put("imageDate", imageDate);
         
         core.uploadLocalImages(request, null);
                 
@@ -389,9 +383,11 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         
         Map<String, Object> request = new LinkedHashMap<>();
+        List<String> imageDate = new ArrayList<String>();
+        imageDate.add(END_DATE);
+        imageDate.add("-");
         request.put("imageDir", OUTPUT_DIR);
-        request.put("imageDate", END_DATE);
-        request.put("dateRange", "after");
+        request.put("imageDate", imageDate);
         
         core.uploadLocalImages(request, null);
                 
@@ -412,11 +408,11 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         
         Map<String, Object> request = new LinkedHashMap<>();
-        List<String> dateRange = new ArrayList<String>();
-        dateRange.add(START_DATE);
-        dateRange.add(END_DATE);
+        List<String> imageDate = new ArrayList<String>();
+        imageDate.add(START_DATE);
+        imageDate.add(END_DATE);
         request.put("imageDir", OUTPUT_DIR);
-        request.put("imageDate", dateRange);
+        request.put("imageDate", imageDate);
         
         core.uploadLocalImages(request, null);
                 

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
@@ -42,14 +42,29 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     static final String OUTPUT_DIR = System.getProperty("buildDir") + "/resources/out";
     static final String NOT_FOUND_CODE = "io.vantiq.resource.not.found";
     
-    static final String IMAGE_NAME_1 = "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-10.jpg";
-    static final String IMAGE_NAME_2 = "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-13.jpg";
-    static final String IMAGE_NAME_3 = "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-16.jpg";
-    static final String IMAGE_NAME_4 = "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-19.jpg";
-    static final String IMAGE_NAME_5 = "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-22.jpg";
+    static final Map<String,String> IMAGE_1 = new LinkedHashMap<String,String>() {{
+        put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-10.jpg");
+        put("date", "2019-02-05--02-35-10.jpg");
+    }};
+    static final Map<String,String> IMAGE_2 = new LinkedHashMap<String,String>() {{
+        put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-13.jpg");
+        put("date", "2019-02-05--02-35-13.jpg");
+    }};
+    static final Map<String,String> IMAGE_3 = new LinkedHashMap<String,String>() {{
+        put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-16.jpg");
+        put("date", "2019-02-05--02-35-16.jpg");
+    }};
+    static final Map<String,String> IMAGE_4 = new LinkedHashMap<String,String>() {{
+        put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-19.jpg");
+        put("date", "2019-02-05--02-35-19.jpg");
+    }};
+    static final Map<String,String> IMAGE_5 = new LinkedHashMap<String,String>() {{
+        put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-22.jpg");
+        put("date", "2019-02-05--02-35-22.jpg");
+    }};
     
-    static final String START_DATE = "2019-02-05--02-35-13";
-    static final String END_DATE = "2019-02-05--02-35-19";
+    static final String START_DATE = IMAGE_2.get("date");
+    static final String END_DATE = IMAGE_4.get("date");
     
     static final int RESIZED_IMAGE_WIDTH = 100;
     static final int RESIZED_IMAGE_HEIGHT = 75;
@@ -64,11 +79,11 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         vantiq.setAccessToken(testAuthToken);
         
         // Add files to be deleted from VANTIQ later
-        vantiqUploadFiles.add(IMAGE_NAME_1);
-        vantiqUploadFiles.add(IMAGE_NAME_2);
-        vantiqUploadFiles.add(IMAGE_NAME_3);
-        vantiqUploadFiles.add(IMAGE_NAME_4);
-        vantiqUploadFiles.add(IMAGE_NAME_5);
+        vantiqUploadFiles.add(IMAGE_1.get("filename"));
+        vantiqUploadFiles.add(IMAGE_2.get("filename"));
+        vantiqUploadFiles.add(IMAGE_3.get("filename"));
+        vantiqUploadFiles.add(IMAGE_4.get("filename"));
+        vantiqUploadFiles.add(IMAGE_5.get("filename"));
     }
     
     @Before
@@ -135,63 +150,63 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         request.put("imageName", "all");
         core.uploadLocalImages(request, null);
                 
-        // Checking that all images were uploaded to VANTIQ
+        // Checking that images were not uploaded to VANTIQ
         Thread.sleep(1000);
-        checkNotUploadToVantiq(IMAGE_NAME_1);
-        checkNotUploadToVantiq(IMAGE_NAME_2);
-        checkNotUploadToVantiq(IMAGE_NAME_3);
-        checkNotUploadToVantiq(IMAGE_NAME_4);
-        checkNotUploadToVantiq(IMAGE_NAME_5);  
+        checkNotUploadToVantiq(IMAGE_1.get("filename"));
+        checkNotUploadToVantiq(IMAGE_2.get("filename"));
+        checkNotUploadToVantiq(IMAGE_3.get("filename"));
+        checkNotUploadToVantiq(IMAGE_4.get("filename"));
+        checkNotUploadToVantiq(IMAGE_5.get("filename"));  
         
         // Using wrong type for imageDir
         request.put("imageDir", 5);
         core.uploadLocalImages(request, null);
         
-        // Checking that all images were uploaded to VANTIQ
+        // Checking that images were not uploaded to VANTIQ
         Thread.sleep(1000);
-        checkNotUploadToVantiq(IMAGE_NAME_1);
-        checkNotUploadToVantiq(IMAGE_NAME_2);
-        checkNotUploadToVantiq(IMAGE_NAME_3);
-        checkNotUploadToVantiq(IMAGE_NAME_4);
-        checkNotUploadToVantiq(IMAGE_NAME_5);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"));
+        checkNotUploadToVantiq(IMAGE_2.get("filename"));
+        checkNotUploadToVantiq(IMAGE_3.get("filename"));
+        checkNotUploadToVantiq(IMAGE_4.get("filename"));
+        checkNotUploadToVantiq(IMAGE_5.get("filename")); 
         
         // Forgetting to include either imageName or imageDate
         request.put("imageDir", OUTPUT_DIR);
         request.remove("imageName");
         core.uploadLocalImages(request, null);
         
-        // Checking that all images were uploaded to VANTIQ
+        // Checking that images were not uploaded to VANTIQ
         Thread.sleep(1000);
-        checkNotUploadToVantiq(IMAGE_NAME_1);
-        checkNotUploadToVantiq(IMAGE_NAME_2);
-        checkNotUploadToVantiq(IMAGE_NAME_3);
-        checkNotUploadToVantiq(IMAGE_NAME_4);
-        checkNotUploadToVantiq(IMAGE_NAME_5);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"));
+        checkNotUploadToVantiq(IMAGE_2.get("filename"));
+        checkNotUploadToVantiq(IMAGE_3.get("filename"));
+        checkNotUploadToVantiq(IMAGE_4.get("filename"));
+        checkNotUploadToVantiq(IMAGE_5.get("filename")); 
         
         // Using wrong type for imageName
         request.put("imageName", 5);
         core.uploadLocalImages(request, null);
         
-        // Checking that all images were uploaded to VANTIQ
+        // Checking that images were not uploaded to VANTIQ
         Thread.sleep(1000);
-        checkNotUploadToVantiq(IMAGE_NAME_1);
-        checkNotUploadToVantiq(IMAGE_NAME_2);
-        checkNotUploadToVantiq(IMAGE_NAME_3);
-        checkNotUploadToVantiq(IMAGE_NAME_4);
-        checkNotUploadToVantiq(IMAGE_NAME_5);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"));
+        checkNotUploadToVantiq(IMAGE_2.get("filename"));
+        checkNotUploadToVantiq(IMAGE_3.get("filename"));
+        checkNotUploadToVantiq(IMAGE_4.get("filename"));
+        checkNotUploadToVantiq(IMAGE_5.get("filename")); 
         
         // Using wrong type for imageDate
         request.remove("imageName");
         request.put("imageDate", 5);
         core.uploadLocalImages(request, null);
         
-        // Checking that all images were uploaded to VANTIQ
+        // Checking that images were not uploaded to VANTIQ
         Thread.sleep(1000);
-        checkNotUploadToVantiq(IMAGE_NAME_1);
-        checkNotUploadToVantiq(IMAGE_NAME_2);
-        checkNotUploadToVantiq(IMAGE_NAME_3);
-        checkNotUploadToVantiq(IMAGE_NAME_4);
-        checkNotUploadToVantiq(IMAGE_NAME_5);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"));
+        checkNotUploadToVantiq(IMAGE_2.get("filename"));
+        checkNotUploadToVantiq(IMAGE_3.get("filename"));
+        checkNotUploadToVantiq(IMAGE_4.get("filename"));
+        checkNotUploadToVantiq(IMAGE_5.get("filename")); 
     }
     
     @Test
@@ -256,11 +271,11 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
                 
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_NAME_1);
-        checkUploadToVantiq(IMAGE_NAME_2);
-        checkUploadToVantiq(IMAGE_NAME_3);
-        checkUploadToVantiq(IMAGE_NAME_4);
-        checkUploadToVantiq(IMAGE_NAME_5);        
+        checkUploadToVantiq(IMAGE_1.get("filename"));
+        checkUploadToVantiq(IMAGE_2.get("filename"));
+        checkUploadToVantiq(IMAGE_3.get("filename"));
+        checkUploadToVantiq(IMAGE_4.get("filename"));
+        checkUploadToVantiq(IMAGE_5.get("filename"));         
     }
     
     @Test
@@ -276,13 +291,13 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
                 
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_NAME_2);
+        checkUploadToVantiq(IMAGE_2.get("filename"));
         
         // Checking that none of the other images were uploaded to VANTIQ
-        checkNotUploadToVantiq(IMAGE_NAME_1);
-        checkNotUploadToVantiq(IMAGE_NAME_3);
-        checkNotUploadToVantiq(IMAGE_NAME_4);
-        checkNotUploadToVantiq(IMAGE_NAME_5);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"));
+        checkNotUploadToVantiq(IMAGE_3.get("filename"));
+        checkNotUploadToVantiq(IMAGE_4.get("filename"));
+        checkNotUploadToVantiq(IMAGE_5.get("filename")); 
         
     }
     
@@ -299,11 +314,11 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
                 
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_NAME_1);
-        checkUploadToVantiq(IMAGE_NAME_2);
-        checkUploadToVantiq(IMAGE_NAME_3);
-        checkUploadToVantiq(IMAGE_NAME_4);
-        checkUploadToVantiq(IMAGE_NAME_5);  
+        checkUploadToVantiq(IMAGE_1.get("filename"));
+        checkUploadToVantiq(IMAGE_2.get("filename"));
+        checkUploadToVantiq(IMAGE_3.get("filename"));
+        checkUploadToVantiq(IMAGE_4.get("filename"));
+        checkUploadToVantiq(IMAGE_5.get("filename"));   
     }
     
     @Test
@@ -321,13 +336,13 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
                 
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_NAME_2);
+        checkUploadToVantiq(IMAGE_2.get("filename"));
         
         // Checking that none of the other images were uploaded to VANTIQ
-        checkNotUploadToVantiq(IMAGE_NAME_1);
-        checkNotUploadToVantiq(IMAGE_NAME_3);
-        checkNotUploadToVantiq(IMAGE_NAME_4);
-        checkNotUploadToVantiq(IMAGE_NAME_5);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"));
+        checkNotUploadToVantiq(IMAGE_3.get("filename"));
+        checkNotUploadToVantiq(IMAGE_4.get("filename"));
+        checkNotUploadToVantiq(IMAGE_5.get("filename"));
         
         // Removing the dateRange value, should default to the same behavior
         request.remove("dateRange");
@@ -336,13 +351,13 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_NAME_2);
+        checkUploadToVantiq(IMAGE_2.get("filename"));
         
         // Checking that none of the other images were uploaded to VANTIQ
-        checkNotUploadToVantiq(IMAGE_NAME_1);
-        checkNotUploadToVantiq(IMAGE_NAME_3);
-        checkNotUploadToVantiq(IMAGE_NAME_4);
-        checkNotUploadToVantiq(IMAGE_NAME_5);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"));
+        checkNotUploadToVantiq(IMAGE_3.get("filename"));
+        checkNotUploadToVantiq(IMAGE_4.get("filename"));
+        checkNotUploadToVantiq(IMAGE_5.get("filename"));
     }
     
     @Test
@@ -359,13 +374,13 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
                 
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_NAME_1);
-        checkUploadToVantiq(IMAGE_NAME_2);
+        checkUploadToVantiq(IMAGE_1.get("filename"));
+        checkUploadToVantiq(IMAGE_2.get("filename"));
         
         // Checking that none of the other images were uploaded to VANTIQ
-        checkNotUploadToVantiq(IMAGE_NAME_3);
-        checkNotUploadToVantiq(IMAGE_NAME_4);
-        checkNotUploadToVantiq(IMAGE_NAME_5);
+        checkNotUploadToVantiq(IMAGE_3.get("filename"));
+        checkNotUploadToVantiq(IMAGE_4.get("filename"));
+        checkNotUploadToVantiq(IMAGE_5.get("filename"));
     }
     
     @Test
@@ -382,13 +397,13 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
                 
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_NAME_4);
-        checkUploadToVantiq(IMAGE_NAME_5);
+        checkUploadToVantiq(IMAGE_4.get("filename"));
+        checkUploadToVantiq(IMAGE_5.get("filename"));
         
         // Checking that none of the other images were uploaded to VANTIQ
-        checkNotUploadToVantiq(IMAGE_NAME_1);
-        checkNotUploadToVantiq(IMAGE_NAME_2);
-        checkNotUploadToVantiq(IMAGE_NAME_3);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"));
+        checkNotUploadToVantiq(IMAGE_2.get("filename"));
+        checkNotUploadToVantiq(IMAGE_3.get("filename"));
     }
     
     @Test
@@ -406,14 +421,14 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         core.uploadLocalImages(request, null);
                 
         // Checking that all images were uploaded to VANTIQ
-        Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_NAME_2);
-        checkUploadToVantiq(IMAGE_NAME_3);
-        checkUploadToVantiq(IMAGE_NAME_4);
+        Thread.sleep(3000);
+        checkUploadToVantiq(IMAGE_2.get("filename"));
+        checkUploadToVantiq(IMAGE_3.get("filename"));
+        checkUploadToVantiq(IMAGE_4.get("filename"));
         
         // Checking that none of the other images were uploaded to VANTIQ
-        checkNotUploadToVantiq(IMAGE_NAME_1);
-        checkNotUploadToVantiq(IMAGE_NAME_5);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"));
+        checkNotUploadToVantiq(IMAGE_5.get("filename"));
     }
     
     @Test
@@ -434,7 +449,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         
         // Checking that image was saved to VANTIQ
         Thread.sleep(1000);
-        vantiqResponse = vantiq.selectOne("system.documents", IMAGE_NAME_2);
+        vantiqResponse = vantiq.selectOne("system.documents", IMAGE_2.get("filename"));
         if (vantiqResponse.hasErrors()) {
             List<VantiqError> errors = vantiqResponse.getErrors();
             for (int i = 0; i < errors.size(); i++) {

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
@@ -44,28 +44,38 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     
     static final String IMAGE_1_DATE = "2019-02-05--02-35-10";
     static final Map<String,String> IMAGE_1 = new LinkedHashMap<String,String>() {{
-        put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-10.jpg");
+        put("filename", "objectRecognition/" + SOURCE_NAME + "/" + IMAGE_1_DATE + ".jpg");
         put("date", IMAGE_1_DATE);
     }};
     static final String IMAGE_2_DATE = "2019-02-05--02-35-13";
     static final Map<String,String> IMAGE_2 = new LinkedHashMap<String,String>() {{
-        put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-13.jpg");
+        put("filename", "objectRecognition/" + SOURCE_NAME + "/" + IMAGE_2_DATE + ".jpg");
         put("date", IMAGE_2_DATE);
     }};
     static final String IMAGE_3_DATE = "2019-02-05--02-35-16";
     static final Map<String,String> IMAGE_3 = new LinkedHashMap<String,String>() {{
-        put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-16.jpg");
+        put("filename", "objectRecognition/" + SOURCE_NAME + "/" + IMAGE_3_DATE + ".jpg");
         put("date", IMAGE_3_DATE);
     }};
     static final String IMAGE_4_DATE = "2019-02-05--02-35-19";
     static final Map<String,String> IMAGE_4 = new LinkedHashMap<String,String>() {{
-        put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-19.jpg");
+        put("filename", "objectRecognition/" + SOURCE_NAME + "/" + IMAGE_4_DATE + ".jpg");
         put("date", IMAGE_4_DATE);
     }};
     static final String IMAGE_5_DATE = "2019-02-05--02-35-22";
     static final Map<String,String> IMAGE_5 = new LinkedHashMap<String,String>() {{
-        put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-22.jpg");
+        put("filename", "objectRecognition/" + SOURCE_NAME + "/" + IMAGE_5_DATE + ".jpg");
         put("date", IMAGE_5_DATE);
+    }};
+    static final String IMAGE_6_DATE = "2019-02-05--02-35-22(1)";
+    static final Map<String,String> IMAGE_6 = new LinkedHashMap<String,String>() {{
+        put("filename", "objectRecognition/" + SOURCE_NAME + "/" + IMAGE_6_DATE + ".jpg");
+        put("date", IMAGE_6_DATE);
+    }};
+    static final String IMAGE_7_DATE = "2019-02-05--02-35-22(2)";
+    static final Map<String,String> IMAGE_7 = new LinkedHashMap<String,String>() {{
+        put("filename", "objectRecognition/" + SOURCE_NAME + "/" + IMAGE_7_DATE + ".jpg");
+        put("date", IMAGE_7_DATE);
     }};
     
     static final String START_DATE = IMAGE_2.get("date");
@@ -77,10 +87,9 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     
     @BeforeClass
     public static void setup() {
-        testAuthToken="-YyPeih6BkZoQoVa5tUT3cMZ4DXaWs7M6hg26WEdU88=";
-        testVantiqServer="https://dev.vantiq.com";
         core = new NoSendORCore(SOURCE_NAME, testAuthToken, testVantiqServer, MODEL_DIRECTORY);
         core.start(10);
+        core.outputDir = OUTPUT_DIR;
         
         vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
         vantiq.setAccessToken(testAuthToken);
@@ -91,6 +100,8 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         vantiqUploadFiles.add(IMAGE_3.get("filename"));
         vantiqUploadFiles.add(IMAGE_4.get("filename"));
         vantiqUploadFiles.add(IMAGE_5.get("filename"));
+        vantiqUploadFiles.add(IMAGE_6.get("filename"));
+        vantiqUploadFiles.add(IMAGE_7.get("filename"));
     }
     
     @Before
@@ -114,6 +125,12 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         ImageIO.write(testImageBuffer, "jpg", testFile);
         
         testFile = new File(OUTPUT_DIR + File.separator + IMAGE_5.get("date") + ".jpg");
+        ImageIO.write(testImageBuffer, "jpg", testFile);
+        
+        testFile = new File(OUTPUT_DIR + File.separator + IMAGE_6.get("date") + ".jpg");
+        ImageIO.write(testImageBuffer, "jpg", testFile);
+        
+        testFile = new File(OUTPUT_DIR + File.separator + IMAGE_7.get("date") + ".jpg");
         ImageIO.write(testImageBuffer, "jpg", testFile);
     }
     
@@ -152,21 +169,8 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         
-        // Forgetting to include imageDir
+        // Not including imageName or imageDate
         Map<String, Object> request = new LinkedHashMap<>();
-        request.put("imageName", "all");
-        core.uploadLocalImages(request, null);
-                
-        // Checking that images were not uploaded to VANTIQ
-        Thread.sleep(1000);
-        checkNotUploadToVantiq(IMAGE_1.get("filename"));
-        checkNotUploadToVantiq(IMAGE_2.get("filename"));
-        checkNotUploadToVantiq(IMAGE_3.get("filename"));
-        checkNotUploadToVantiq(IMAGE_4.get("filename"));
-        checkNotUploadToVantiq(IMAGE_5.get("filename"));
-        
-        // Using wrong type for imageDir
-        request.put("imageDir", 5);
         core.uploadLocalImages(request, null);
         
         // Checking that images were not uploaded to VANTIQ
@@ -176,19 +180,8 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_3.get("filename"));
         checkNotUploadToVantiq(IMAGE_4.get("filename"));
         checkNotUploadToVantiq(IMAGE_5.get("filename"));
-        
-        // Forgetting to include either imageName or imageDate
-        request.put("imageDir", OUTPUT_DIR);
-        request.remove("imageName");
-        core.uploadLocalImages(request, null);
-        
-        // Checking that images were not uploaded to VANTIQ
-        Thread.sleep(1000);
-        checkNotUploadToVantiq(IMAGE_1.get("filename"));
-        checkNotUploadToVantiq(IMAGE_2.get("filename"));
-        checkNotUploadToVantiq(IMAGE_3.get("filename"));
-        checkNotUploadToVantiq(IMAGE_4.get("filename"));
-        checkNotUploadToVantiq(IMAGE_5.get("filename"));
+        checkNotUploadToVantiq(IMAGE_6.get("filename"));
+        checkNotUploadToVantiq(IMAGE_7.get("filename"));
         
         // Using wrong type for imageName
         request.put("imageName", 5);
@@ -201,6 +194,8 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_3.get("filename"));
         checkNotUploadToVantiq(IMAGE_4.get("filename"));
         checkNotUploadToVantiq(IMAGE_5.get("filename"));
+        checkNotUploadToVantiq(IMAGE_6.get("filename"));
+        checkNotUploadToVantiq(IMAGE_7.get("filename"));
         
         // Using wrong type for imageDate
         request.remove("imageName");
@@ -214,6 +209,8 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_3.get("filename"));
         checkNotUploadToVantiq(IMAGE_4.get("filename"));
         checkNotUploadToVantiq(IMAGE_5.get("filename"));
+        checkNotUploadToVantiq(IMAGE_6.get("filename"));
+        checkNotUploadToVantiq(IMAGE_7.get("filename"));
         
         // Using an imageDate list that is null
         List<String> invalidImageDates = null;
@@ -227,6 +224,8 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_3.get("filename"));
         checkNotUploadToVantiq(IMAGE_4.get("filename"));
         checkNotUploadToVantiq(IMAGE_5.get("filename"));
+        checkNotUploadToVantiq(IMAGE_6.get("filename"));
+        checkNotUploadToVantiq(IMAGE_7.get("filename"));
         
         // Using an imageDate list that has no values
         invalidImageDates = new ArrayList<String>();
@@ -239,6 +238,8 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_3.get("filename"));
         checkNotUploadToVantiq(IMAGE_4.get("filename"));
         checkNotUploadToVantiq(IMAGE_5.get("filename"));
+        checkNotUploadToVantiq(IMAGE_6.get("filename"));
+        checkNotUploadToVantiq(IMAGE_7.get("filename"));
         
         // Using an imageDate list that contains non-dates
         invalidImageDates.add("Not a date");
@@ -253,6 +254,8 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_3.get("filename"));
         checkNotUploadToVantiq(IMAGE_4.get("filename"));
         checkNotUploadToVantiq(IMAGE_5.get("filename"));
+        checkNotUploadToVantiq(IMAGE_6.get("filename"));
+        checkNotUploadToVantiq(IMAGE_7.get("filename"));
         
         // Using an imageDate list with only one date
         invalidImageDates.clear();
@@ -267,6 +270,8 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_3.get("filename"));
         checkNotUploadToVantiq(IMAGE_4.get("filename"));
         checkNotUploadToVantiq(IMAGE_5.get("filename"));
+        checkNotUploadToVantiq(IMAGE_6.get("filename"));
+        checkNotUploadToVantiq(IMAGE_7.get("filename"));
         
         // Using an imageDate list with more than two dates
         invalidImageDates.add(IMAGE_2_DATE);
@@ -281,6 +286,8 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_3.get("filename"));
         checkNotUploadToVantiq(IMAGE_4.get("filename"));
         checkNotUploadToVantiq(IMAGE_5.get("filename"));
+        checkNotUploadToVantiq(IMAGE_6.get("filename"));
+        checkNotUploadToVantiq(IMAGE_7.get("filename"));
     }
     
     @Test
@@ -290,29 +297,12 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         
         File d = new File(OUTPUT_DIR);
         
-        // Forgetting to include imageDir
+        // Not including imageName or imageDate
         Map<String, Object> request = new LinkedHashMap<>();
-        request.put("imageName", "all");
-        core.deleteLocalImages(request, null); 
+        core.deleteLocalImages(request, null);
         
         File[] dList = d.listFiles();
-        assert dList.length == 5;
-        
-        // Using wrong type for imageDir
-        request.put("imageDir", 5);
-        core.deleteLocalImages(request, null);
-        
-        dList = d.listFiles();
-        assert dList.length == 5;
-        
-        
-        // Forgetting to include either imageName or imageDate
-        request.put("imageDir", OUTPUT_DIR);
-        request.remove("imageName");
-        core.deleteLocalImages(request, null);
-        
-        dList = d.listFiles();
-        assert dList.length == 5;
+        assert dList.length == 7;
         
         
         // Using wrong type for imageName
@@ -320,7 +310,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         core.deleteLocalImages(request, null);
         
         dList = d.listFiles();
-        assert dList.length == 5;
+        assert dList.length == 7;
         
         
         // Using wrong type for imageDate
@@ -329,7 +319,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         core.deleteLocalImages(request, null);
         
         dList = d.listFiles();
-        assert dList.length == 5;
+        assert dList.length == 7;
         
         // Using an imageDate list that is null
         List<String> invalidImageDates = null;
@@ -337,14 +327,14 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         core.uploadLocalImages(request, null);
         
         dList = d.listFiles();
-        assert dList.length == 5;
+        assert dList.length == 7;
         
         // Using an imageDate list that has no values
         invalidImageDates = new ArrayList<String>();
         core.uploadLocalImages(request, null);
         
         dList = d.listFiles();
-        assert dList.length == 5;
+        assert dList.length == 7;
         
         // Using an imageDate list that contains non-dates
         invalidImageDates.add("Not a date");
@@ -353,7 +343,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         core.uploadLocalImages(request, null);
         
         dList = d.listFiles();
-        assert dList.length == 5;
+        assert dList.length == 7;
         
         // Using an imageDate list with only one date
         invalidImageDates.clear();
@@ -362,7 +352,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         core.uploadLocalImages(request, null);
         
         dList = d.listFiles();
-        assert dList.length == 5;
+        assert dList.length == 7;
         
         // Using an imageDate list with more than two dates
         invalidImageDates.add(IMAGE_2_DATE);
@@ -371,7 +361,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         core.uploadLocalImages(request, null);
         
         dList = d.listFiles();
-        assert dList.length == 5;
+        assert dList.length == 7;
     }
     
     @Test
@@ -380,7 +370,6 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         
         Map<String, Object> request = new LinkedHashMap<>();
-        request.put("imageDir", OUTPUT_DIR);
         request.put("imageName", "all");
         
         core.uploadLocalImages(request, null);
@@ -391,7 +380,9 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         checkUploadToVantiq(IMAGE_2.get("filename"));
         checkUploadToVantiq(IMAGE_3.get("filename"));
         checkUploadToVantiq(IMAGE_4.get("filename"));
-        checkUploadToVantiq(IMAGE_5.get("filename"));         
+        checkUploadToVantiq(IMAGE_5.get("filename")); 
+        checkUploadToVantiq(IMAGE_6.get("filename"));
+        checkUploadToVantiq(IMAGE_7.get("filename"));
     }
     
     @Test
@@ -400,7 +391,6 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         
         Map<String, Object> request = new LinkedHashMap<>();
-        request.put("imageDir", OUTPUT_DIR);
         request.put("imageName", START_DATE);
         
         core.uploadLocalImages(request, null);
@@ -413,7 +403,9 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_1.get("filename"));
         checkNotUploadToVantiq(IMAGE_3.get("filename"));
         checkNotUploadToVantiq(IMAGE_4.get("filename"));
-        checkNotUploadToVantiq(IMAGE_5.get("filename")); 
+        checkNotUploadToVantiq(IMAGE_5.get("filename"));
+        checkNotUploadToVantiq(IMAGE_6.get("filename"));
+        checkNotUploadToVantiq(IMAGE_7.get("filename"));
         
     }
     
@@ -426,7 +418,6 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         List<String> imageDate = new ArrayList<String>();
         imageDate.add("-");
         imageDate.add("-");
-        request.put("imageDir", OUTPUT_DIR);
         request.put("imageDate", imageDate);
         
         
@@ -438,7 +429,9 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         checkUploadToVantiq(IMAGE_2.get("filename"));
         checkUploadToVantiq(IMAGE_3.get("filename"));
         checkUploadToVantiq(IMAGE_4.get("filename"));
-        checkUploadToVantiq(IMAGE_5.get("filename"));   
+        checkUploadToVantiq(IMAGE_5.get("filename"));
+        checkUploadToVantiq(IMAGE_6.get("filename"));
+        checkUploadToVantiq(IMAGE_7.get("filename"));
     }
     
     @Test
@@ -450,7 +443,6 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         List<String> imageDate = new ArrayList<String>();
         imageDate.add(START_DATE);
         imageDate.add(START_DATE);
-        request.put("imageDir", OUTPUT_DIR);
         request.put("imageDate", imageDate);
         
         core.uploadLocalImages(request, null);
@@ -464,6 +456,8 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_3.get("filename"));
         checkNotUploadToVantiq(IMAGE_4.get("filename"));
         checkNotUploadToVantiq(IMAGE_5.get("filename"));
+        checkNotUploadToVantiq(IMAGE_6.get("filename"));
+        checkNotUploadToVantiq(IMAGE_7.get("filename"));
     }
     
     @Test
@@ -475,7 +469,6 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         List<String> imageDate = new ArrayList<String>();
         imageDate.add("-");
         imageDate.add(START_DATE);
-        request.put("imageDir", OUTPUT_DIR);
         request.put("imageDate", imageDate);
         
         core.uploadLocalImages(request, null);
@@ -489,6 +482,8 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_3.get("filename"));
         checkNotUploadToVantiq(IMAGE_4.get("filename"));
         checkNotUploadToVantiq(IMAGE_5.get("filename"));
+        checkNotUploadToVantiq(IMAGE_6.get("filename"));
+        checkNotUploadToVantiq(IMAGE_7.get("filename"));
     }
     
     @Test
@@ -500,7 +495,6 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         List<String> imageDate = new ArrayList<String>();
         imageDate.add(END_DATE);
         imageDate.add("-");
-        request.put("imageDir", OUTPUT_DIR);
         request.put("imageDate", imageDate);
         
         core.uploadLocalImages(request, null);
@@ -509,6 +503,8 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         Thread.sleep(1000);
         checkUploadToVantiq(IMAGE_4.get("filename"));
         checkUploadToVantiq(IMAGE_5.get("filename"));
+        checkUploadToVantiq(IMAGE_6.get("filename"));
+        checkUploadToVantiq(IMAGE_7.get("filename"));
         
         // Checking that none of the other images were uploaded to VANTIQ
         checkNotUploadToVantiq(IMAGE_1.get("filename"));
@@ -525,7 +521,6 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         List<String> imageDate = new ArrayList<String>();
         imageDate.add(START_DATE);
         imageDate.add(END_DATE);
-        request.put("imageDir", OUTPUT_DIR);
         request.put("imageDate", imageDate);
         
         core.uploadLocalImages(request, null);
@@ -539,6 +534,8 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         // Checking that none of the other images were uploaded to VANTIQ
         checkNotUploadToVantiq(IMAGE_1.get("filename"));
         checkNotUploadToVantiq(IMAGE_5.get("filename"));
+        checkNotUploadToVantiq(IMAGE_6.get("filename"));
+        checkNotUploadToVantiq(IMAGE_7.get("filename"));
     }
     
     @Test
@@ -551,7 +548,6 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         
         savedResolution.put("longEdge", RESIZED_IMAGE_WIDTH);
         
-        request.put("imageDir", OUTPUT_DIR);
         request.put("imageName", START_DATE);
         request.put("savedResolution", savedResolution);
         
@@ -589,7 +585,6 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     @Test
     public void testImageNameDeleteAll() {
         Map<String, Object> request = new LinkedHashMap<>();
-        request.put("imageDir", OUTPUT_DIR);
         request.put("imageName", "all");
         
         core.deleteLocalImages(request, null);
@@ -603,7 +598,6 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     @Test
     public void testImageNameDeleteOne() {
         Map<String, Object> request = new LinkedHashMap<>();
-        request.put("imageDir", OUTPUT_DIR);
         request.put("imageName", START_DATE);
         
         core.deleteLocalImages(request, null);
@@ -611,7 +605,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         File d = new File(OUTPUT_DIR);
         File[] dList = d.listFiles();
         
-        assert dList.length == 4;
+        assert dList.length == 6;
         
         for (File imageFile: dList) {
             if (imageFile.getName().equals(IMAGE_2.get("filename"))) {
@@ -626,7 +620,6 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         List<String> imageDate = new ArrayList<String>();
         imageDate.add("-");
         imageDate.add("-");
-        request.put("imageDir", OUTPUT_DIR);
         request.put("imageDate", imageDate);
         
         core.deleteLocalImages(request, null);
@@ -643,7 +636,6 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         List<String> imageDate = new ArrayList<String>();
         imageDate.add(START_DATE);
         imageDate.add(START_DATE);
-        request.put("imageDir", OUTPUT_DIR);
         request.put("imageDate", imageDate);
         
         core.deleteLocalImages(request, null);
@@ -651,7 +643,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         File d = new File(OUTPUT_DIR);
         File[] dList = d.listFiles();
         
-        assert dList.length == 4;
+        assert dList.length == 6;
         
         for (File imageFile: dList) {
             if (imageFile.getName().equals(IMAGE_2.get("filename"))) {
@@ -666,7 +658,6 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         List<String> imageDate = new ArrayList<String>();
         imageDate.add("-");
         imageDate.add(START_DATE);
-        request.put("imageDir", OUTPUT_DIR);
         request.put("imageDate", imageDate);
         
         core.deleteLocalImages(request, null);
@@ -674,7 +665,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         File d = new File(OUTPUT_DIR);
         File[] dList = d.listFiles();
         
-        assert dList.length == 3;
+        assert dList.length == 5;
         
         for (File imageFile: dList) {
             if (imageFile.getName().equals(IMAGE_1.get("filename")) || imageFile.getName().equals(IMAGE_2.get("filename"))) {
@@ -689,7 +680,6 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         List<String> imageDate = new ArrayList<String>();
         imageDate.add(START_DATE);
         imageDate.add("-");
-        request.put("imageDir", OUTPUT_DIR);
         request.put("imageDate", imageDate);
         
         core.deleteLocalImages(request, null);
@@ -707,7 +697,6 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         List<String> dateRange = new ArrayList<String>();
         dateRange.add(START_DATE);
         dateRange.add(END_DATE);
-        request.put("imageDir", OUTPUT_DIR);
         request.put("imageDate", dateRange);
         
         core.deleteLocalImages(request, null);
@@ -715,10 +704,11 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         File d = new File(OUTPUT_DIR);
         File[] dList = d.listFiles();
         
-        assert dList.length == 2;
+        assert dList.length == 4;
         
         for (File imageFile: dList) {
-            if (!imageFile.getName().equals(IMAGE_1.get("date") + ".jpg") && !imageFile.getName().equals(IMAGE_5.get("date") + ".jpg")) {
+            if (!imageFile.getName().equals(IMAGE_1.get("date") + ".jpg") && !imageFile.getName().equals(IMAGE_5.get("date") + ".jpg")
+                    && !imageFile.getName().equals(IMAGE_6.get("date") + ".jpg") && !imageFile.getName().equals(IMAGE_7.get("date") + ".jpg")) {
                 fail("Images should have been deleted locally.");
             }
         }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
@@ -44,23 +44,23 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     
     static final Map<String,String> IMAGE_1 = new LinkedHashMap<String,String>() {{
         put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-10.jpg");
-        put("date", "2019-02-05--02-35-10.jpg");
+        put("date", "2019-02-05--02-35-10");
     }};
     static final Map<String,String> IMAGE_2 = new LinkedHashMap<String,String>() {{
         put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-13.jpg");
-        put("date", "2019-02-05--02-35-13.jpg");
+        put("date", "2019-02-05--02-35-13");
     }};
     static final Map<String,String> IMAGE_3 = new LinkedHashMap<String,String>() {{
         put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-16.jpg");
-        put("date", "2019-02-05--02-35-16.jpg");
+        put("date", "2019-02-05--02-35-16");
     }};
     static final Map<String,String> IMAGE_4 = new LinkedHashMap<String,String>() {{
         put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-19.jpg");
-        put("date", "2019-02-05--02-35-19.jpg");
+        put("date", "2019-02-05--02-35-19");
     }};
     static final Map<String,String> IMAGE_5 = new LinkedHashMap<String,String>() {{
         put("filename", "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-22.jpg");
-        put("date", "2019-02-05--02-35-22.jpg");
+        put("date", "2019-02-05--02-35-22");
     }};
     
     static final String START_DATE = IMAGE_2.get("date");
@@ -96,19 +96,19 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         InputStream in = new ByteArrayInputStream(testImageBytes);
         BufferedImage testImageBuffer = ImageIO.read(in);
         
-        File testFile = new File(OUTPUT_DIR + File.separator + "2019-02-05--02-35-10.jpg");
+        File testFile = new File(OUTPUT_DIR + File.separator + IMAGE_1.get("date") + ".jpg");
         ImageIO.write(testImageBuffer, "jpg", testFile);
         
-        testFile = new File(OUTPUT_DIR + File.separator + "2019-02-05--02-35-13.jpg");
+        testFile = new File(OUTPUT_DIR + File.separator + IMAGE_2.get("date") + ".jpg");
         ImageIO.write(testImageBuffer, "jpg", testFile);
         
-        testFile = new File(OUTPUT_DIR + File.separator + "2019-02-05--02-35-16.jpg");
+        testFile = new File(OUTPUT_DIR + File.separator + IMAGE_3.get("date") + ".jpg");
         ImageIO.write(testImageBuffer, "jpg", testFile);
         
-        testFile = new File(OUTPUT_DIR + File.separator + "2019-02-05--02-35-19.jpg");
+        testFile = new File(OUTPUT_DIR + File.separator + IMAGE_4.get("date") + ".jpg");
         ImageIO.write(testImageBuffer, "jpg", testFile);
         
-        testFile = new File(OUTPUT_DIR + File.separator + "2019-02-05--02-35-22.jpg");
+        testFile = new File(OUTPUT_DIR + File.separator + IMAGE_5.get("date") + ".jpg");
         ImageIO.write(testImageBuffer, "jpg", testFile);
     }
     
@@ -500,7 +500,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         assert dList.length == 4;
         
         for (File imageFile: dList) {
-            if (imageFile.getName().equals(START_DATE + ".jpg")) {
+            if (imageFile.getName().equals(IMAGE_2.get("filename"))) {
                 fail("Image should have been deleted locally.");
             }
         }
@@ -509,8 +509,11 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     @Test
     public void testImageDateDeleteAll() {
         Map<String, Object> request = new LinkedHashMap<>();
+        List<String> imageDate = new ArrayList<String>();
+        imageDate.add("-");
+        imageDate.add("-");
         request.put("imageDir", OUTPUT_DIR);
-        request.put("imageDate", "all");
+        request.put("imageDate", imageDate);
         
         core.deleteLocalImages(request, null);
         
@@ -523,8 +526,11 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     @Test
     public void testImageDateDeleteOne() {
         Map<String, Object> request = new LinkedHashMap<>();
+        List<String> imageDate = new ArrayList<String>();
+        imageDate.add(START_DATE);
+        imageDate.add(START_DATE);
         request.put("imageDir", OUTPUT_DIR);
-        request.put("imageDate", START_DATE);
+        request.put("imageDate", imageDate);
         
         core.deleteLocalImages(request, null);
         
@@ -534,7 +540,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         assert dList.length == 4;
         
         for (File imageFile: dList) {
-            if (imageFile.getName().equals(START_DATE + ".jpg")) {
+            if (imageFile.getName().equals(IMAGE_2.get("filename"))) {
                 fail("Image should have been deleted locally.");
             }
         }
@@ -543,9 +549,11 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     @Test
     public void testImageDateDeleteBefore() {
         Map<String, Object> request = new LinkedHashMap<>();
+        List<String> imageDate = new ArrayList<String>();
+        imageDate.add("-");
+        imageDate.add(START_DATE);
         request.put("imageDir", OUTPUT_DIR);
-        request.put("imageDate", START_DATE);
-        request.put("dateRange", "before");
+        request.put("imageDate", imageDate);
         
         core.deleteLocalImages(request, null);
         
@@ -555,7 +563,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         assert dList.length == 3;
         
         for (File imageFile: dList) {
-            if (imageFile.getName().equals(START_DATE + ".jpg") || imageFile.getName().equals("2019-02-05--02-35-10.jpg")) {
+            if (imageFile.getName().equals(IMAGE_1.get("filename")) || imageFile.getName().equals(IMAGE_2.get("filename"))) {
                 fail("Image should have been deleted locally.");
             }
         }
@@ -564,9 +572,11 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     @Test
     public void testImageDateDeleteAfter() {
         Map<String, Object> request = new LinkedHashMap<>();
+        List<String> imageDate = new ArrayList<String>();
+        imageDate.add(START_DATE);
+        imageDate.add("-");
         request.put("imageDir", OUTPUT_DIR);
-        request.put("imageDate", START_DATE);
-        request.put("dateRange", "after");
+        request.put("imageDate", imageDate);
         
         core.deleteLocalImages(request, null);
         
@@ -574,7 +584,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         File[] dList = d.listFiles();
         
         assert dList.length == 1;
-        assert dList[0].getName().equals("2019-02-05--02-35-10.jpg");
+        assert dList[0].getName().equals(IMAGE_1.get("date") + ".jpg");
     }
     
     @Test
@@ -594,7 +604,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         assert dList.length == 2;
         
         for (File imageFile: dList) {
-            if (!imageFile.getName().equals("2019-02-05--02-35-10.jpg") && !imageFile.getName().equals("2019-02-05--02-35-22.jpg")) {
+            if (!imageFile.getName().equals(IMAGE_1.get("date") + ".jpg") && !imageFile.getName().equals(IMAGE_5.get("date") + ".jpg")) {
                 fail("Images should have been deleted locally.");
             }
         }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
@@ -365,27 +365,6 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     }
     
     @Test
-    public void testImageNameUploadAll() throws InterruptedException {
-        // Only run test with intended vantiq availability
-        assumeTrue(testAuthToken != null && testVantiqServer != null);
-        
-        Map<String, Object> request = new LinkedHashMap<>();
-        request.put("imageName", "all");
-        
-        core.uploadLocalImages(request, null);
-                
-        // Checking that all images were uploaded to VANTIQ
-        Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_1.get("filename"));
-        checkUploadToVantiq(IMAGE_2.get("filename"));
-        checkUploadToVantiq(IMAGE_3.get("filename"));
-        checkUploadToVantiq(IMAGE_4.get("filename"));
-        checkUploadToVantiq(IMAGE_5.get("filename")); 
-        checkUploadToVantiq(IMAGE_6.get("filename"));
-        checkUploadToVantiq(IMAGE_7.get("filename"));
-    }
-    
-    @Test
     public void testImageNameUploadOne() throws InterruptedException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
@@ -581,19 +560,6 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         assert resizedImage.getWidth() == RESIZED_IMAGE_WIDTH;
         assert resizedImage.getHeight() == RESIZED_IMAGE_HEIGHT;
     }
-    
-    @Test
-    public void testImageNameDeleteAll() {
-        Map<String, Object> request = new LinkedHashMap<>();
-        request.put("imageName", "all");
-        
-        core.deleteLocalImages(request, null);
-        
-        File d = new File(OUTPUT_DIR);
-        File[] dList = d.listFiles();
-        
-        assert dList.length == 0;
-    }   
     
     @Test
     public void testImageNameDeleteOne() {

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
@@ -1,0 +1,612 @@
+package io.vantiq.extsrc.objectRecognition.neuralNet;
+
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.imageio.ImageIO;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import io.vantiq.client.BaseResponseHandler;
+import io.vantiq.client.Vantiq;
+import io.vantiq.client.VantiqError;
+import io.vantiq.client.VantiqResponse;
+import io.vantiq.extsrc.objectRecognition.NoSendORCore;
+import okhttp3.Response;
+import okio.BufferedSource;
+
+public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
+    static NoSendORCore core;
+    
+    static Vantiq vantiq;
+    static VantiqResponse vantiqResponse;
+    static List<String> vantiqUploadFiles = new ArrayList<>();
+    
+    static final String OUTPUT_DIR = System.getProperty("buildDir") + "/resources/out";
+    static final String NOT_FOUND_CODE = "io.vantiq.resource.not.found";
+    
+    static final String IMAGE_NAME_1 = "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-10.jpg";
+    static final String IMAGE_NAME_2 = "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-13.jpg";
+    static final String IMAGE_NAME_3 = "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-16.jpg";
+    static final String IMAGE_NAME_4 = "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-19.jpg";
+    static final String IMAGE_NAME_5 = "objectRecognition/" + SOURCE_NAME + "/2019-02-05--02-35-22.jpg";
+    
+    static final String START_DATE = "2019-02-05--02-35-13";
+    static final String END_DATE = "2019-02-05--02-35-19";
+    
+    static final int RESIZED_IMAGE_WIDTH = 100;
+    static final int RESIZED_IMAGE_HEIGHT = 75;
+    
+    
+    @BeforeClass
+    public static void setup() {        
+        core = new NoSendORCore(SOURCE_NAME, testAuthToken, testVantiqServer, MODEL_DIRECTORY);
+        core.start(10);
+        
+        vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
+        vantiq.setAccessToken(testAuthToken);
+        
+        // Add files to be deleted from VANTIQ later
+        vantiqUploadFiles.add(IMAGE_NAME_1);
+        vantiqUploadFiles.add(IMAGE_NAME_2);
+        vantiqUploadFiles.add(IMAGE_NAME_3);
+        vantiqUploadFiles.add(IMAGE_NAME_4);
+        vantiqUploadFiles.add(IMAGE_NAME_5);
+    }
+    
+    @Before
+    public void addLocalTestImages() throws IOException {
+        new File(OUTPUT_DIR).mkdirs();
+        
+        byte[] testImageBytes = getTestImage();
+        InputStream in = new ByteArrayInputStream(testImageBytes);
+        BufferedImage testImageBuffer = ImageIO.read(in);
+        
+        File testFile = new File(OUTPUT_DIR + File.separator + "2019-02-05--02-35-10.jpg");
+        ImageIO.write(testImageBuffer, "jpg", testFile);
+        
+        testFile = new File(OUTPUT_DIR + File.separator + "2019-02-05--02-35-13.jpg");
+        ImageIO.write(testImageBuffer, "jpg", testFile);
+        
+        testFile = new File(OUTPUT_DIR + File.separator + "2019-02-05--02-35-16.jpg");
+        ImageIO.write(testImageBuffer, "jpg", testFile);
+        
+        testFile = new File(OUTPUT_DIR + File.separator + "2019-02-05--02-35-19.jpg");
+        ImageIO.write(testImageBuffer, "jpg", testFile);
+        
+        testFile = new File(OUTPUT_DIR + File.separator + "2019-02-05--02-35-22.jpg");
+        ImageIO.write(testImageBuffer, "jpg", testFile);
+    }
+    
+    @AfterClass
+    public static void tearDown() {
+        core.stop();
+    }
+    
+    @After
+    public void deleteFromVantiq() throws InterruptedException {
+        for (int i = 0; i < vantiqUploadFiles.size(); i++) {
+            Thread.sleep(1000);
+            vantiq.deleteOne("system.documents", vantiqUploadFiles.get(i), new BaseResponseHandler() {
+
+                @Override
+                public void onSuccess(Object body, Response response) {
+                    super.onSuccess(body, response);
+                }
+
+                @Override
+                public void onError(List<VantiqError> errors, Response response) {
+                    super.onError(errors, response);
+                }
+
+            });
+        }
+        
+        File d = new File(OUTPUT_DIR);
+        if (d.exists()) {
+            deleteDirectory(OUTPUT_DIR);
+        }
+    }
+    
+    @Test
+    public void testInvalidImageUploadParameters() throws InterruptedException {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+        
+        // Forgetting to include imageDir
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("imageName", "all");
+        core.uploadLocalImages(request, null);
+                
+        // Checking that all images were uploaded to VANTIQ
+        Thread.sleep(1000);
+        checkNotUploadToVantiq(IMAGE_NAME_1);
+        checkNotUploadToVantiq(IMAGE_NAME_2);
+        checkNotUploadToVantiq(IMAGE_NAME_3);
+        checkNotUploadToVantiq(IMAGE_NAME_4);
+        checkNotUploadToVantiq(IMAGE_NAME_5);  
+        
+        // Using wrong type for imageDir
+        request.put("imageDir", 5);
+        core.uploadLocalImages(request, null);
+        
+        // Checking that all images were uploaded to VANTIQ
+        Thread.sleep(1000);
+        checkNotUploadToVantiq(IMAGE_NAME_1);
+        checkNotUploadToVantiq(IMAGE_NAME_2);
+        checkNotUploadToVantiq(IMAGE_NAME_3);
+        checkNotUploadToVantiq(IMAGE_NAME_4);
+        checkNotUploadToVantiq(IMAGE_NAME_5);
+        
+        // Forgetting to include either imageName or imageDate
+        request.put("imageDir", OUTPUT_DIR);
+        request.remove("imageName");
+        core.uploadLocalImages(request, null);
+        
+        // Checking that all images were uploaded to VANTIQ
+        Thread.sleep(1000);
+        checkNotUploadToVantiq(IMAGE_NAME_1);
+        checkNotUploadToVantiq(IMAGE_NAME_2);
+        checkNotUploadToVantiq(IMAGE_NAME_3);
+        checkNotUploadToVantiq(IMAGE_NAME_4);
+        checkNotUploadToVantiq(IMAGE_NAME_5);
+        
+        // Using wrong type for imageName
+        request.put("imageName", 5);
+        core.uploadLocalImages(request, null);
+        
+        // Checking that all images were uploaded to VANTIQ
+        Thread.sleep(1000);
+        checkNotUploadToVantiq(IMAGE_NAME_1);
+        checkNotUploadToVantiq(IMAGE_NAME_2);
+        checkNotUploadToVantiq(IMAGE_NAME_3);
+        checkNotUploadToVantiq(IMAGE_NAME_4);
+        checkNotUploadToVantiq(IMAGE_NAME_5);
+        
+        // Using wrong type for imageDate
+        request.remove("imageName");
+        request.put("imageDate", 5);
+        core.uploadLocalImages(request, null);
+        
+        // Checking that all images were uploaded to VANTIQ
+        Thread.sleep(1000);
+        checkNotUploadToVantiq(IMAGE_NAME_1);
+        checkNotUploadToVantiq(IMAGE_NAME_2);
+        checkNotUploadToVantiq(IMAGE_NAME_3);
+        checkNotUploadToVantiq(IMAGE_NAME_4);
+        checkNotUploadToVantiq(IMAGE_NAME_5);
+    }
+    
+    @Test
+    public void testInvalidImageDeleteParameters() {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+        
+        File d = new File(OUTPUT_DIR);
+        
+        // Forgetting to include imageDir
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("imageName", "all");
+        core.deleteLocalImages(request, null); 
+        
+        File[] dList = d.listFiles();
+        assert dList.length == 5;
+        
+        // Using wrong type for imageDir
+        request.put("imageDir", 5);
+        core.deleteLocalImages(request, null);
+        
+        dList = d.listFiles();
+        assert dList.length == 5;
+        
+        
+        // Forgetting to include either imageName or imageDate
+        request.put("imageDir", OUTPUT_DIR);
+        request.remove("imageName");
+        core.deleteLocalImages(request, null);
+        
+        dList = d.listFiles();
+        assert dList.length == 5;
+        
+        
+        // Using wrong type for imageName
+        request.put("imageName", 5);
+        core.deleteLocalImages(request, null);
+        
+        dList = d.listFiles();
+        assert dList.length == 5;
+        
+        
+        // Using wrong type for imageDate
+        request.remove("imageName");
+        request.put("imageDate", 5);
+        core.deleteLocalImages(request, null);
+        
+        dList = d.listFiles();
+        assert dList.length == 5;
+    }
+    
+    @Test
+    public void testImageNameUploadAll() throws InterruptedException {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+        
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("imageDir", OUTPUT_DIR);
+        request.put("imageName", "all");
+        
+        core.uploadLocalImages(request, null);
+                
+        // Checking that all images were uploaded to VANTIQ
+        Thread.sleep(1000);
+        checkUploadToVantiq(IMAGE_NAME_1);
+        checkUploadToVantiq(IMAGE_NAME_2);
+        checkUploadToVantiq(IMAGE_NAME_3);
+        checkUploadToVantiq(IMAGE_NAME_4);
+        checkUploadToVantiq(IMAGE_NAME_5);        
+    }
+    
+    @Test
+    public void testImageNameUploadOne() throws InterruptedException {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+        
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("imageDir", OUTPUT_DIR);
+        request.put("imageName", START_DATE);
+        
+        core.uploadLocalImages(request, null);
+                
+        // Checking that all images were uploaded to VANTIQ
+        Thread.sleep(1000);
+        checkUploadToVantiq(IMAGE_NAME_2);
+        
+        // Checking that none of the other images were uploaded to VANTIQ
+        checkNotUploadToVantiq(IMAGE_NAME_1);
+        checkNotUploadToVantiq(IMAGE_NAME_3);
+        checkNotUploadToVantiq(IMAGE_NAME_4);
+        checkNotUploadToVantiq(IMAGE_NAME_5);
+        
+    }
+    
+    @Test
+    public void testImageDateUploadAll() throws InterruptedException {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+        
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("imageDir", OUTPUT_DIR);
+        request.put("imageDate", "all");
+        
+        core.uploadLocalImages(request, null);
+                
+        // Checking that all images were uploaded to VANTIQ
+        Thread.sleep(1000);
+        checkUploadToVantiq(IMAGE_NAME_1);
+        checkUploadToVantiq(IMAGE_NAME_2);
+        checkUploadToVantiq(IMAGE_NAME_3);
+        checkUploadToVantiq(IMAGE_NAME_4);
+        checkUploadToVantiq(IMAGE_NAME_5);  
+    }
+    
+    @Test
+    public void testImageDateUploadOne() throws InterruptedException {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+        
+        Map<String, Object> request = new LinkedHashMap<>();
+        // Specifying the dateRange as "none"
+        request.put("imageDir", OUTPUT_DIR);
+        request.put("imageDate", START_DATE);
+        request.put("dateRange", "none");
+        
+        core.uploadLocalImages(request, null);
+                
+        // Checking that all images were uploaded to VANTIQ
+        Thread.sleep(1000);
+        checkUploadToVantiq(IMAGE_NAME_2);
+        
+        // Checking that none of the other images were uploaded to VANTIQ
+        checkNotUploadToVantiq(IMAGE_NAME_1);
+        checkNotUploadToVantiq(IMAGE_NAME_3);
+        checkNotUploadToVantiq(IMAGE_NAME_4);
+        checkNotUploadToVantiq(IMAGE_NAME_5);
+        
+        // Removing the dateRange value, should default to the same behavior
+        request.remove("dateRange");
+        
+        core.uploadLocalImages(request, null);
+        
+        // Checking that all images were uploaded to VANTIQ
+        Thread.sleep(1000);
+        checkUploadToVantiq(IMAGE_NAME_2);
+        
+        // Checking that none of the other images were uploaded to VANTIQ
+        checkNotUploadToVantiq(IMAGE_NAME_1);
+        checkNotUploadToVantiq(IMAGE_NAME_3);
+        checkNotUploadToVantiq(IMAGE_NAME_4);
+        checkNotUploadToVantiq(IMAGE_NAME_5);
+    }
+    
+    @Test
+    public void testImageDateUploadBefore() throws InterruptedException {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+        
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("imageDir", OUTPUT_DIR);
+        request.put("imageDate", START_DATE);
+        request.put("dateRange", "before");
+        
+        core.uploadLocalImages(request, null);
+                
+        // Checking that all images were uploaded to VANTIQ
+        Thread.sleep(1000);
+        checkUploadToVantiq(IMAGE_NAME_1);
+        checkUploadToVantiq(IMAGE_NAME_2);
+        
+        // Checking that none of the other images were uploaded to VANTIQ
+        checkNotUploadToVantiq(IMAGE_NAME_3);
+        checkNotUploadToVantiq(IMAGE_NAME_4);
+        checkNotUploadToVantiq(IMAGE_NAME_5);
+    }
+    
+    @Test
+    public void testImageDateUploadAfter() throws InterruptedException {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+        
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("imageDir", OUTPUT_DIR);
+        request.put("imageDate", END_DATE);
+        request.put("dateRange", "after");
+        
+        core.uploadLocalImages(request, null);
+                
+        // Checking that all images were uploaded to VANTIQ
+        Thread.sleep(1000);
+        checkUploadToVantiq(IMAGE_NAME_4);
+        checkUploadToVantiq(IMAGE_NAME_5);
+        
+        // Checking that none of the other images were uploaded to VANTIQ
+        checkNotUploadToVantiq(IMAGE_NAME_1);
+        checkNotUploadToVantiq(IMAGE_NAME_2);
+        checkNotUploadToVantiq(IMAGE_NAME_3);
+    }
+    
+    @Test
+    public void testImageDateUploadRange() throws InterruptedException {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+        
+        Map<String, Object> request = new LinkedHashMap<>();
+        List<String> dateRange = new ArrayList<String>();
+        dateRange.add(START_DATE);
+        dateRange.add(END_DATE);
+        request.put("imageDir", OUTPUT_DIR);
+        request.put("imageDate", dateRange);
+        
+        core.uploadLocalImages(request, null);
+                
+        // Checking that all images were uploaded to VANTIQ
+        Thread.sleep(1000);
+        checkUploadToVantiq(IMAGE_NAME_2);
+        checkUploadToVantiq(IMAGE_NAME_3);
+        checkUploadToVantiq(IMAGE_NAME_4);
+        
+        // Checking that none of the other images were uploaded to VANTIQ
+        checkNotUploadToVantiq(IMAGE_NAME_1);
+        checkNotUploadToVantiq(IMAGE_NAME_5);
+    }
+    
+    @Test
+    public void testImageUploadChangeResolution() throws InterruptedException, IOException {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+        
+        Map<String, Object> request = new LinkedHashMap<>();
+        Map<String, Object> savedResolution = new LinkedHashMap<>();
+        
+        savedResolution.put("longEdge", RESIZED_IMAGE_WIDTH);
+        
+        request.put("imageDir", OUTPUT_DIR);
+        request.put("imageName", START_DATE);
+        request.put("savedResolution", savedResolution);
+        
+        core.uploadLocalImages(request, null);
+        
+        // Checking that image was saved to VANTIQ
+        Thread.sleep(1000);
+        vantiqResponse = vantiq.selectOne("system.documents", IMAGE_NAME_2);
+        if (vantiqResponse.hasErrors()) {
+            List<VantiqError> errors = vantiqResponse.getErrors();
+            for (int i = 0; i < errors.size(); i++) {
+                if (errors.get(i).getCode().equals(NOT_FOUND_CODE)) {
+                    fail();
+                }
+            }
+        }
+        
+        // Get the path to the saved image in VANTIQ
+        JsonObject responseObj = (JsonObject) vantiqResponse.getBody();
+        JsonElement pathJSON = responseObj.get("content");
+        String imagePath = pathJSON.getAsString();
+        
+        // Download image so we can confirm dimensions
+        vantiqResponse = vantiq.download(imagePath);
+        BufferedSource source = (BufferedSource) vantiqResponse.getBody();
+        byte[] imageBytes = source.readByteArray();
+        InputStream imageStream = new ByteArrayInputStream(imageBytes);
+        BufferedImage resizedImage = ImageIO.read(imageStream);
+        
+        
+        assert resizedImage.getWidth() == RESIZED_IMAGE_WIDTH;
+        assert resizedImage.getHeight() == RESIZED_IMAGE_HEIGHT;
+    }
+    
+    @Test
+    public void testImageNameDeleteAll() {
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("imageDir", OUTPUT_DIR);
+        request.put("imageName", "all");
+        
+        core.deleteLocalImages(request, null);
+        
+        File d = new File(OUTPUT_DIR);
+        File[] dList = d.listFiles();
+        
+        assert dList.length == 0;
+    }   
+    
+    @Test
+    public void testImageNameDeleteOne() {
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("imageDir", OUTPUT_DIR);
+        request.put("imageName", START_DATE);
+        
+        core.deleteLocalImages(request, null);
+        
+        File d = new File(OUTPUT_DIR);
+        File[] dList = d.listFiles();
+        
+        assert dList.length == 4;
+        
+        for (File imageFile: dList) {
+            if (imageFile.getName().equals(START_DATE + ".jpg")) {
+                fail("Image should have been deleted locally.");
+            }
+        }
+    }
+    
+    @Test
+    public void testImageDateDeleteAll() {
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("imageDir", OUTPUT_DIR);
+        request.put("imageDate", "all");
+        
+        core.deleteLocalImages(request, null);
+        
+        File d = new File(OUTPUT_DIR);
+        File[] dList = d.listFiles();
+        
+        assert dList.length == 0;
+    }
+    
+    @Test
+    public void testImageDateDeleteOne() {
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("imageDir", OUTPUT_DIR);
+        request.put("imageDate", START_DATE);
+        
+        core.deleteLocalImages(request, null);
+        
+        File d = new File(OUTPUT_DIR);
+        File[] dList = d.listFiles();
+        
+        assert dList.length == 4;
+        
+        for (File imageFile: dList) {
+            if (imageFile.getName().equals(START_DATE + ".jpg")) {
+                fail("Image should have been deleted locally.");
+            }
+        }
+    }
+    
+    @Test
+    public void testImageDateDeleteBefore() {
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("imageDir", OUTPUT_DIR);
+        request.put("imageDate", START_DATE);
+        request.put("dateRange", "before");
+        
+        core.deleteLocalImages(request, null);
+        
+        File d = new File(OUTPUT_DIR);
+        File[] dList = d.listFiles();
+        
+        assert dList.length == 3;
+        
+        for (File imageFile: dList) {
+            if (imageFile.getName().equals(START_DATE + ".jpg") || imageFile.getName().equals("2019-02-05--02-35-10.jpg")) {
+                fail("Image should have been deleted locally.");
+            }
+        }
+    }
+    
+    @Test
+    public void testImageDateDeleteAfter() {
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("imageDir", OUTPUT_DIR);
+        request.put("imageDate", START_DATE);
+        request.put("dateRange", "after");
+        
+        core.deleteLocalImages(request, null);
+        
+        File d = new File(OUTPUT_DIR);
+        File[] dList = d.listFiles();
+        
+        assert dList.length == 1;
+        assert dList[0].getName().equals("2019-02-05--02-35-10.jpg");
+    }
+    
+    @Test
+    public void testImageDateDeleteRange() {
+        Map<String, Object> request = new LinkedHashMap<>();
+        List<String> dateRange = new ArrayList<String>();
+        dateRange.add(START_DATE);
+        dateRange.add(END_DATE);
+        request.put("imageDir", OUTPUT_DIR);
+        request.put("imageDate", dateRange);
+        
+        core.deleteLocalImages(request, null);
+        
+        File d = new File(OUTPUT_DIR);
+        File[] dList = d.listFiles();
+        
+        assert dList.length == 2;
+        
+        for (File imageFile: dList) {
+            if (!imageFile.getName().equals("2019-02-05--02-35-10.jpg") && !imageFile.getName().equals("2019-02-05--02-35-22.jpg")) {
+                fail("Images should have been deleted locally.");
+            }
+        }
+    }
+    
+    // ================================================= Helper functions =================================================
+    
+    public void checkUploadToVantiq(String name) {
+        vantiqResponse = vantiq.selectOne("system.documents", name);
+        if (vantiqResponse.hasErrors()) {
+            List<VantiqError> errors = vantiqResponse.getErrors();
+            for (int i = 0; i < errors.size(); i++) {
+                if (errors.get(i).getCode().equals(NOT_FOUND_CODE)) {
+                    fail("Image should have been uploaded to VANTIQ");
+                }
+            }
+        }
+    }
+    
+    public void checkNotUploadToVantiq(String name) {
+        vantiqResponse = vantiq.selectOne("system.documents", name);
+        if (vantiqResponse.isSuccess()) {
+            fail("Image should not have been uploaded to VANTIQ");
+        }
+    }
+}


### PR DESCRIPTION
Fixes Issue #126 

Adds new functionality for Object Recognition Source queries. Queries can now be used to upload locally saved images to VANTIQ. Queries can also be used to delete locally saved images.

The images can be uploaded with user-specified resolution, as described in the README. This can be accomplished by adding a "savedResolution" option to the query parameters ("where" clause in query), exactly as you would for the source configuration.

**TO DO**:
* Need to update the README
* Need to handle the case of duplicate image names (i.e. 2019-02-05--02-35-10.jpg, 2019-02-05--02-35-10(1).jpg, 2019-02-05--02-35-10(2).jpg, etc...)