### PR TITLE
Fixing JDBC Connector bug

### DIFF
--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
@@ -119,35 +119,33 @@ public class JDBC {
                         int columnType = md.getColumnType(i);
                         switch (columnType) {
                             case java.sql.Types.DECIMAL:
-                                row.put(md.getColumnName(i), queryResults.getBigDecimal(i));
+                                if (queryResults.getBigDecimal(i) != null) {
+                                    row.put(md.getColumnName(i), queryResults.getBigDecimal(i));
+                                }
                                 break;
                             case java.sql.Types.DATE:
                                 Date rowDate = queryResults.getDate(i);
                                 if (rowDate != null) {
                                     row.put(md.getColumnName(i), dfDate.format(rowDate));
-                                } else {
-                                    row.put(md.getColumnName(i), null);
                                 }
                                 break;
                             case java.sql.Types.TIME:
                                 Time rowTime = queryResults.getTime(i);
                                 if (rowTime != null) {
                                     row.put(md.getColumnName(i), dfTime.format(rowTime));
-                                } else {
-                                    row.put(md.getColumnName(i), null);
                                 }
                                 break;
                             case java.sql.Types.TIMESTAMP:
                                 Timestamp rowTimestamp = queryResults.getTimestamp(i);
                                 if (rowTimestamp != null) {
                                     row.put(md.getColumnName(i), dfTimestamp.format(rowTimestamp));
-                                } else {
-                                    row.put(md.getColumnName(i), null);
                                 }
                                 break;
                             default:
                                 // If none of the initial cases are met, the data will be converted to a String via getObject()
-                                row.put(md.getColumnName(i), queryResults.getObject(i));
+                                if(queryResults.getObject(i) != null) {
+                                    row.put(md.getColumnName(i), queryResults.getObject(i));
+                                }
                                 break;
                         }
                     }

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
@@ -123,15 +123,27 @@ public class JDBC {
                                 break;
                             case java.sql.Types.DATE:
                                 Date rowDate = queryResults.getDate(i);
-                                row.put(md.getColumnName(i), dfDate.format(rowDate));
+                                if (rowDate != null) {
+                                    row.put(md.getColumnName(i), dfDate.format(rowDate));
+                                } else {
+                                    row.put(md.getColumnName(i), null);
+                                }
                                 break;
                             case java.sql.Types.TIME:
                                 Time rowTime = queryResults.getTime(i);
-                                row.put(md.getColumnName(i), dfTime.format(rowTime));
+                                if (rowTime != null) {
+                                    row.put(md.getColumnName(i), dfTime.format(rowTime));
+                                } else {
+                                    row.put(md.getColumnName(i), null);
+                                }
                                 break;
                             case java.sql.Types.TIMESTAMP:
                                 Timestamp rowTimestamp = queryResults.getTimestamp(i);
-                                row.put(md.getColumnName(i), dfTimestamp.format(rowTimestamp));
+                                if (rowTimestamp != null) {
+                                    row.put(md.getColumnName(i), dfTimestamp.format(rowTimestamp));
+                                } else {
+                                    row.put(md.getColumnName(i), null);
+                                }
                                 break;
                             default:
                                 // If none of the initial cases are met, the data will be converted to a String via getObject()

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
@@ -202,14 +202,14 @@ public class JDBCCore {
                         + "not a string.", null);
             }
         } catch (VantiqSQLException e) {
-            log.warn("Could not execute requested query.", e);
-            log.debug("Request was: {}", request);
+            log.error("Could not execute requested query.", e);
+            log.error("Request was: {}", request);
             client.sendQueryError(replyAddress, VantiqSQLException.class.getCanonicalName(), 
                     "Failed to execute query for reason: " + e.getMessage() + 
                     ". Exception was: " + e.getClass().getName() + ". Request was: " + request.get("query"), null);
         } catch (Exception e) {
-            log.warn("An unexpected error occured when executing the requested query.", e);
-            log.debug("Request was: {}", request);
+            log.error("An unexpected error occurred when executing the requested query.", e);
+            log.error("Request was: {}", request);
             client.sendQueryError(replyAddress, Exception.class.getCanonicalName(), 
                     "Failed to execute query for reason: " + e.getMessage() + 
                     ". Exception was: " + e.getClass().getName() + ". Request was: " + request.get("query"), null);
@@ -239,10 +239,10 @@ public class JDBCCore {
             }
         } catch (VantiqSQLException e) {
             log.error("Could not execute requested query.", e);
-            log.debug("Request was: {}", request);
+            log.error("Request was: {}", request);
         } catch (Exception e) {
-            log.error("An unexpected error occured when executing the requested query.", e);
-            log.debug("Request was: {}", request);
+            log.error("An unexpected error occurred when executing the requested query.", e);
+            log.error("Request was: {}", request);
         }
     }
     
