### PR TITLE
Naf jdbc date tests

### DIFF
--- a/jdbcSource/README.md
+++ b/jdbcSource/README.md
@@ -249,15 +249,23 @@ SQLException, and contains the Error Message, SQL State, and Error Code from the
 In order to properly run the tests, you must create an environment variable named JDBC\_DRIVER\_LOC which points to the 
 appropriate JDBC Driver .jar file. Additionally, you must first add the SQL Database username, password, and URL to your 
 gradle.properties file in the ~/.gradle directory. You must also add the Target VANTIQ Server, as well as the corresponding 
-Authentication Token to the same file. The following shows what the gradle.properties file should look like:
+Authentication Token to the same file. The Target VANTIQ Server and Auth Token will be used to create a temporary VANTIQ 
+Source and Type, named testSourceName and testTypeName respectively. These names can optionally be configured by adding 
+EntConTestSourceName and EntConTestTypeName to the gradle.properties file. The following shows what the gradle.properties file 
+should look like:
 
 ```
     EntConJDBCUsername=<yourUsername>
     EntConJDBCPassword=<yourPassword>
     EntConJDBCURL=<yourURL>
+    EntConTestSourceName=<yourDesiredSourceName>
+    EntConTestTypeName=<yourDesiredTypeName>
     TestVantiqServer=<yourVantiqServer>
     TestAuthToken=<yourAuthToken>
 ```
