### PR TITLE
Making Timeout for Queue Message Consumption an Optional Query Parameter

### DIFF
--- a/jmsSource/README.md
+++ b/jmsSource/README.md
@@ -241,9 +241,13 @@ INSERT JMSMessageType(myObj)
 ### Select Statements <a name="select" id="select"></a>
 
 In order to read messages from a queue, (**NOT** a queueListener), a VAIL SELECT statement must be used. The SELECT statement 
-must have two query parameters: `operation` and `queue`. Currently there is only one `operation` that is supported, which is 
-the "read" `operation`. In the future, there may be different SELECT Operations. The `queue` parameter is the name of the 
-queue from which to read. The following is an example of a Procedure created in VANTIQ Modelo querying against a JMS Source:
+must have two query parameters: `operation` and `queue`. A third optional parameter, `timeout`, can be specified as well. 
+Currently there is only one `operation` that is supported, which is the "read" `operation`. In the future, there may be 
+different SELECT Operations. The `queue` parameter is the name of the queue from which to read. The `timeout` parameter can be 
+used to force the queue message consumer to wait up to `timeout` milliseconds for a queue message to arrive. The `timeout` 
+parameter must be a **non-negative integer**. If the `timeout` value is set to 0, this will make the queue message consumer 
+wait *indefinitely* for a queue message to arrive. The following two examples demonstrate a Procedure created in VANTIQ Modelo 
+querying against a JMS Source, (with and without `timeout`):
 
 ```
 PROCEDURE readMessageFromQueue()
@@ -251,6 +255,24 @@ PROCEDURE readMessageFromQueue()
 SELECT * FROM SOURCE JMS1 AS msg WITH
     operation: "read",
     queue: "NamirJMSServer-0/NamirSystemModule-0!NamirJMSServer-0@/com/namir/weblogic/base/dq"
+    {
+        var myObj = {}
+        myObj.message = msg.message
+	myObj.headers = msg.headers
+	myObj.properties = msg.properties
+    	myObj.destination = msg.queue
+        
+        INSERT JMSMessageType(myObj)
+    }
+```
+
+```
+PROCEDURE readMessageFromQueueWithTimeout()
+
+SELECT * FROM SOURCE JMS1 AS msg WITH
+    operation: "read",
+    queue: "NamirJMSServer-0/NamirSystemModule-0!NamirJMSServer-0@/com/namir/weblogic/base/dq",
+    timeout: 1000
     {
         var myObj = {}
         myObj.message = msg.message

--- a/jmsSource/README.md
+++ b/jmsSource/README.md
@@ -245,9 +245,8 @@ must have two query parameters: `operation` and `queue`. A third optional parame
 Currently there is only one `operation` that is supported, which is the "read" `operation`. In the future, there may be 
 different SELECT Operations. The `queue` parameter is the name of the queue from which to read. The `timeout` parameter can be 
 used to force the queue message consumer to wait up to `timeout` milliseconds for a queue message to arrive. The `timeout` 
-parameter must be a **non-negative integer**, otherwise it will be ignored. If the `timeout` value is set to 0, this will make 
-the queue message consumer wait *indefinitely* for a queue message to arrive. The following two examples demonstrate a 
-Procedure created in VANTIQ Modelo querying against a JMS Source, (with and without `timeout`):
+parameter must be a **positive integer**, otherwise it will be ignored. The following two examples demonstrate a Procedure 
+created in VANTIQ Modelo querying against a JMS Source, (with and without `timeout`):
 
 ```
 PROCEDURE readMessageFromQueue()

