### PR TITLE
Naf jdbc message size

### DIFF
--- a/jdbcSource/README.md
+++ b/jdbcSource/README.md
@@ -149,14 +149,19 @@ will be sent as a unique Notification.
 
 In order to interact with the JDBC Source, one option is to use VAIL to select from the source. To do this, you will need 
 to specify the SQL Query you wish to execute against your database as part of the WITH clause. The SQL Queries used here must 
-only be **SELECT STATEMENTS**. The data will be returned as an array of the resulting rows. A query parameter named 
-`bundleFactor` can be used to specify how many rows of data a given message will contain. This parameter is useful when 
-querying a very large number of rows, where the data is likely to exceed the maximum message size allowed by the VANTIQ 
-System. Specifying this parameter as part of the WITH clause allows the connector to stream the data using multiple messages, 
-each containing `bundleFactor` number of rows. If no `bundleFactor` is specified, then the default value of 1000 will be used. 
-If a `bundleFactor` of 0 is specified, then the connector will attempt to send all of the queried rows in a single message, 
-(**NOTE**: this can likely cause errors if the combined data exceeds the maximum message size). The following is an example of 
-a Procedure created in VANTIQ Modelo querying against a JDBC Source.
+only be **SELECT STATEMENTS**. The data will be returned to VANTIQ as a set of messages, where each message contains some 
+number of rows.
+
+A query parameter named `bundleFactor` determines how many rows are bundled into each message. Generally, the default value of 
+500 will be fine. However, in cases where rows may be very large, a smaller value may be required.
+
+The `bundleFactor` parameter is specified in the `WITH` clause, allowing each query to adjust as appropriate. If the parameter 
+is not specified, the default value (500) is used -- that will be fine for most cases. If a value of `0` is provided, then all 
+rows will be placed into a single message (the use of this is discouraged as it may cause problems). If the value is positive 
+(and non-zero), then that many rows will be sent at a time.
+
+From the perspective of consuming the rows, there is no visible difference here. The `bundleFactor` parameter is present to 
+allow control when returning very large rows.
 
 ```
 PROCEDURE queryJDBC()

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
@@ -278,7 +278,7 @@ public class JDBCCore {
     */
    public void sendDataFromQuery(HashMap[] queryArray, ExtensionServiceMessage message) {
        String replyAddress = ExtensionServiceMessage.extractReplyAddress(message);
-              
+       
        // Send the results of the query
        if (queryArray.length == 0) {
            // If data is empty send empty map with 204 code

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
@@ -299,23 +299,16 @@ public class JDBCCore {
        } else {
            // Otherwise, send messages containing 'bundleFactor' number of rows
            int len = queryArray.length;
-           
-           for (int i = 0; i < len - bundleFactor + 1; i += bundleFactor) {
-               HashMap[] rowBundle = Arrays.copyOfRange(queryArray, i, i + bundleFactor);
-               // If we have bundled the last rows, then send with code 200
-               if (i == len - bundleFactor) {
+           for (int i = 0; i < len; i += bundleFactor) {
+               HashMap[] rowBundle = Arrays.copyOfRange(queryArray, i, Math.min(queryArray.length, i+bundleFactor));
+               
+               // If we reached the last row, send with 200 code
+               if  (i + bundleFactor >= len) {
                    client.sendQueryResponse(200, replyAddress, rowBundle);
-               // Otherwise, send with code 100 signifying more data to come    
                } else {
+                   // Otherwise, send row with 100 code signifying more data to come 
                    client.sendQueryResponse(100, replyAddress, rowBundle);
                }
-               lastRowBundle = rowBundle;
-           }
-           
-           // Check for remainder and send if necessary
-           if (len % bundleFactor != 0) {
-               HashMap[] rowBundle = Arrays.copyOfRange(queryArray, len - len % bundleFactor, len);
-               client.sendQueryResponse(200, replyAddress, rowBundle);
                lastRowBundle = rowBundle;
            }
        }

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
@@ -278,13 +278,21 @@ public class JDBCCore {
     */
    public void sendDataFromQuery(HashMap[] queryArray, ExtensionServiceMessage message) {
        String replyAddress = ExtensionServiceMessage.extractReplyAddress(message);
-       
+              
        // Send the results of the query
        if (queryArray.length == 0) {
            // If data is empty send empty map with 204 code
            client.sendQueryResponse(204, replyAddress, new LinkedHashMap<>());
        } else {
-           client.sendQueryResponse(200, replyAddress, queryArray);
+           for (int i = 0; i < queryArray.length; i++) {
+               // If last row, send a 200 code
+               if (i == queryArray.length - 1) {
+                   client.sendQueryResponse(200, replyAddress, queryArray[i]);
+               } else {
+                   // Otherwise, send row with 100 code signifying more data to come
+                   client.sendQueryResponse(100, replyAddress, queryArray[i]);
+               }
+           }
        }
    }
    

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -82,6 +82,14 @@ public class TestJDBC extends TestJDBCBase {
     static final String CREATE_TABLE_AFTER_LOST_CONNECTION = "CREATE TABLE NoConnection(id int);";
     static final String DROP_TABLE_AFTER_LOST_CONNECTION = "DROP TABLE NoConnection;";
     
+    // Queries for max message size test
+    static final String CREATE_TABLE_MAX_MESSAGE_SIZE = "CREATE TABLE TestMessageSize(id int, first varchar (255), last varchar (255), "
+            + "age int, title varchar (255), is_active varchar (255), department varchar (255), salary int);";
+    static final String INSERT_ROW_MAX_MESSAGE_SIZE = "INSERT INTO TestMessageSize VALUES(1, 'First', 'Last', 30, 'Title', 'Active',"
+            + " 'Department', 1000000);";
+    static final String QUERY_TABLE_MAX_MESSAGE_SIZE = "SELECT * FROM TestMessageSize;";
+    static final String DROP_TABLE_MAX_MESSAGE_SIZE = "DROP TABLE TestMessageSize";
+    
     static final String timestampPattern = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}-\\d{4}";
     static final String datePattern = "\\d{4}-\\d{2}-\\d{2}";
     static final String timePattern = "\\d{2}:\\d{2}:\\d{2}.\\d{3}-\\d{4}";
@@ -150,6 +158,13 @@ public class TestJDBC extends TestJDBCBase {
             // Delete fifth table
             try {
                 dropTablesJDBC.processPublish(DROP_TABLE_AFTER_LOST_CONNECTION);
+            } catch (VantiqSQLException e) {
+                // Shouldn't throw Exception
+            }
+            
+            // Delete sixth table
+            try {
+                dropTablesJDBC.processPublish(DROP_TABLE_MAX_MESSAGE_SIZE);
             } catch (VantiqSQLException e) {
                 // Shouldn't throw Exception
             }
@@ -538,6 +553,43 @@ public class TestJDBC extends TestJDBCBase {
         }
         
         jdbc.close();
+    }
+    
+    @Test
+    public void testMaxMessageSize() throws VantiqSQLException {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+        assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
+        
+        // Check that Source does not already exist in namespace, and skip test if it does
+        assumeFalse(checkSourceExists());
+        
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword);
+        
+        // Setup a VANTIQ JDBC Source, and start running the core
+        setupSource(createSourceDef());
+        
+        // Publish to the source in order to create a table
+        Map<String,Object> create_params = new LinkedHashMap<String,Object>();
+        create_params.put("query", CREATE_TABLE_MAX_MESSAGE_SIZE);
+        vantiq.publish("sources", testSourceName, create_params);
+        
+        // Insert 2000 rows into the the table
+        Map<String,Object> insert_params = new LinkedHashMap<String,Object>();
+        for (int i = 0; i < 2000; i ++) {
+            insert_params.put("query", INSERT_ROW_MAX_MESSAGE_SIZE);
+            vantiq.publish("sources", testSourceName, insert_params);
+        }
+        
+        // Query the Source and make sure there were no errors
+        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        params.put("query", QUERY_TABLE_MAX_MESSAGE_SIZE);
+        VantiqResponse response = vantiq.query(testSourceName, params);
+        JsonArray responseBody = (JsonArray) response.getBody();
+        assert responseBody.size() == 2000;
+
+        // Delete the Source from VANTIQ
+        deleteSource();
     }
     
     // ================================================= Helper functions =================================================


### PR DESCRIPTION
Fixes Issue #163 

Changed the JDBC Connector to send messages row by row, so we should never run into the issue of exceeding the maximum message size. Added a test to ensure that this works as expected.