+
+* **NOTE:** We strongly encourage users to create a unique VANTIQ Namespace in order to ensure that tests do not accidentally 
+override any existing Sources or Types.
 
 ## Licensing
 The source code uses the [MIT License](https://opensource.org/licenses/MIT).  

--- a/jdbcSource/README.md
+++ b/jdbcSource/README.md
@@ -248,12 +248,15 @@ SQLException, and contains the Error Message, SQL State, and Error Code from the
 
 In order to properly run the tests, you must create an environment variable named JDBC\_DRIVER\_LOC which points to the 
 appropriate JDBC Driver .jar file. Additionally, you must first add the SQL Database username, password, and URL to your 
-gradle.properties file in the ~/.gradle directory as follows:
+gradle.properties file in the ~/.gradle directory. You must also add the Target VANTIQ Server, as well as the corresponding 
+Authentication Token to the same file. The following shows what the gradle.properties file should look like:
 
 ```
     EntConJDBCUsername=<yourUsername>
     EntConJDBCPassword=<yourPassword>
     EntConJDBCURL=<yourURL>
+    TestVantiqServer=<yourVantiqServer>
+    TestAuthToken=<yourAuthToken>
 ```
 
 ## Licensing

--- a/jdbcSource/build.gradle
+++ b/jdbcSource/build.gradle
@@ -49,10 +49,10 @@ tasks.withType(Test) {
         systemProperty "EntConJDBCURL", rootProject.findProperty("EntConJDBCURL") ?: "empty"
     }
     if (rootProject.hasProperty("EntConTestSourceName")) {
-        systemProperty "EntConTestSourceName", rootProject.findProperty("EntConTestSourceName") ?: "empty"
+        systemProperty "EntConTestSourceName", rootProject.findProperty("EntConTestSourceName")
     }
     if (rootProject.hasProperty("EntConTestTypeName")) {
-        systemProperty "EntConTestTypeName", rootProject.findProperty("EntConTestTypeName") ?: "empty"
+        systemProperty "EntConTestTypeName", rootProject.findProperty("EntConTestTypeName")
     }
     if (rootProject.hasProperty("TestAuthToken")) {
         systemProperty "TestAuthToken", rootProject.findProperty("TestAuthToken") ?: "empty"

--- a/jdbcSource/build.gradle
+++ b/jdbcSource/build.gradle
@@ -48,6 +48,12 @@ tasks.withType(Test) {
     if (rootProject.hasProperty("EntConJDBCURL")) {
         systemProperty "EntConJDBCURL", rootProject.findProperty("EntConJDBCURL") ?: "empty"
     }
+    if (rootProject.hasProperty("EntConTestSourceName")) {
+        systemProperty "EntConTestSourceName", rootProject.findProperty("EntConTestSourceName") ?: "empty"
+    }
+    if (rootProject.hasProperty("EntConTestTypeName")) {
+        systemProperty "EntConTestTypeName", rootProject.findProperty("EntConTestTypeName") ?: "empty"
+    }
     if (rootProject.hasProperty("TestAuthToken")) {
         systemProperty "TestAuthToken", rootProject.findProperty("TestAuthToken") ?: "empty"
     }

--- a/jdbcSource/build.gradle
+++ b/jdbcSource/build.gradle
@@ -9,6 +9,11 @@ sourceCompatibility = 1.8
 repositories {
     mavenCentral()
     jcenter()
+    
+    // Used for checking VANTIQ date format behavior with VANTIQ SDK
+    maven {
+    	url "https://dl.bintray.com/vantiq/maven"
+    }
 }
 
 mainClassName = 'io.vantiq.extsrc.jdbcSource.JDBCMain'
@@ -43,6 +48,12 @@ tasks.withType(Test) {
     if (rootProject.hasProperty("EntConJDBCURL")) {
         systemProperty "EntConJDBCURL", rootProject.findProperty("EntConJDBCURL") ?: "empty"
     }
+    if (rootProject.hasProperty("TestAuthToken")) {
+        systemProperty "TestAuthToken", rootProject.findProperty("TestAuthToken") ?: "empty"
+    }
+    if (rootProject.hasProperty("TestVantiqServer")) {
+        systemProperty "TestVantiqServer", rootProject.findProperty("TestVantiqServer") ?: "empty"
+    }
 }
 
 dependencies {
@@ -56,6 +67,9 @@ dependencies {
     
     //  Compiling relevant JDBC Driver .jar file
     runtime files("${System.env.JDBC_DRIVER_LOC}")
+    
+    // Used for checking VANTIQ date format behavior with VANTIQ SDK
+    compile 'io.vantiq:vantiq-sdk:1.0.17'
     
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -64,9 +64,10 @@ public class TestJDBC extends TestJDBCBase {
     static final String INSERT_WRONG_TYPE = "INSERT INTO Test VALUES ('string', 'string', 3, 4)";
     
     // Queries to test DateTime format in VANTIQ
-    static final String CREATE_TABLE_DATETIME = "CREATE TABLE Test(ts TIMESTAMP);";
-    static final String INSERT_VALUE_DATETIME = "INSERT INTO Test VALUES ('" + TIMESTAMP + "');";
-    static final String QUERY_TABLE_DATETIME = "SELECT * FROM Test";
+    static final String CREATE_TABLE_DATETIME = "CREATE TABLE TestDates(ts TIMESTAMP);";
+    static final String INSERT_VALUE_DATETIME = "INSERT INTO TestDates VALUES ('" + TIMESTAMP + "');";
+    static final String QUERY_TABLE_DATETIME = "SELECT * FROM TestDates";
+    static final String DROP_TABLE_DATETIME = "DROP TABLE TestDates";
     
     static final String timestampPattern = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}-\\d{4}";
     static final String datePattern = "\\d{4}-\\d{2}-\\d{2}";
@@ -111,6 +112,13 @@ public class TestJDBC extends TestJDBCBase {
                 jdbc.processPublish(DELETE_TABLE_EXTENDED_TYPES);
             } catch (VantiqSQLException e) {
                 // Shoudn't throw Exception
+            }
+            
+            // Delete third table
+            try {
+                jdbc.processPublish(DROP_TABLE_DATETIME);
+            } catch (VantiqSQLException e) {
+                // Shouldn't throw Exception
             }
         }
         if (core != null) {

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -12,15 +12,21 @@ import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 import java.math.BigDecimal;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import io.vantiq.client.Vantiq;
+import io.vantiq.client.VantiqResponse;
 import io.vantiq.extsrc.jdbcSource.exception.VantiqSQLException;
 
 public class TestJDBC extends TestJDBCBase {
@@ -39,6 +45,7 @@ public class TestJDBC extends TestJDBCBase {
     static final String TIME = "9:24:18";
     static final String FORMATTED_TIMESTAMP = "2018-08-15T09:24:18.000-0700";
     static final String FORMATTED_TIME = "09:24:18.000-0800";
+    static final String VANTIQ_FORMATTED_TIMESTAMP = "2018-08-15T16:24:18Z";
     
     // Queries to test oddball types
     static final String CREATE_TABLE_EXTENDED_TYPES = "create table TestTypes(id int, ts TIMESTAMP, testDate DATE, "
@@ -56,15 +63,28 @@ public class TestJDBC extends TestJDBCBase {
     static final String INSERT_NO_FIELD = "INSERT INTO Test VALUES (1, 25, 'Santa', 'Claus', 'jibberish')";
     static final String INSERT_WRONG_TYPE = "INSERT INTO Test VALUES ('string', 'string', 3, 4)";
     
+    // Queries to test DateTime format in VANTIQ
+    static final String CREATE_TABLE_DATETIME = "CREATE TABLE Test(ts TIMESTAMP);";
+    static final String INSERT_VALUE_DATETIME = "INSERT INTO Test VALUES ('" + TIMESTAMP + "');";
+    static final String QUERY_TABLE_DATETIME = "SELECT * FROM Test";
+    
     static final String timestampPattern = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}-\\d{4}";
     static final String datePattern = "\\d{4}-\\d{2}-\\d{2}";
     static final String timePattern = "\\d{2}:\\d{2}:\\d{2}.\\d{3}-\\d{4}";
     
+    static final String SOURCE_NAME = "testSourceName";
+    static final String TYPE_NAME = "testTypeName";
+    static final int CORE_START_TIMEOUT = 10;
+    
+    static JDBCCore core;
     static JDBC jdbc;
+    static Vantiq vantiq;
     
     @Before
     public void setup() { 
         jdbc = new JDBC();
+        vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
+        vantiq.setAccessToken(testAuthToken);
     }
     
     /* Uncomment this BeforeClass when debugging to ensure tables have been properly deleted.
@@ -93,7 +113,14 @@ public class TestJDBC extends TestJDBCBase {
                 // Shoudn't throw Exception
             }
         }
-        jdbc.close();
+        if (core != null) {
+            core.close();
+            core = null;
+        }
+        if (jdbc != null) {
+            jdbc.close();
+            jdbc = null;
+        }
     }
     
     @Test
@@ -226,6 +253,59 @@ public class TestJDBC extends TestJDBCBase {
     }
     
     @Test
+    public void testVantiqDateFormatting() throws VantiqSQLException {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+        assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword);
+        
+        // Setup a VANTIQ JDBC Source, and start running the core
+        setupSource(createSourceDef());
+        
+        // Publish to the source in order to create a table
+        Map<String,Object> create_params = new LinkedHashMap<String,Object>();
+        create_params.put("query", CREATE_TABLE_DATETIME);
+        vantiq.publish("sources", SOURCE_NAME, create_params);
+        
+        // Publish to the source in order to insert data into the table
+        Map<String,Object> insert_params = new LinkedHashMap<String,Object>();
+        insert_params.put("query", INSERT_VALUE_DATETIME);
+        vantiq.publish("sources", SOURCE_NAME, insert_params);
+        
+        // Query the Source, and get the returned date
+        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        params.put("query", QUERY_TABLE_DATETIME);
+        VantiqResponse response = vantiq.query(SOURCE_NAME, params);
+        JsonArray responseBody = (JsonArray) response.getBody();
+        JsonObject responseMap = (JsonObject) responseBody.get(0);
+        String timestamp = (String) responseMap.get("ts").getAsString();
+        assert timestamp.equals(FORMATTED_TIMESTAMP);
+
+        // Create a Type with DateTime property
+        setupType();
+        
+        // Insert timestamp into Type
+        Map<String,String> insertObj = new LinkedHashMap<String,String>();
+        insertObj.put("timestamp", timestamp);
+        vantiq.insert(TYPE_NAME, insertObj);
+        
+        // Check that value is as expected
+        response = vantiq.select(TYPE_NAME, null, null, null);
+        ArrayList typeResponseBody = (ArrayList) response.getBody();
+        responseMap = (JsonObject) typeResponseBody.get(0);
+        String vantiqTimestamp = (String) responseMap.get("timestamp").getAsString();
+        
+        // Check that the date was offset by adding 7 hours (since original date ends in 0700)
+        assert vantiqTimestamp.equals(VANTIQ_FORMATTED_TIMESTAMP);
+        
+        // Delete the Type from VANTIQ
+        deleteType();
+        
+        // Delete the Source from VANTIQ
+        deleteSource();
+    }
+    
+    @Test
     public void testCorrectErrors() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
         assumeTrue(testDBURL.contains("mysql"));
@@ -288,4 +368,71 @@ public class TestJDBC extends TestJDBCBase {
         }
         
     }
+    
+    // ================================================= Helper functions =================================================
+
+    public static void setupSource(Map<String,Object> sourceDef) {
+        VantiqResponse insertResponse = vantiq.insert("system.sources", sourceDef);
+        if (insertResponse.isSuccess()) {
+            core = new JDBCCore(SOURCE_NAME, testAuthToken, testVantiqServer);
+            core.start(CORE_START_TIMEOUT);
+        }
+    }
+    
+    public static Map<String,Object> createSourceDef() {
+        Map<String,Object> sourceDef = new LinkedHashMap<String,Object>();
+        Map<String,Object> sourceConfig = new LinkedHashMap<String,Object>();
+        Map<String,Object> jdbcConfig = new LinkedHashMap<String,Object>();
+        Map<String,Object> vantiq = new LinkedHashMap<String,Object>();
+        Map<String,Object> general = new LinkedHashMap<String,Object>();
+        
+        // Setting up vantiq config options
+        vantiq.put("packageRows", "true");
+        
+        // Setting up general config options
+        general.put("username", testDBUsername);
+        general.put("password", testDBPassword);
+        general.put("dbURL", testDBURL);
+        
+        // Placing general config options in "jdbcConfig"
+        jdbcConfig.put("general", general);
+        
+        // Putting objRecConfig and vantiq config in the source configuration
+        sourceConfig.put("jdbcConfig", jdbcConfig);
+        sourceConfig.put("vantiq", vantiq);
+        
+        // Setting up the source definition
+        sourceDef.put("config", sourceConfig);
+        sourceDef.put("name", SOURCE_NAME);
+        sourceDef.put("type", "JDBC");
+        sourceDef.put("active", "true");
+        sourceDef.put("direction", "BOTH");
+        
+        return sourceDef;
+    }
+    
+    public static void deleteSource() {
+        Map<String,Object> where = new LinkedHashMap<String,Object>();
+        where.put("name", SOURCE_NAME);
+        vantiq.delete("system.sources", where);
+    }
+    
+    public static void setupType() {
+        Map<String,Object> typeDef = new LinkedHashMap<String,Object>();
+        Map<String,Object> properties = new LinkedHashMap<String,Object>();
+        Map<String,Object> propertyDef = new LinkedHashMap<String,Object>();
+        propertyDef.put("type", "DateTime");
+        propertyDef.put("required", true);
+        properties.put("timestamp", propertyDef);
+        typeDef.put("properties", properties);
+        typeDef.put("name", TYPE_NAME);
+        vantiq.insert("system.types", typeDef);
+    }
+    
+    public static void deleteType() {
+        Map<String,Object> where = new LinkedHashMap<String,Object>();
+        where.put("name", TYPE_NAME);
+        vantiq.delete("system.types", where);
+    }
+    
 }

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCBase.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCBase.java
@@ -14,6 +14,8 @@ public class TestJDBCBase {
     static String testDBUsername;
     static String testDBPassword;
     static String testDBURL;
+    static String testAuthToken;
+    static String testVantiqServer;
     static String jdbcDriverLoc;
     
     @BeforeClass
@@ -21,6 +23,8 @@ public class TestJDBCBase {
         testDBUsername = System.getProperty("EntConJDBCUsername", null);
         testDBPassword = System.getProperty("EntConJDBCPassword", null);
         testDBURL = System.getProperty("EntConJDBCURL", null);
+        testAuthToken = System.getProperty("TestAuthToken", null);
+        testVantiqServer = System.getProperty("TestVantiqServer", null);
         jdbcDriverLoc = System.getenv("JDBC_DRIVER_LOC");
     }
 }

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCBase.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCBase.java
@@ -17,6 +17,8 @@ public class TestJDBCBase {
     static String testAuthToken;
     static String testVantiqServer;
     static String jdbcDriverLoc;
+    static String testSourceName;
+    static String testTypeName;
     
     @BeforeClass
     public static void getProps() {
@@ -26,5 +28,7 @@ public class TestJDBCBase {
         testAuthToken = System.getProperty("TestAuthToken", null);
         testVantiqServer = System.getProperty("TestVantiqServer", null);
         jdbcDriverLoc = System.getenv("JDBC_DRIVER_LOC");
+        testSourceName = System.getProperty("EntConTestSourceName", "testSourceName");
+        testTypeName = System.getProperty("EntConTestTypeName", "testTypeName");
     }
 }


### PR DESCRIPTION
Added a test to setup a VANTIQ Source and Publish/Query against it using the VANTIQ SDK. Then set up a Type with a DateTime property, and inserted the DateTime element we queried for into that Type. Finally, checked that the DateTime was converted properly, using the timezone offset that was provided.

(In this case, the DateTime property added 7 hours to the value, since the offset is listed as 0700.)