### PR TITLE
Naf label fix #130

### DIFF
--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
@@ -216,6 +216,7 @@ public class ObjectDetector {
                 imageUtil.outputDir = outputDir;
                 imageUtil.vantiq = vantiq;
                 imageUtil.sourceName = sourceName;
+                imageUtil.frameSize = frameSize;
                 if (fileName == null) {
                     fileName = format.format(now) + ".jpg";
                 } else if (!fileName.endsWith(".jpg") && !fileName.endsWith(".jpeg")) {

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
@@ -127,6 +127,7 @@ public class ObjectDetector {
                 }
             }
             this.imageUtil = imageUtil;
+            imageUtil.frameSize = this.frameSize;
             this.vantiq = vantiq;
             this.labelImage = labelImage;
             this.sourceName = sourceName;

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
@@ -28,6 +28,7 @@ public class ImageUtil {
     public Vantiq vantiq = null; // Added to allow image saving with VANTIQ
     public String sourceName = null;
     public Boolean saveImage;
+    public int frameSize;
     public int longEdge = 0;
 
     /**
@@ -36,8 +37,8 @@ public class ImageUtil {
      * @param recognitions  list of recognized objects
      */
     public BufferedImage labelImage(BufferedImage bufferedImage, final List<Recognition> recognitions) {
-        float scaleX = (float) bufferedImage.getWidth() / (float) Config.FRAME_SIZE;
-        float scaleY = (float) bufferedImage.getHeight() / (float) Config.FRAME_SIZE;
+        float scaleX = (float) bufferedImage.getWidth() / (float) frameSize;
+        float scaleY = (float) bufferedImage.getHeight() / (float) frameSize;
         Graphics2D graphics = (Graphics2D) bufferedImage.getGraphics();
 
         for (Recognition recognition: recognitions) {


### PR DESCRIPTION
Fixes Issue #130 

Changes the labelImage() method in the ImageUtil class to use the correct frameSize value. Added fix for both polling and queries (processNextFrame). 

All tests pass, and the project builds successfully. I will add the configurable bounding box size as a separate enhancement issue.