@@ -262,9 +262,10 @@ public class JDBCCore {
             }
         } catch (VantiqSQLException e) {
             log.error("Could not execute polling query.", e);
+            log.error("The pollQuery was: " + pollQuery);
         } catch (Exception e) {
-            log.error("An unexpected error occured when executing the polling query.", e);
-            log.debug("The pollQuery was: " + pollQuery);
+            log.error("An unexpected error occurred when executing the polling query.", e);
+            log.error("The pollQuery was: " + pollQuery);
         }
     }
     

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
@@ -208,7 +208,7 @@ public class JDBCCore {
                     "Failed to execute query for reason: " + e.getMessage() + 
                     ". Exception was: " + e.getClass().getName() + ". Request was: " + request.get("query"), null);
         } catch (Exception e) {
-            log.warn("An unexpected error occured when executing the requested query.");
+            log.warn("An unexpected error occured when executing the requested query.", e);
             log.debug("Request was: {}", request);
             client.sendQueryError(replyAddress, Exception.class.getCanonicalName(), 
                     "Failed to execute query for reason: " + e.getMessage() + 
@@ -241,7 +241,7 @@ public class JDBCCore {
             log.error("Could not execute requested query.", e);
             log.debug("Request was: {}", request);
         } catch (Exception e) {
-            log.error("An unexpected error occured when executing the requested query.");
+            log.error("An unexpected error occured when executing the requested query.", e);
             log.debug("Request was: {}", request);
         }
     }
@@ -263,7 +263,8 @@ public class JDBCCore {
         } catch (VantiqSQLException e) {
             log.error("Could not execute polling query.", e);
         } catch (Exception e) {
-            log.error("An unexpected error occured when executing the polling query.");
+            log.error("An unexpected error occured when executing the polling query.", e);
+            log.debug("The pollQuery was: " + pollQuery);
         }
     }
     

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
@@ -207,6 +207,12 @@ public class JDBCCore {
             client.sendQueryError(replyAddress, VantiqSQLException.class.getCanonicalName(), 
                     "Failed to execute query for reason: " + e.getMessage() + 
                     ". Exception was: " + e.getClass().getName() + ". Request was: " + request.get("query"), null);
+        } catch (Exception e) {
+            log.warn("An unexpected error occured when executing the requested query.");
+            log.debug("Request was: {}", request);
+            client.sendQueryError(replyAddress, Exception.class.getCanonicalName(), 
+                    "Failed to execute query for reason: " + e.getMessage() + 
+                    ". Exception was: " + e.getClass().getName() + ". Request was: " + request.get("query"), null);
         }
     }
     
@@ -234,6 +240,9 @@ public class JDBCCore {
         } catch (VantiqSQLException e) {
             log.error("Could not execute requested query.", e);
             log.debug("Request was: {}", request);
+        } catch (Exception e) {
+            log.error("An unexpected error occured when executing the requested query.");
+            log.debug("Request was: {}", request);
         }
     }
     
@@ -253,6 +262,8 @@ public class JDBCCore {
             }
         } catch (VantiqSQLException e) {
             log.error("Could not execute polling query.", e);
+        } catch (Exception e) {
+            log.error("An unexpected error occured when executing the polling query.");
         }
     }
     


### PR DESCRIPTION
Fixes Issue #143 

Fixing bug related to JDBC Connector crashing when date fields in SQL table are null.  Crash resulted from trying to use a SimpleDateFormat on a null value. Added test to ensure the appropriate behavior occurs.