### PR TITLE
Fixed SimpleDateFormat to properly format the date coming from the DB.

### DIFF
--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
@@ -33,8 +33,8 @@ public class JDBC {
     private Statement   stmt = null;
     private ResultSet   rs   = null;    
     
-    DateFormat dfTimestamp  = new SimpleDateFormat("yyyy-dd-mm'T'HH:mm:ss.SSSZ");
-    DateFormat dfDate       = new SimpleDateFormat("yyyy-dd-mm");
+    DateFormat dfTimestamp  = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    DateFormat dfDate       = new SimpleDateFormat("yyyy-MM-dd");
     DateFormat dfTime       = new SimpleDateFormat("HH:mm:ss.SSSZ");
     
     /**

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -49,9 +49,6 @@ public class TestJDBC extends TestJDBCBase {
     static final String INSERT_NO_FIELD = "INSERT INTO Test VALUES (1, 25, 'Santa', 'Claus', 'jibberish')";
     static final String INSERT_WRONG_TYPE = "INSERT INTO Test VALUES ('string', 'string', 3, 4)";
     
-    DateFormat dfTimestamp  = new SimpleDateFormat("yyyy-dd-mm'T'HH:mm:ss.SSSZ");
-    DateFormat dfDate       = new SimpleDateFormat("yyyy-dd-mm");
-    DateFormat dfTime       = new SimpleDateFormat("HH:mm:ss.SSSZ");
     static final String timestampPattern = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}-\\d{4}";
     static final String datePattern = "\\d{4}-\\d{2}-\\d{2}";
     static final String timePattern = "\\d{2}:\\d{2}:\\d{2}.\\d{3}-\\d{4}";

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -33,11 +33,18 @@ public class TestJDBC extends TestJDBCBase {
     static final String DELETE_ROW = "DELETE FROM Test WHERE first='Santa';";
     static final String DELETE_TABLE = "DROP TABLE Test;";
     
+    // Date values used to test oddball types
+    static final String TIMESTAMP = "2018-08-15 9:24:18";
+    static final String DATE = "2018-08-15";
+    static final String TIME = "9:24:18";
+    static final String FORMATTED_TIMESTAMP = "2018-08-15T09:24:18.000-0700";
+    static final String FORMATTED_TIME = "09:24:18.000-0800";
+    
     // Queries to test oddball types
-    static final String CREATE_TABLE_EXTENDED_TYPES = "create table TestTypes(id int, ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,"
-            + " testDate DATE, testTime TIME, testDec decimal(5,2));";
-    static final String PUBLISH_QUERY_EXTENDED_TYPES = "INSERT INTO TestTypes VALUES (1, CURRENT_TIMESTAMP, '2018-08-15',"
-            + " '9:24:18', 145.86);";
+    static final String CREATE_TABLE_EXTENDED_TYPES = "create table TestTypes(id int, ts TIMESTAMP, testDate DATE, "
+            + "testTime TIME, testDec decimal(5,2));";
+    static final String PUBLISH_QUERY_EXTENDED_TYPES = "INSERT INTO TestTypes VALUES (1, '" + TIMESTAMP + "', '" + DATE + "',"
+            + " '" + TIME + "', 145.86);";
     static final String SELECT_QUERY_EXTENDED_TYPES = "SELECT * FROM TestTypes;";
     static final String DELETE_ROW_EXTENDED_TYPES = "DELETE FROM TestTypes;";
     static final String DELETE_TABLE_EXTENDED_TYPES = "DROP TABLE TestTypes;";
@@ -197,10 +204,13 @@ public class TestJDBC extends TestJDBCBase {
             queryResult = jdbc.processQuery(SELECT_QUERY_EXTENDED_TYPES);
             String timestampTest = (String) queryResult[0].get("ts");
             assert timestampTest.matches(timestampPattern);
+            assert timestampTest.equals(FORMATTED_TIMESTAMP);
             String dateTest = (String) queryResult[0].get("testDate");
             assert dateTest.matches(datePattern);
+            assert dateTest.equals(DATE);
             String timeTest = (String) queryResult[0].get("testTime");
             assert timeTest.matches(timePattern);
+            assert timeTest.equals(FORMATTED_TIME);
             assert ((BigDecimal) queryResult[0].get("testDec")).compareTo(new BigDecimal("145.86")) == 0;
         } catch (VantiqSQLException e) {
             fail("Should not have thrown exception.");


### PR DESCRIPTION
Fixes Issue #139 

There was a simple mistake with the SimpleDateFormat, which caused them to misinterpret datetime elements coming from the database.

@fhcarter 
DateTime elements stored in a DB are returned from the JDBC Extension Source as strings. Is there anyway we could handle incoming dates on the server side, and create VANTIQ Date Types implicitly. If this isn't possible that's fine, I've checked that you can use vail to format the incoming date strings into Vantiq Date Types. This would just remove that extra step.