--- a/jmsSource/src/main/java/io/vantiq/extsrc/jmsSource/JMS.java
+++ b/jmsSource/src/main/java/io/vantiq/extsrc/jmsSource/JMS.java
@@ -316,12 +316,13 @@ public class JMS {
     /**
      * Called by the JMSCore, and used to read the most recent message from a given queue.
      * @param queue         Name of the queue from which to read.
+     * @param timeout       The timeout value for consuming a queue message, (-1 if not specified in query parameters)
      * @return              A map containing the message, queue name, message headers and properties
      * @throws JMSException
      * @throws DestinationNotConfiguredException
      * @throws UnsupportedJMSMessageTypeException
      */
-    public Map<String, Object> consumeMessage(String queue) throws Exception {
+    public Map<String, Object> consumeMessage(String queue, int timeout) throws Exception {
         JMSQueueMessageConsumer msgConsumer = queueMessageConsumers.get(queue);
         
         // To avoid getting a NullPointerException
@@ -329,7 +330,7 @@ public class JMS {
             throw new DestinationNotConfiguredException();
         }
         
-        return msgConsumer.consumeMessage();
+        return msgConsumer.consumeMessage(timeout);
     }
     
     /**

--- a/jmsSource/src/main/java/io/vantiq/extsrc/jmsSource/JMSCore.java
+++ b/jmsSource/src/main/java/io/vantiq/extsrc/jmsSource/JMSCore.java
@@ -268,7 +268,7 @@ public class JMSCore {
           if (request.get("queue") instanceof String) {
               String queue = (String) request.get("queue");
               int timeout = -1;
-              if (request.get("timeout") instanceof Integer) {
+              if (request.get("timeout") instanceof Integer && (Integer) request.get("timeout") > 0) {
                   timeout = (Integer) request.get("timeout");
               }
               try {

--- a/jmsSource/src/main/java/io/vantiq/extsrc/jmsSource/JMSCore.java
+++ b/jmsSource/src/main/java/io/vantiq/extsrc/jmsSource/JMSCore.java
@@ -267,8 +267,12 @@ public class JMSCore {
           // Retrieve most recent message from specified queue. If no queue name is specified, or if exception is thrown, return query error.
           if (request.get("queue") instanceof String) {
               String queue = (String) request.get("queue");
+              int timeout = -1;
+              if (request.get("timeout") instanceof Integer) {
+                  timeout = (Integer) request.get("timeout");
+              }
               try {
-                  Map<String, Object> messageMap = localJMS.consumeMessage(queue);
+                  Map<String, Object> messageMap = localJMS.consumeMessage(queue, timeout);
                   if (messageMap == null) {
                       client.sendQueryError(replyAddress, this.getClass().getName() + ".invalidMessage", 
                               "The returned message was invalid. This is most likely because the MessageHandler did not format "

--- a/jmsSource/src/main/java/io/vantiq/extsrc/jmsSource/communication/JMSQueueMessageConsumer.java
+++ b/jmsSource/src/main/java/io/vantiq/extsrc/jmsSource/communication/JMSQueueMessageConsumer.java
@@ -35,9 +35,6 @@ public class JMSQueueMessageConsumer {
     
     private boolean closing = false;
     
-    // The timeout for receiving a message, set to 1 second
-    private static final int CONSUME_TIMEOUT = 1000;
-    
     private Context context;
     private ConnectionFactory connectionFactory;
     private Connection connection;
@@ -95,13 +92,20 @@ public class JMSQueueMessageConsumer {
     
     /**
      * Called by the JMS Class, and used to read the next available JMS Message from the associated queue
-     * @return A map containing the message, as well as the queue name and the JMS Message Type
-     * @throws JMSException
-     * @throws UnsupportedJMSMessageTypeException
+     * @param  timeout  The timeout value for consuming a queue message, (-1 if not specified in query parameters)
+     * @return          A map containing the message, as well as the queue name and the JMS Message Type
+     * @throws          JMSException
+     * @throws          UnsupportedJMSMessageTypeException
      */
-    public Map<String, Object> consumeMessage() throws Exception {
+    public Map<String, Object> consumeMessage(int timeout) throws Exception {
         try {
-            Message message = consumer.receive(CONSUME_TIMEOUT);
+            Message message;
+            if (timeout < 0) {
+                message = consumer.receiveNoWait();
+            } else {
+                message = consumer.receive(timeout);
+            }
+            
             Map<String, Object> msgMap = messageHandler.parseIncomingMessage(message, destName, true);
             // Making sure msgMap has the appropriate data
             if (msgMap != null && msgMap.get("headers") instanceof Map && msgMap.get("queue") instanceof String) {

--- a/jmsSource/src/test/java/io/vantiq/extsrc/jmsSource/TestJMS.java
+++ b/jmsSource/src/test/java/io/vantiq/extsrc/jmsSource/TestJMS.java
@@ -133,7 +133,7 @@ public class TestJMS extends TestJMSBase {
         
         // Reading message from the queue, and checking that it is equal to the message that was sent
         try {
-            Map<String, Object> queueMessage = jms.consumeMessage(testJMSQueue);
+            Map<String, Object> queueMessage = jms.consumeMessage(testJMSQueue, -1);
             assert ((String) queueMessage.get("message")).equals(message);
         } catch (Exception e) {
             fail("Should not throw an Exception when consuming message from queue.");
@@ -174,7 +174,7 @@ public class TestJMS extends TestJMSBase {
         sendToQueueParams.put("queue", testJMSQueue);
         vantiq.publish("sources", testSourceName, sendToQueueParams);
         
-        // Query with no operation set
+        // Query the source
         Map<String,Object> queryParams = new LinkedHashMap<String,Object>();
         queryParams.put("queue", testJMSQueue);
         queryParams.put("operation", "read");
@@ -280,6 +280,85 @@ public class TestJMS extends TestJMSBase {
         assert !queryResponse.hasErrors();
         JsonObject responseBody = (JsonObject) queryResponse.getBody();
         String responseMessage = (String) responseBody.get("message").getAsString();
+        assert responseMessage.equals(message);
+        
+        // Delete the Source from VANTIQ
+        deleteSource();
+        core.stop();  
+    }
+    
+    @Test
+    public void testQueryTimeout() {
+        checkAllJMSProperties(false);
+        
+        // Check that Source and Type do not already exist in namespace, and skip test if they do
+        assumeFalse(checkSourceExists());
+        
+        // Setup a VANTIQ JMS Source, and start running the core
+        setupSource(createSourceDef(false));
+        
+        // Create message to send
+        Date date = new Date();
+        String message = "A message sent at time: " + dateFormat.format(date);
+        
+        // Publish message to the source (send to queue)
+        Map<String,Object> sendToQueueParams = new LinkedHashMap<String,Object>();
+        Map<String, Object> headers = new LinkedHashMap<String, Object>();
+        headers.put("JMSType", "TextMessage");
+        sendToQueueParams.put("headers", headers);
+        sendToQueueParams.put("message", message);
+        sendToQueueParams.put("queue", testJMSQueue);
+        vantiq.publish("sources", testSourceName, sendToQueueParams);
+        
+        // Querying the source with no timeout
+        Map<String,Object> queryParams = new LinkedHashMap<String,Object>();
+        queryParams.put("queue", testJMSQueue);
+        queryParams.put("operation", "read");
+        VantiqResponse queryResponse = vantiq.query(testSourceName, queryParams);
+        
+        // Should query successfully
+        assert !queryResponse.hasErrors();
+        JsonObject responseBody = (JsonObject) queryResponse.getBody();
+        String responseMessage = (String) responseBody.get("message").getAsString();
+        assert responseMessage.equals(message);
+        
+        // Publish a message again
+        vantiq.publish("sources", testSourceName, sendToQueueParams);
+        
+        // Querying the source with non-integer timeout
+        queryParams.put("timeout", "jibberish");
+        queryResponse = vantiq.query(testSourceName, queryParams);
+        
+        // Should query successfully
+        assert !queryResponse.hasErrors();
+        responseBody = (JsonObject) queryResponse.getBody();
+        responseMessage = (String) responseBody.get("message").getAsString();
+        assert responseMessage.equals(message);
+        
+        // Publish a message again
+        vantiq.publish("sources", testSourceName, sendToQueueParams);
+        
+        // Querying the source with a negative timeout value
+        queryParams.put("timeout", -1000);
+        queryResponse = vantiq.query(testSourceName, queryParams);
+        
+        // Should query successfully
+        assert !queryResponse.hasErrors();
+        responseBody = (JsonObject) queryResponse.getBody();
+        responseMessage = (String) responseBody.get("message").getAsString();
+        assert responseMessage.equals(message);
+        
+        // Publish a message again
+        vantiq.publish("sources", testSourceName, sendToQueueParams);
+        
+        // Querying the source with a valid timeout
+        queryParams.put("timeout", 1000);
+        queryResponse = vantiq.query(testSourceName, queryParams);
+        
+        // Should query successfully
+        assert !queryResponse.hasErrors();
+        responseBody = (JsonObject) queryResponse.getBody();
+        responseMessage = (String) responseBody.get("message").getAsString();
         assert responseMessage.equals(message);
         
         // Delete the Source from VANTIQ

--- a/jmsSource/src/test/java/io/vantiq/extsrc/jmsSource/TestJMS.java
+++ b/jmsSource/src/test/java/io/vantiq/extsrc/jmsSource/TestJMS.java
@@ -361,6 +361,16 @@ public class TestJMS extends TestJMSBase {
         responseMessage = (String) responseBody.get("message").getAsString();
         assert responseMessage.equals(message);
         
+        // Querying the source without publishing again, and with a timeout of 0
+        queryParams.put("timeout", 0);
+        queryResponse = vantiq.query(testSourceName, queryParams);
+        
+        // Should query successfully, without waiting indefinitely
+        assert !queryResponse.hasErrors();
+        responseBody = (JsonObject) queryResponse.getBody();
+        JsonElement responseMessageElement = responseBody.get("message");
+        assertTrue(responseMessageElement.isJsonNull());
+
         // Delete the Source from VANTIQ
         deleteSource();
         core.stop();  


### PR DESCRIPTION
Closes Issue #152 

Changed the default behavior of SELECTING from the VANTIQ Source to use the `consumer.receiveNoWait()` method. If no `timeout` parameter is specified in the SELECT statement, or if the value is invalid, (not a non-negative integer), then the new default behavior will be used. However, if a valid `timeout` is specified, then it will be used.