### PR TITLE
JDBC Bug Fix to quiet error message.

### DIFF
--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
@@ -58,8 +58,8 @@ public class JDBC {
     /**
      * The method used to execute the provided query, triggered by a SELECT on the respective source from VANTIQ.
      * @param sqlQuery          A String representation of the query, retrieved from the WITH clause from VANTIQ.
-     * @return                  A HashMap Array containing all of the data retrieved by the query, (null if 
-     *                          nothing was returned)
+     * @return                  A HashMap Array containing all of the data retrieved by the query, (empty HashMap 
+     *                          Array if nothing was returned)
      * @throws VantiqSQLException
      */
     public HashMap[] processQuery(String sqlQuery) throws VantiqSQLException {
@@ -99,14 +99,14 @@ public class JDBC {
      * Method used to create a map out of the output ResultSet. Map is needed in order to send the data back to VANTIQ
      * @param queryResults   A ResultSet containing return value from executeQuery()
      * @return               A HashMap Array containing all of the rows from the ResultSet, each converted to a HashMap,
-     *                       (or null if the ResultSet was empty).
+     *                       (or an empty HashMap Array if the ResultSet was empty).
      * @throws VantiqSQLException
      */
     HashMap[] createMapFromResults(ResultSet queryResults) throws VantiqSQLException {
         ArrayList<HashMap> rows = new ArrayList<HashMap>();
         try {
             if (!queryResults.next()) { 
-                return null;
+                return rows.toArray(new HashMap[rows.size()]);
             } else {
                 ResultSetMetaData md = queryResults.getMetaData(); 
                 int columns = md.getColumnCount();

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
@@ -256,8 +256,10 @@ public class JDBCCore {
         try {
             synchronized (this) {
                 HashMap[] queryMap = jdbc.processQuery(pollQuery);
-                for (HashMap h : queryMap) {
-                    client.sendNotification(h);
+                if (queryMap != null) {
+                    for (HashMap h : queryMap) {
+                        client.sendNotification(h);
+                    }
                 }
             }
         } catch (VantiqSQLException e) {

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
@@ -279,7 +279,7 @@ public class JDBCCore {
        
        // Send the results of the query
        if (queryArray.length == 0) {
-           // If data is empty send empty list with 204 code
+           // If data is empty send empty map with 204 code
            client.sendQueryResponse(204, replyAddress, new LinkedHashMap<>());
        } else {
            client.sendQueryResponse(200, replyAddress, queryArray);

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
@@ -278,7 +278,7 @@ public class JDBCCore {
        String replyAddress = ExtensionServiceMessage.extractReplyAddress(message);
        
        // Send the results of the query
-       if (queryArray == null) {
+       if (queryArray.length == 0) {
            // If data is empty send empty list with 204 code
            client.sendQueryResponse(204, replyAddress, new LinkedHashMap<>());
        } else {

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -227,10 +227,10 @@ public class TestJDBC extends TestJDBCBase {
             fail("Should not throw an exception: " + e.getMessage());
         }
         
-        // Try selecting again, should return null since row was deleted
+        // Try selecting again, should return empty HashMap Array since row was deleted
         try {
             queryResult = jdbc.processQuery(SELECT_QUERY);
-            assert queryResult == null;
+            assert queryResult.length == 0;
         } catch (VantiqSQLException e) {
             fail("Should not throw an exception: " + e.getMessage());
         }


### PR DESCRIPTION
Fixes Issue #145 

Added quick fix to stop null pointer error message from repeatedly being thrown when polling an empty DB.

Issue was that if ResultSet was empty, the executeQuery method returned null. In the executePolling method, this resulted in a null pointer exception being thrown when we tried to iterate through the maps in the HashMap Array, (to send each one as a notification). Changed the method to not return null, and instead to just return an empty HashMap Array.