### PR TITLE
Naf obj pre crop

### DIFF
--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -168,11 +168,11 @@ The Configuration document may look similar to the following example:
              "savedResolution": {
                 "longEdge": 400
              },
-             "preCrop": {
+             "cropBeforeAnalysis": {
                 "x": 50,
                 "y": 100,
-                "w": 600,
-                "h": 400
+                "width": 600,
+                "height": 400
              }
           }
        }
@@ -221,12 +221,12 @@ configuration options](#yoloNet). The ones that are the same across all implemen
 *   threshold: Optional. Threshold is used to decide if the Neural Net's result is a valid one, by comparing the resulting confidence of the recognition against the threshold value. A high threshold will lead to fewer results, all with a higher confidence. A low threshold will lead to more results, some of which having a lower confidence. Threshold defaults to 0.5 if not specified, or if invalid. There are two ways to specify this value:
     1.  The value can be a number between 0 and 1 (i.e. 0.4, or 0.2, etc...)
     2.  The value can be a number between 0 and 100 (i.e. 40, or 20, etc...)
-*   preCrop: Optional. Used to crop the retrieved images before they are processed by the Neural Net. This option *must* 
-contain the following values:
+*   cropBeforeAnalysis: Optional. Used to crop the retrieved images before they are processed by the Neural Net. This option 
+*must* contain the following values:
     *   **x**: The top left x-coordinate used to crop the image.
     *   **y**: The top left y-coordinate used to crop the image.
-    *   **w**: The width of the cropped image, (starting at the x-coordinate specified above).
-    *   **h**: The height of the cropped image, (starting at the y-coordinate specified above).
+    *   **width**: The width of the cropped image, (starting at the x-coordinate specified above).
+    *   **height**: The height of the cropped image, (starting at the y-coordinate specified above).
 *   saveImage: Optional. The value can be one of the following three options:
     1.  "local"     - This will save images to the disk (outputDir must be specified in order for this to work).
     2.  "vantiq"    - This will save images as documents in VANTIQ. No images will be saved locally even if outputDir is specified.
@@ -344,8 +344,9 @@ it will be set to the default value, "processNextFrame".
         *   "NNoutputDir": Optional. This value can be set exactly like the "outputDir" value in the source configuration.
         *   "NNfileName": Optional. A string representing the unique name used to save the file. If not specified, the file 
         will be named using the standard <yyyy-MM-dd--HH-mm-ss.jpg> value.
-        *   "preCrop": Optional. This value can be set exactly like the "preCrop" value in the source configuration. If no 
-        preCrop value is set as a query parameter, the source configuration's preCrop value will be used.
+        *   "cropBeforeAnalysis": Optional. This value can be set exactly like the "cropBeforeAnalysis" value in the source 
+        configuration. If no cropBeforeAnalysis value is set as a query parameter, the source configuration's 
+        cropBeforeAnalysis value will be used.
     
 **EXAMPLE QUERIES**:
 
@@ -401,11 +402,11 @@ SELECT * FROM SOURCE Camera1 AS results WITH
     	NNsaveImage:"local",
     	NNoutputDir:"testDir",
     	NNfileName:"testFile",
-        preCrop: {
+        cropBeforeAnalysis: {
             x: 50,
             y: 100,
-            w: 600,
-            h: 400
+            width: 600,
+            height: 400
         }
 ```
 

--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -167,6 +167,12 @@ The Configuration document may look similar to the following example:
              "outputDir": "imageOut",
              "savedResolution": {
                 "longEdge": 400
+             },
+             "preCrop": {
+                "x": 50,
+                "y": 100,
+                "w": 600,
+                "h": 400
              }
           }
        }
@@ -215,6 +221,12 @@ configuration options](#yoloNet). The ones that are the same across all implemen
 *   threshold: Optional. Threshold is used to decide if the Neural Net's result is a valid one, by comparing the resulting confidence of the recognition against the threshold value. A high threshold will lead to fewer results, all with a higher confidence. A low threshold will lead to more results, some of which having a lower confidence. Threshold defaults to 0.5 if not specified, or if invalid. There are two ways to specify this value:
     1.  The value can be a number between 0 and 1 (i.e. 0.4, or 0.2, etc...)
     2.  The value can be a number between 0 and 100 (i.e. 40, or 20, etc...)
+*   preCrop: Optional. Used to crop the retrieved images before they are processed by the Neural Net. This option *must* 
+contain the following values:
+    *   **x**: The top left x-coordinate used to crop the image.
+    *   **y**: The top left y-coordinate used to crop the image.
+    *   **w**: The width of the cropped image, (starting at the x-coordinate specified above).
+    *   **h**: The height of the cropped image, (starting at the y-coordinate specified above).
 *   saveImage: Optional. The value can be one of the following three options:
     1.  "local"     - This will save images to the disk (outputDir must be specified in order for this to work).
     2.  "vantiq"    - This will save images as documents in VANTIQ. No images will be saved locally even if outputDir is specified.
@@ -332,6 +344,8 @@ it will be set to the default value, "processNextFrame".
         *   "NNoutputDir": Optional. This value can be set exactly like the "outputDir" value in the source configuration.
         *   "NNfileName": Optional. A string representing the unique name used to save the file. If not specified, the file 
         will be named using the standard <yyyy-MM-dd--HH-mm-ss.jpg> value.
+        *   "preCrop": Optional. This value can be set exactly like the "preCrop" value in the source configuration. If no 
+        preCrop value is set as a query parameter, the source configuration's preCrop value will be used.
     
 **EXAMPLE QUERIES**:
 
@@ -378,6 +392,21 @@ SELECT * FROM SOURCE Camera1 AS results WITH
     	NNsaveImage:"local",
     	NNoutputDir:"testDir",
     	NNfileName:"testFile"
+```
+
+*   Process Next Frame Query, with preCrop set:
+```
+SELECT * FROM SOURCE Camera1 AS results WITH
+        operation:"processNextFrame",
+    	NNsaveImage:"local",
+    	NNoutputDir:"testDir",
+    	NNfileName:"testFile",
+        preCrop: {
+            x: 50,
+            y: 100,
+            w: 600,
+            h: 400
+        }
 ```
 
 *   Process Next Frame Query without specifying operation *(not recommended)*:

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/ImageCropper.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/ImageCropper.java
@@ -1,0 +1,52 @@
+package io.vantiq.extsrc.objectRecognition.neuralNet;
+
+import java.awt.image.BufferedImage;
+import java.awt.image.RasterFormatException;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class ImageCropper {
+    
+    Logger log = LoggerFactory.getLogger(this.getClass());
+    
+    /**
+     * A helper method used to crop images before they are run through the YOLO Processor, if specified in the
+     * source configuration or as query parameters. Returns the original image if an exception was caught while
+     * cropping.
+     * @param image     The byte array representation of the captured image
+     * @param x         The top left x coordinate
+     * @param y         The top left y coordinate
+     * @param w         The width of the "sub image"
+     * @param h         The height of the "sub image"
+     * @return          The cropped image resulting from the parameters above
+     */
+    public byte[] cropImage(byte[] image, int x, int y, int w, int h) {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(image);
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();){
+            
+            // Convert byte[] to BufferedImage and crop
+            BufferedImage buffImage = ImageIO.read(bais);
+            BufferedImage croppedImage = buffImage.getSubimage(x, y, w, h);
+            
+            // Convert BufferedImage to byte[] and save it
+            ImageIO.write(croppedImage, "jpg", baos);
+            baos.flush();
+            image = baos.toByteArray();
+        } catch (IOException e) {
+            log.error("An error occured when trying to crop the captured image. Image will not be cropped.");
+        } catch (RasterFormatException e) {
+            log.error("An error occured when trying to crop the captured image. This most likely occured because "
+                    + "the values given for cropping resulted in coordinates outside of the image. Image will not be cropped");
+        } catch (Exception e) {
+            log.error("An unexpected error occured while trying to crop the captured image. Image will not be cropped");
+        }
+        
+        return image;
+    }
+}

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/ImageCropper.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/ImageCropper.java
@@ -16,7 +16,7 @@ public abstract class ImageCropper {
     Logger log = LoggerFactory.getLogger(this.getClass());
     
     /**
-     * A helper method used to crop images before they are run through the YOLO Processor, if specified in the
+     * A helper method used to crop images before they are run through the Neural Net, if specified in the
      * source configuration or as query parameters. Returns the original image if an exception was caught while
      * cropping.
      * @param image     The byte array representation of the captured image

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetUtils.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetUtils.java
@@ -11,7 +11,7 @@ import javax.imageio.ImageIO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class ImageCropper {
+public abstract class NeuralNetUtils {
     
     Logger log = LoggerFactory.getLogger(this.getClass());
     

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -65,7 +65,7 @@ import io.vantiq.client.Vantiq;
  * 
  * No additional data is given.
  */
-public class YoloProcessor extends ImageCropper implements NeuralNetInterface {
+public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface {
     
     Logger log = LoggerFactory.getLogger(this.getClass());
     String pbFile = null;
@@ -91,6 +91,8 @@ public class YoloProcessor extends ImageCropper implements NeuralNetInterface {
     boolean preCropping = false;
     
     ObjectDetector objectDetector = null;
+    
+    private static final String CROP_BEFORE = "cropBeforeAnalysis";
     
     @Override
     public void setupImageProcessing(Map<String, ?> neuralNetConfig, String sourceName, String modelDirectory, String authToken, String server) throws Exception {
@@ -243,8 +245,8 @@ public class YoloProcessor extends ImageCropper implements NeuralNetInterface {
        }
        
        // Checking if pre cropping was specified in config
-       if (neuralNet.get("cropBeforeAnalysis") instanceof Map) {
-           Map preCrop = (Map) neuralNet.get("cropBeforeAnalysis");
+       if (neuralNet.get(CROP_BEFORE) instanceof Map) {
+           Map preCrop = (Map) neuralNet.get(CROP_BEFORE);
            if (preCrop.get("x") instanceof Integer && (Integer) preCrop.get("x") >= 0) {
                x = (Integer) preCrop.get("x");
            }
@@ -338,8 +340,8 @@ public class YoloProcessor extends ImageCropper implements NeuralNetInterface {
         boolean queryCrop = false;
         int x, y, w, h;
         x = y = w = h = -1;
-        if (request.get("cropBeforeAnalysis") instanceof Map) {
-            Map preCrop = (Map) request.get("cropBeforeAnalysis");
+        if (request.get(CROP_BEFORE) instanceof Map) {
+            Map preCrop = (Map) request.get(CROP_BEFORE);
             if (preCrop.get("x") instanceof Integer && (Integer) preCrop.get("x") >= 0) {
                 x = (Integer) preCrop.get("x");
             }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -71,10 +71,16 @@ public class TestYoloProcessor extends NeuralNetTestBase {
     static final int RESIZED_IMAGE_HEIGHT = 75;
     
     // For pre cropping tests
-    static final int TOP_LEFT_X_COORDINATE = 50;
-    static final int TOP_LEFT_Y_COORDINATE = 50;
+    static final int PRECROP_TOP_LEFT_X_COORDINATE = 50;
+    static final int PRECROP_TOP_LEFT_Y_COORDINATE = 50;
     static final int CROPPED_WIDTH = 200;
     static final int CROPPED_HEIGHT = 150;
+    
+    // For pre cropping results test
+    static final int KEYBOARD_TOP_LEFT_X_COORDINATE = 120;
+    static final int KEYBOARD_TOP_LEFT_Y_COORDINATE = 250;
+    static final int KEYBOARD_CROPPED_WIDTH = 230;
+    static final int KEYBOARD_CROPPED_HEIGHT = 125;
 
     static YoloProcessor ypJson;
     static Vantiq vantiq;
@@ -1231,46 +1237,106 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         Map config = new LinkedHashMap<>();
         Map preCrop = new LinkedHashMap<>();
         
-        // The width and height are larger than the original image, should not do any resizing
-        preCrop.put("x", TOP_LEFT_X_COORDINATE);
-        preCrop.put("y", TOP_LEFT_Y_COORDINATE);
-        preCrop.put("w", 1000);
-        preCrop.put("h", 1000);
-
+        // Uninitialized preCrop
         config.put("pbFile", PB_FILE);
         config.put("metaFile", META_FILE);
         config.put("outputDir", OUTPUT_DIR);
         config.put("saveRate", SAVE_RATE);
         config.put("saveImage", "local");
-        config.put("preCrop", preCrop);
+        config.put("cropBeforeAnalysis", preCrop);
+        checkInvalidPreCropping(config);
+        
+        // Only the "x" value
+        preCrop.put("x", PRECROP_TOP_LEFT_X_COORDINATE);
+        config.put("cropBeforeAnalysis", preCrop);
+        checkInvalidPreCropping(config);
+        
+        // Only the "y" value
+        preCrop.remove("x");
+        preCrop.put("y", PRECROP_TOP_LEFT_Y_COORDINATE);
+        config.put("cropBeforeAnalysis", preCrop);
+        checkInvalidPreCropping(config);
+        
+        // Only the "width" value
+        preCrop.remove("y");
+        preCrop.put("width", CROPPED_WIDTH);
+        config.put("cropBeforeAnalysis", preCrop);
+        checkInvalidPreCropping(config);
+        
+        // Only the "height" value
+        preCrop.remove("width");
+        preCrop.put("height", CROPPED_HEIGHT);
+        config.put("cropBeforeAnalysis", preCrop);
+        checkInvalidPreCropping(config);
+        
+        // Only "x" and "y"
+        preCrop.remove("height");
+        preCrop.put("x", PRECROP_TOP_LEFT_X_COORDINATE);
+        preCrop.put("y", PRECROP_TOP_LEFT_Y_COORDINATE);
+        config.put("cropBeforeAnalysis", preCrop);
+        checkInvalidPreCropping(config);
+        
+        // Only "x", "y", and "width"
+        preCrop.put("width", CROPPED_WIDTH);
+        config.put("cropBeforeAnalysis", preCrop);
+        checkInvalidPreCropping(config);
+        
+        // The width and height are larger than the original image, should not do any resizing
+        preCrop.put("x", PRECROP_TOP_LEFT_X_COORDINATE);
+        preCrop.put("y", PRECROP_TOP_LEFT_Y_COORDINATE);
+        preCrop.put("width", 1000);
+        preCrop.put("height", 1000);
+        config.put("cropBeforeAnalysis", preCrop);
+        checkInvalidPreCropping(config);
+        
+        // The width and height are 0, should not do any resizing
+        preCrop.put("width", 0);
+        preCrop.put("height", 0);
+        config.put("cropBeforeAnalysis", preCrop);
         checkInvalidPreCropping(config);
         
         // The coordinates are negative, should not do any resizing
         preCrop.put("x", -1);
         preCrop.put("y", -1);
-        preCrop.put("w", CROPPED_WIDTH);
-        preCrop.put("h", CROPPED_HEIGHT);
-        config.put("preCrop", preCrop); 
+        preCrop.put("width", CROPPED_WIDTH);
+        preCrop.put("height", CROPPED_HEIGHT);
+        config.put("cropBeforeAnalysis", preCrop); 
+        checkInvalidPreCropping(config);
+        
+        // Just x coordinate is negative, should not do any resizing
+        preCrop.put("x", -1);
+        preCrop.put("y", PRECROP_TOP_LEFT_Y_COORDINATE);
+        preCrop.put("width", CROPPED_WIDTH);
+        preCrop.put("height", CROPPED_HEIGHT);
+        config.put("cropBeforeAnalysis", preCrop); 
+        checkInvalidPreCropping(config);
+        
+        // Just y coordinate is negative, should not do any resizing
+        preCrop.put("x", PRECROP_TOP_LEFT_X_COORDINATE);
+        preCrop.put("y", -1);
+        preCrop.put("width", CROPPED_WIDTH);
+        preCrop.put("height", CROPPED_HEIGHT);
+        config.put("cropBeforeAnalysis", preCrop); 
         checkInvalidPreCropping(config);
         
         // Two values are not integers, should not do any resizing
-        preCrop.put("x", TOP_LEFT_X_COORDINATE);
-        preCrop.put("y", TOP_LEFT_Y_COORDINATE);
-        preCrop.put("w", 0.5);
-        preCrop.put("h", 0.5);
-        config.put("preCrop", preCrop);
+        preCrop.put("x", PRECROP_TOP_LEFT_X_COORDINATE);
+        preCrop.put("y", PRECROP_TOP_LEFT_Y_COORDINATE);
+        preCrop.put("width", 0.5);
+        preCrop.put("height", 0.5);
+        config.put("cropBeforeAnalysis", preCrop);
         checkInvalidPreCropping(config);
         
         // A value is not a number, should not do any resizing
-        preCrop.put("x", TOP_LEFT_X_COORDINATE);
-        preCrop.put("y", TOP_LEFT_Y_COORDINATE);
-        preCrop.put("w", "jibberish");
-        preCrop.put("h", CROPPED_HEIGHT);
-        config.put("preCrop", preCrop);
+        preCrop.put("x", PRECROP_TOP_LEFT_X_COORDINATE);
+        preCrop.put("y", PRECROP_TOP_LEFT_Y_COORDINATE);
+        preCrop.put("width", "jibberish");
+        preCrop.put("height", CROPPED_HEIGHT);
+        config.put("cropBeforeAnalysis", preCrop);
         checkInvalidPreCropping(config);
         
-        // The preCrop is not a map which is not allowed, should not do any resizing
-        config.put("preCrop", "jibberish");
+        // The cropBeforeAnalysis is not a map which is not allowed, should not do any resizing
+        config.put("cropBeforeAnalysis", "jibberish");
         checkInvalidPreCropping(config);
     }
     
@@ -1324,17 +1390,17 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         Map preCrop = new LinkedHashMap<>();
         YoloProcessor ypImageSaver = new YoloProcessor();
         
-        preCrop.put("x", TOP_LEFT_X_COORDINATE);
-        preCrop.put("y", TOP_LEFT_Y_COORDINATE);
-        preCrop.put("w", CROPPED_WIDTH);
-        preCrop.put("h", CROPPED_HEIGHT);
+        preCrop.put("x", PRECROP_TOP_LEFT_X_COORDINATE);
+        preCrop.put("y", PRECROP_TOP_LEFT_Y_COORDINATE);
+        preCrop.put("width", CROPPED_WIDTH);
+        preCrop.put("height", CROPPED_HEIGHT);
         
         config.put("pbFile", PB_FILE);
         config.put("metaFile", META_FILE);
         config.put("outputDir", OUTPUT_DIR);
         config.put("saveRate", SAVE_RATE);
         config.put("saveImage", "local");
-        config.put("preCrop", preCrop);
+        config.put("cropBeforeAnalysis", preCrop);
         try {
             ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
         } catch (Exception e) {
@@ -1381,17 +1447,17 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         Map preCrop = new LinkedHashMap<>();
         YoloProcessor ypImageSaver = new YoloProcessor();
         
-        preCrop.put("x", TOP_LEFT_X_COORDINATE);
-        preCrop.put("y", TOP_LEFT_Y_COORDINATE);
-        preCrop.put("w", CROPPED_WIDTH);
-        preCrop.put("h", CROPPED_HEIGHT);
+        preCrop.put("x", PRECROP_TOP_LEFT_X_COORDINATE);
+        preCrop.put("y", PRECROP_TOP_LEFT_Y_COORDINATE);
+        preCrop.put("width", CROPPED_WIDTH);
+        preCrop.put("height", CROPPED_HEIGHT);
 
         config.put("pbFile", PB_FILE);
         config.put("metaFile", META_FILE);
         config.put("outputDir", OUTPUT_DIR);
         config.put("saveRate", SAVE_RATE);
         config.put("saveImage", "vantiq");
-        config.put("preCrop", preCrop);
+        config.put("cropBeforeAnalysis", preCrop);
         try {
             ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
         } catch (Exception e) {
@@ -1446,17 +1512,17 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         Map preCrop = new LinkedHashMap<>();
         YoloProcessor ypImageSaver = new YoloProcessor();
         
-        preCrop.put("x", TOP_LEFT_X_COORDINATE);
-        preCrop.put("y", TOP_LEFT_Y_COORDINATE);
-        preCrop.put("w", CROPPED_WIDTH);
-        preCrop.put("h", CROPPED_HEIGHT);
+        preCrop.put("x", PRECROP_TOP_LEFT_X_COORDINATE);
+        preCrop.put("y", PRECROP_TOP_LEFT_Y_COORDINATE);
+        preCrop.put("width", CROPPED_WIDTH);
+        preCrop.put("height", CROPPED_HEIGHT);
 
         config.put("pbFile", PB_FILE);
         config.put("metaFile", META_FILE);
         config.put("outputDir", OUTPUT_DIR);
         config.put("saveRate", SAVE_RATE);
         config.put("saveImage", "both");
-        config.put("preCrop", preCrop);
+        config.put("cropBeforeAnalysis", preCrop);
         try {
             ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
         } catch (Exception e) {
@@ -1533,10 +1599,10 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         Map savedResolution = new LinkedHashMap<>();
         YoloProcessor ypImageSaver = new YoloProcessor();
         
-        preCrop.put("x", TOP_LEFT_X_COORDINATE);
-        preCrop.put("y", TOP_LEFT_Y_COORDINATE);
-        preCrop.put("w", CROPPED_WIDTH);
-        preCrop.put("h", CROPPED_HEIGHT);
+        preCrop.put("x", PRECROP_TOP_LEFT_X_COORDINATE);
+        preCrop.put("y", PRECROP_TOP_LEFT_Y_COORDINATE);
+        preCrop.put("width", CROPPED_WIDTH);
+        preCrop.put("height", CROPPED_HEIGHT);
         
         savedResolution.put("longEdge", RESIZED_IMAGE_WIDTH);
         
@@ -1545,7 +1611,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         config.put("outputDir", OUTPUT_DIR);
         config.put("saveRate", SAVE_RATE);
         config.put("saveImage", "local");
-        config.put("preCrop", preCrop);
+        config.put("cropBeforeAnalysis", preCrop);
         config.put("savedResolution", savedResolution);
         try {
             ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
@@ -1595,10 +1661,10 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         Map savedResolution = new LinkedHashMap<>();
         YoloProcessor ypImageSaver = new YoloProcessor();
         
-        preCrop.put("x", TOP_LEFT_X_COORDINATE);
-        preCrop.put("y", TOP_LEFT_Y_COORDINATE);
-        preCrop.put("w", CROPPED_WIDTH);
-        preCrop.put("h", CROPPED_HEIGHT);
+        preCrop.put("x", PRECROP_TOP_LEFT_X_COORDINATE);
+        preCrop.put("y", PRECROP_TOP_LEFT_Y_COORDINATE);
+        preCrop.put("width", CROPPED_WIDTH);
+        preCrop.put("height", CROPPED_HEIGHT);
         
         // This value is larger than the pre-cropped image size
         savedResolution.put("longEdge", 400);
@@ -1608,7 +1674,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         config.put("outputDir", OUTPUT_DIR);
         config.put("saveRate", SAVE_RATE);
         config.put("saveImage", "local");
-        config.put("preCrop", preCrop);
+        config.put("cropBeforeAnalysis", preCrop);
         config.put("savedResolution", savedResolution);
         try {
             ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
@@ -1647,7 +1713,37 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             ypImageSaver.close();
         }
     }
- 
+    
+    @Test
+    public void testPreCroppingResults() {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+
+        Map config = new LinkedHashMap<>();
+        Map preCrop = new LinkedHashMap<>();
+        YoloProcessor ypImageSaver = new YoloProcessor();
+        
+        preCrop.put("x", KEYBOARD_TOP_LEFT_X_COORDINATE);
+        preCrop.put("y", KEYBOARD_TOP_LEFT_Y_COORDINATE);
+        preCrop.put("width", KEYBOARD_CROPPED_WIDTH);
+        preCrop.put("height", KEYBOARD_CROPPED_HEIGHT);
+
+        config.put("pbFile", PB_FILE);
+        config.put("metaFile", META_FILE);
+        config.put("cropBeforeAnalysis", preCrop);
+
+        // Config with meta file, label file, pb file, and anchors
+        try {
+            ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
+            verifyProcessing(ypImageSaver, croppedImageResultsAsString);
+        } catch (Exception e) {
+            fail("Should not fail with valid config.");
+        } finally {
+            if (ypImageSaver != null) {
+                ypImageSaver.close();
+            }
+        }
+    }
     // ================================================= Helper functions =================================================
     String imageResultsAsString = "[{\"confidence\":0.8445639, \"location\":{\"top\":255.70024, \"left\":121.859344, \"bottom\":372.2343, "
             + "\"right\":350.1204}, \"label\":\"keyboard\"}, {\"confidence\":0.7974271, \"location\":{\"top\":91.255974, \"left\":164.41359, "
@@ -1656,7 +1752,10 @@ public class TestYoloProcessor extends NeuralNetTestBase {
     String imageResultsAsString608 = "[{\"confidence\":0.8672237, \"location\":{\"top\":93.55155, \"left\":157.38762, \"bottom\":280.36542, "
             + "\"right\":345.06442}, \"label\":\"tvmonitor\"}, {\"confidence\":0.7927524, \"location\":{\"top\":263.62683, \"left\":123.48807, "
             + "\"bottom\":371.69046, \"right\":331.86023}, \"label\":\"keyboard\"}]";
-
+    
+    String croppedImageResultsAsString = "[{\"confidence\":0.91599655, \"location\":{\"top\":8.16388, \"left\":1.0525968, \"bottom\":118.984344, " 
+            +"\"right\":217.2165}, \"label\":\"keyboard\"}]";
+    
     String neuralNetJSON1 =
             "{"
                     + "     \"neuralNet\":"

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -77,8 +77,8 @@ public class TestYoloProcessor extends NeuralNetTestBase {
     static final int CROPPED_HEIGHT = 150;
     
     // For pre cropping results test
-    static final int KEYBOARD_TOP_LEFT_X_COORDINATE = 120;
-    static final int KEYBOARD_TOP_LEFT_Y_COORDINATE = 250;
+    static final int PRECROP_KEYBOARD_TOP_LEFT_X_COORDINATE = 120;
+    static final int PRECROP_KEYBOARD_TOP_LEFT_Y_COORDINATE = 250;
     static final int KEYBOARD_CROPPED_WIDTH = 230;
     static final int KEYBOARD_CROPPED_HEIGHT = 125;
 
@@ -1723,8 +1723,8 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         Map preCrop = new LinkedHashMap<>();
         YoloProcessor ypImageSaver = new YoloProcessor();
         
-        preCrop.put("x", KEYBOARD_TOP_LEFT_X_COORDINATE);
-        preCrop.put("y", KEYBOARD_TOP_LEFT_Y_COORDINATE);
+        preCrop.put("x", PRECROP_KEYBOARD_TOP_LEFT_X_COORDINATE);
+        preCrop.put("y", PRECROP_KEYBOARD_TOP_LEFT_Y_COORDINATE);
         preCrop.put("width", KEYBOARD_CROPPED_WIDTH);
         preCrop.put("height", KEYBOARD_CROPPED_HEIGHT);
 

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -1217,7 +1217,17 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         }
 
     }
-
+    
+    @Test
+    public void testInvalidPreCropping() {
+        
+    }
+    
+    @Test
+    public void testPreCropping() {
+        
+    }
+ 
     // ================================================= Helper functions =================================================
     String imageResultsAsString = "[{\"confidence\":0.8445639, \"location\":{\"top\":255.70024, \"left\":121.859344, \"bottom\":372.2343, "
             + "\"right\":350.1204}, \"label\":\"keyboard\"}, {\"confidence\":0.7974271, \"location\":{\"top\":91.255974, \"left\":164.41359, "

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -97,8 +97,8 @@ public class TestYoloQueries extends NeuralNetTestBase {
     static final int RESIZED_IMAGE_HEIGHT = 75;
     
     // For pre cropping tests
-    static final int TOP_LEFT_X_COORDINATE = 50;
-    static final int TOP_LEFT_Y_COORDINATE = 50;
+    static final int PRECROP_TOP_LEFT_X_COORDINATE = 50;
+    static final int PRECROP_TOP_LEFT_Y_COORDINATE = 50;
     static final int CROPPED_WIDTH = 200;
     static final int CROPPED_HEIGHT = 150;
     static final int IP_CAMERA_WIDTH = 800;
@@ -772,8 +772,8 @@ public class TestYoloQueries extends NeuralNetTestBase {
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         Map<String, Object> preCrop = new LinkedHashMap<>();
         
-        preCrop.put("x", TOP_LEFT_X_COORDINATE);
-        preCrop.put("y", TOP_LEFT_Y_COORDINATE);
+        preCrop.put("x", PRECROP_TOP_LEFT_X_COORDINATE);
+        preCrop.put("y", PRECROP_TOP_LEFT_Y_COORDINATE);
         preCrop.put("width", CROPPED_WIDTH);
         preCrop.put("height", CROPPED_HEIGHT);
         

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -735,7 +735,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         
         // Invalid preCrop, it isn't a map
-        params.put("preCrop", "jibberish");
+        params.put("cropBeforeAnalysis", "jibberish");
         
         // Run query without setting "operation":"processNextFrame"
         params.put("NNsaveImage", "local");
@@ -774,10 +774,10 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         preCrop.put("x", TOP_LEFT_X_COORDINATE);
         preCrop.put("y", TOP_LEFT_Y_COORDINATE);
-        preCrop.put("w", CROPPED_WIDTH);
-        preCrop.put("h", CROPPED_HEIGHT);
+        preCrop.put("width", CROPPED_WIDTH);
+        preCrop.put("height", CROPPED_HEIGHT);
         
-        params.put("preCrop", preCrop);
+        params.put("cropBeforeAnalysis", preCrop);
         
         // Run query without setting "operation":"processNextFrame"
         params.put("NNsaveImage", "local");


### PR DESCRIPTION
Closes Issue #151 

Using the VANTIQ Source configuration, a user can "pre crop" all images before they are processed. "preCrop" values can be specified in query parameters as well, which will override those specified in the source configuration. Otherwise, the source config values will be used.

Edit: Updated the README to describe this new feature.