### PR TITLE
Naf jdbc #158

### DIFF
--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
@@ -30,8 +30,6 @@ import io.vantiq.extsrc.jdbcSource.exception.VantiqSQLException;
 public class JDBC {
     Logger              log  = LoggerFactory.getLogger(this.getClass().getCanonicalName());
     private Connection  conn = null;
-    private Statement   stmt = null;
-    private ResultSet   rs   = null;    
     
     // Used to reconnect if necessary
     private String dbURL;
@@ -81,8 +79,6 @@ public class JDBC {
         HashMap[] rsArray = null;
         try (Statement stmt = conn.createStatement();
             ResultSet rs = stmt.executeQuery(sqlQuery)) {
-            this.stmt = stmt;
-            this.rs = rs;
             rsArray = createMapFromResults(rs);           
         } catch (SQLException e) {
             // Handle errors for JDBC
@@ -103,7 +99,6 @@ public class JDBC {
         
         int publishSuccess = -1;
         try (Statement stmt = conn.createStatement()) {
-            this.stmt = stmt;
             publishSuccess = stmt.executeUpdate(sqlQuery);
         } catch (SQLException e) {
             // Handle errors for JDBC
@@ -204,44 +199,9 @@ public class JDBC {
     }
     
     /**
-     * Calls the close functions for the SQL ResultSet, Statement, and Connection.
-     */
-    public void close() {
-        closeResultSet();
-        closeStatement();
-        closeConnection();
-    }
-    
-    /**
-     * Closes the SQL ResultSet.
-     */
-    public void closeResultSet() {
-        try {
-            if (rs!=null) {
-                rs.close();
-            }
-        } catch(SQLException e) {
-            log.error("A error occurred when closing the ResultSet: ", e);
-        }
-    }
-    
-    /**
-     * Closes the SQL Statement.
-     */
-    public void closeStatement() {
-        try {
-            if (stmt!=null) {
-                stmt.close();
-            }
-        } catch(SQLException e) {
-            log.error("A error occurred when closing the Statement: ", e);
-        }
-    }
-    
-    /**
      * Closes the SQL Connection.
      */
-    public void closeConnection() {
+    public void close() {
         try {
             if (conn!=null) {
                 conn.close();

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -93,7 +93,7 @@ public class TestJDBC extends TestJDBCBase {
     static Vantiq vantiq;
     
     @Before
-    public void setup() { 
+    public void setup() {
         jdbc = new JDBC();
         vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
         vantiq.setAccessToken(testAuthToken);

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -78,6 +78,10 @@ public class TestJDBC extends TestJDBCBase {
     static final String DELETE_ROW_NULL_VALUES = "DELETE FROM TestNullValues";
     static final String DROP_TABLE_NULL_VALUES = "DROP TABLE TestNullValues";
     
+    // Queries for checking dropped connection
+    static final String CREATE_TABLE_AFTER_LOST_CONNECTION = "CREATE TABLE NoConnection(id int);";
+    static final String DROP_TABLE_AFTER_LOST_CONNECTION = "DROP TABLE NoConnection;";
+    
     static final String timestampPattern = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}-\\d{4}";
     static final String datePattern = "\\d{4}-\\d{2}-\\d{2}";
     static final String timePattern = "\\d{2}:\\d{2}:\\d{2}.\\d{3}-\\d{4}";
@@ -139,6 +143,13 @@ public class TestJDBC extends TestJDBCBase {
             // Delete fourth table
             try {
                 dropTablesJDBC.processPublish(DROP_TABLE_NULL_VALUES);
+            } catch (VantiqSQLException e) {
+                // Shouldn't throw Exception
+            }
+            
+            // Delete fifth table
+            try {
+                dropTablesJDBC.processPublish(DROP_TABLE_AFTER_LOST_CONNECTION);
             } catch (VantiqSQLException e) {
                 // Shouldn't throw Exception
             }
@@ -507,6 +518,26 @@ public class TestJDBC extends TestJDBCBase {
             assert message.contains("1366");
         }
         
+    }
+    
+    @Test
+    public void testDBReconnect() throws VantiqSQLException {
+        assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword);
+        
+        // Close the connection, and then try to query
+        jdbc.close();
+        
+        // Query should still work, because reconnect will be triggered
+        int publishResult;
+        try {
+            publishResult = jdbc.processPublish(CREATE_TABLE_AFTER_LOST_CONNECTION);
+            assert publishResult == 0;
+        } catch (VantiqSQLException e) {
+            fail("Should not throw an exception");
+        }
+        
+        jdbc.close();
     }
     
     // ================================================= Helper functions =================================================


### PR DESCRIPTION
Closes Issue #158 

Added a `diagnoseConnection` method that checks if the connection is still valid, and tries to reconnect if it is not.

I did not add any tests to check this behavior, since I am not sure how to stop/start the SQL Server from a test. I manually tested this extensively and it works as I expect.

Also removed the global `rs` and `stmt` variables and deleted their close functions. This is because we always create them locally using a "try with resources", which will close the variables once execution is complete (in the same way that a `finally` block would).