### PR TITLE
Naf jdbc performance #167

### DIFF
--- a/jdbcSource/LICENSE/HikariCP-license.txt
+++ b/jdbcSource/LICENSE/HikariCP-license.txt
@@ -1,0 +1,203 @@
+
+
+                                     Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+     
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+     
+       1. Definitions.
+     
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+     
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+     
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+     
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+     
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+     
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+     
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+     
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+     
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+     
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+     
+       2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+     
+       3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+     
+       4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+     
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+     
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+     
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+     
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+     
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+     
+       5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+     
+       6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+     
+       7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+     
+       8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+     
+       9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+     
+       END OF TERMS AND CONDITIONS
+     
+       APPENDIX: How to apply the Apache License to your work.
+     
+          To apply the Apache License to your work, attach the following
+          boilerplate notice, with the fields enclosed by brackets "[]"
+          replaced with your own identifying information. (Don't include
+          the brackets!)  The text should be enclosed in the appropriate
+          comment syntax for the file format. We also recommend that a
+          file or class name and description of purpose be included on the
+          same "printed page" as the copyright notice for easier
+          identification within third-party archives.
+     
+       Copyright [yyyy] [name of copyright owner]
+     
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+     
+           http://www.apache.org/licenses/LICENSE-2.0
+     
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.

--- a/jdbcSource/README.md
+++ b/jdbcSource/README.md
@@ -89,8 +89,11 @@ The Configuration document may look similar to the following example:
           "general": {
              "username": "sqlUsername",
              "password": "sqlPassword",
-             "dbURL": "jdbc:mysql://localhost/myDB?useSSL=false&serverTimezone=UTC"
-             "pollTime": 3000
+             "dbURL": "jdbc:mysql://localhost/myDB?useSSL=false&serverTimezone=UTC",
+             "asynchronousProcessing": true,
+             "maxRunningThreads": 10,
+             "maxQueuedTasks" 20,
+             "pollTime": 3000,
              "pollQuery": "SELECT * FROM myTable"
           }
        }
@@ -104,6 +107,12 @@ The Configuration document may look similar to the following example:
 *   **username**: Required. This is the username that will be used to connect to the SQL Database.
 *   **password**: Required. This is the password that will be used to connect to the SQL Database.
 *   **dbURL**: Required. This is the URL corresponding to the SQL Database that you will connect to.
+*   **asynchronousProcessing**: Optional. If set to `true`, query and publish requests will be handled asynchronously, as 
+opposed to the default behavior which is synchronous.
+*   **maxRunningThreads**: Optional. Only used if `asynchronousProcessing` is set to `true`. The maximum number of threads 
+running at any given point for query or publish requests, respectively. Must be a non-zero integer.
+*   **maxQueuedTasks**: Optional. Only used if `asynchronousProcessing` is set to `true`. The maximum number of queued 
+tasks at any given point for query or publish requests, respectively. Must be a non-zero integer.
 *   **pollTime**: Optional. If specified, you must specify the pollQuery as well. This option allows you to specify a polling 
     rate indicating the frequency (in milliseconds) at which the pollQuery will be executed. The value must be a positive
     number greater than 0, (*i.e.* 3000 --> executing every 3 seconds).
@@ -261,14 +270,13 @@ SQLException, and contains the Error Message, SQL State, and Error Code from the
 In order to properly run the tests, you must create an environment variable named **JDBC\_DRIVER\_LOC** which points to the 
 appropriate JDBC Driver .jar file.
 
- Additionally, you must add properties to your _gradle.properties_ file 
-in the _~/.gradle_ directory. 
-These properties include the JDBC Database username, password, and URL.
-You must also add the Target VANTIQ Server URL, as well as an 
-Authentication Token for that server. The Target VANTIQ Server and Auth Token will be used to create a temporary VANTIQ 
-Source and Type, named _testSourceName_ and _testTypeName_ respectively. These names can optionally be configured by adding 
-`EntConTestSourceName` and `EntConTestTypeName` to the gradle.properties file. The following shows what the gradle.properties file 
-should look like:
+Additionally, you must add properties to your _gradle.properties_ file in the _~/.gradle_ directory. These properties include 
+the JDBC Database username, password, and URL. You must also add the Target VANTIQ Server URL, as well as an Authentication 
+Token for that server. The Target VANTIQ Server and Auth Token will be used to create a temporary VANTIQ Source, VANTIQ Type, 
+VANTIQ Topic, VANTIQ Procedure and VANTIQ Rule. They will be named _testSourceName_, _testTypeName_, _testTopicName_, 
+_testProcedureName_ and _testRuleName_ respectively. These names can optionally be configured by adding 
+`EntConTestSourceName`, `EntConTestTypeName`, `EntConTestTopicName`, `EntConTestProcedureName` and `EntConTestRuleName` to the 
+gradle.properties file. The following shows what the gradle.properties file should look like:
 
 ```
     EntConJDBCUsername=<yourUsername>
@@ -278,6 +286,9 @@ should look like:
     TestAuthToken=<yourAuthToken>
     EntConTestSourceName=<yourDesiredSourceName>
     EntConTestTypeName=<yourDesiredTypeName>
+    EntConTestTopicName=<yourDesiredTopicName>
+    EntConTestProcedureName=<yourDesiredProcedureName>
+    EntConTestRuleName=<yourDesiredRuleName>
 ```
 
 * **NOTE:** We strongly encourage users to create a unique VANTIQ Namespace in order to ensure that tests do not accidentally 

--- a/jdbcSource/README.md
+++ b/jdbcSource/README.md
@@ -110,9 +110,9 @@ The Configuration document may look similar to the following example:
 *   **asynchronousProcessing**: Optional. If set to `true`, query and publish requests will be handled asynchronously, as 
 opposed to the default behavior which is synchronous.
 *   **maxRunningThreads**: Optional. Only used if `asynchronousProcessing` is set to `true`. The maximum number of threads 
-running at any given point for query or publish requests, respectively. Must be a non-zero integer.
+running at any given point for query or publish requests, respectively. Must be a non-zero integer. Default value is 5.
 *   **maxQueuedTasks**: Optional. Only used if `asynchronousProcessing` is set to `true`. The maximum number of queued 
-tasks at any given point for query or publish requests, respectively. Must be a non-zero integer.
+tasks at any given point for query or publish requests, respectively. Must be a non-zero integer. Default value is 10.
 *   **pollTime**: Optional. If specified, you must specify the pollQuery as well. This option allows you to specify a polling 
     rate indicating the frequency (in milliseconds) at which the pollQuery will be executed. The value must be a positive
     number greater than 0, (*i.e.* 3000 --> executing every 3 seconds).

--- a/jdbcSource/README.md
+++ b/jdbcSource/README.md
@@ -91,7 +91,7 @@ The Configuration document may look similar to the following example:
              "password": "sqlPassword",
              "dbURL": "jdbc:mysql://localhost/myDB?useSSL=false&serverTimezone=UTC",
              "asynchronousProcessing": true,
-             "maxRunningThreads": 10,
+             "maxActiveTasks": 10,
              "maxQueuedTasks" 20,
              "pollTime": 3000,
              "pollQuery": "SELECT * FROM myTable"
@@ -109,10 +109,10 @@ The Configuration document may look similar to the following example:
 *   **dbURL**: Required. This is the URL corresponding to the SQL Database that you will connect to.
 *   **asynchronousProcessing**: Optional. If set to `true`, query and publish requests will be handled asynchronously, as 
 opposed to the default behavior which is synchronous.
-*   **maxRunningThreads**: Optional. Only used if `asynchronousProcessing` is set to `true`. The maximum number of threads 
-running at any given point for query or publish requests, respectively. Must be a non-zero integer. Default value is 5.
+*   **maxActiveTasks**: Optional. Only used if `asynchronousProcessing` is set to `true`. The maximum number of threads 
+running at any given point for query or publish requests, respectively. Must be a positive integer. Default value is 5.
 *   **maxQueuedTasks**: Optional. Only used if `asynchronousProcessing` is set to `true`. The maximum number of queued 
-tasks at any given point for query or publish requests, respectively. Must be a non-zero integer. Default value is 10.
+tasks at any given point for query or publish requests, respectively. Must be a positive integer. Default value is 10.
 *   **pollTime**: Optional. If specified, you must specify the pollQuery as well. This option allows you to specify a polling 
     rate indicating the frequency (in milliseconds) at which the pollQuery will be executed. The value must be a positive
     number greater than 0, (*i.e.* 3000 --> executing every 3 seconds).
@@ -297,7 +297,7 @@ override any existing Sources or Types.
 ## Licensing
 The source code uses the [MIT License](https://opensource.org/licenses/MIT).  
 
-okhttp3, log4j, and jackson-databind are licensed under
+HikariCP, okhttp3, log4j, and jackson-databind are licensed under
 [Apache Version 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).  
 
 slf4j is licensed under the [MIT License](https://opensource.org/licenses/MIT).  

--- a/jdbcSource/build.gradle
+++ b/jdbcSource/build.gradle
@@ -80,4 +80,8 @@ dependencies {
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'
     testCompile project(path:":extjsdk", configuration:"testArtifacts")
+
+    // Used to create a connection pool if asynchronous processing has been specified for publish/query handlers
+    compile group: 'com.zaxxer', name: 'HikariCP', version: '3.3.1'
+
 }

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
@@ -259,7 +259,6 @@ public class JDBC {
         try {
             if (conn!=null) {
                 conn.close();
-                conn = null;
             }
         } catch(SQLException e) {
             log.error("A error occurred when closing the Connection: ", e);
@@ -267,7 +266,6 @@ public class JDBC {
         // Close connection pool if open
         if (ds != null) {
             ds.close();
-            ds = null;
         }
     }
 }

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
@@ -61,7 +61,7 @@ public class JDBC {
      * @param username          The username to be used to connect to the SQL Database.
      * @param password          The password to be used to connect to the SQL Database.
      * @param asyncProcessing   A boolean flag specifying if publish/query requests are handled synchronously, or asynchronously.
-     * @param maxPoolSize       An integer representing the maxPoolSize for the Connection Pool. If value is < 1, then use default.
+     * @param maxPoolSize       An integer representing the maxPoolSize for the Connection Pool.
      * @throws VantiqSQLException 
      */
     public void setupJDBC(String dbURL, String username, String password, boolean asyncProcessing, int maxPoolSize) throws VantiqSQLException {
@@ -79,10 +79,8 @@ public class JDBC {
                 ds = new HikariDataSource(connectionPoolConfig);
                 ds.setConnectionTimeout(CONNECTION_POOL_TIMEOUT);
 
-                // Setting max pool size if specified
-                if (maxPoolSize > 0) {
-                    ds.setMaximumPoolSize(maxPoolSize);
-                }
+                // Setting max pool size (should always match number of active threads for publish and query)
+                ds.setMaximumPoolSize(maxPoolSize);
             } else {
                 // Open a single connection
                 conn = DriverManager.getConnection(dbURL,username,password);

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
@@ -337,7 +337,7 @@ public class JDBCCore {
             pollTimer.cancel();
             pollTimer = null;
         }
-        synchronized (this) {
+        synchronized (SYNCH_LOCK) {
             if (jdbc != null) {
                 jdbc.close();
                 jdbc = null;

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCHandleConfiguration.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCHandleConfiguration.java
@@ -226,14 +226,14 @@ public class JDBCHandleConfiguration extends Handler<ExtensionServiceMessage> {
 
             if (generalConfig.get(MAX_ACTIVE) instanceof Integer && (Integer) generalConfig.get(MAX_ACTIVE) > 0) {
                 maxActiveTasks = (Integer) generalConfig.get(MAX_ACTIVE);
-
-                // Used to set the max pool size for connection pool
-                maxPoolSize = 2*maxActiveTasks;
             }
 
             if (generalConfig.get(MAX_QUEUED) instanceof Integer && (Integer) generalConfig.get(MAX_QUEUED) > 0) {
                 maxQueuedTasks = (Integer) generalConfig.get(MAX_QUEUED);
             }
+
+            // Used to set the max pool size for connection pool
+            maxPoolSize = 2*maxActiveTasks;
 
             // Creating the thread pool executors with Queue
             source.queryPool = new ThreadPoolExecutor(maxActiveTasks, maxActiveTasks, 0l, TimeUnit.MILLISECONDS,

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCHandleConfiguration.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCHandleConfiguration.java
@@ -11,6 +11,10 @@ package io.vantiq.extsrc.jdbcSource;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +22,6 @@ import org.slf4j.LoggerFactory;
 import io.vantiq.extjsdk.ExtensionServiceMessage;
 import io.vantiq.extjsdk.ExtensionWebSocketClient;
 import io.vantiq.extjsdk.Handler;
-import io.vantiq.extsrc.jdbcSource.JDBCCore;
 import io.vantiq.extsrc.jdbcSource.exception.VantiqSQLException;
 
 /**
@@ -43,46 +46,34 @@ public class JDBCHandleConfiguration extends Handler<ExtensionServiceMessage> {
     Logger                  log;
     String                  sourceName;
     JDBCCore                source;
-    int                     polling = 0;
     boolean                 configComplete = false; // Not currently used
+    boolean                 asynchronousProcessing = false;
         
     Handler<ExtensionServiceMessage> queryHandler;
     Handler<ExtensionServiceMessage> publishHandler;
-    
+
+    private static final int MAX_RUNNING_THREADS = 5;
+    private static final int MAX_QUEUED_TASKS = 10;
+
+    // Constants for getting config options
+    private static final String CONFIG = "config";
+    private static final String JDBC_CONFIG = "jdbcConfig";
+    private static final String VANTIQ = "vantiq";
+    private static final String GENERAL = "general";
+    private static final String PACKAGE_ROWS = "packageRows";
+    private static final String USERNAME = "username";
+    private static final String PASSWORD = "password";
+    private static final String DB_URL = "dbURL";
+    private static final String POLL_TIME = "pollTime";
+    private static final String POLL_QUERY = "pollQuery";
+    private static final String ASYNCH_PROCESSING = "asynchronousProcessing";
+    private static final String MAX_RUNNING = "maxRunningThreads";
+    private static final String MAX_QUEUED = "maxQueuedTasks";
+
     public JDBCHandleConfiguration(JDBCCore source) {
         this.source = source;
         this.sourceName = source.getSourceName();
         log = LoggerFactory.getLogger(this.getClass().getCanonicalName() + "#" + sourceName);
-        queryHandler = new Handler<ExtensionServiceMessage>() {
-            ExtensionWebSocketClient client = source.client;
-            
-            @Override
-            public void handleMessage(ExtensionServiceMessage message) {
-                // Should never happen, but just in case something changes in the backend
-                if ( !(message.getObject() instanceof Map) ) {
-                    String replyAddress = ExtensionServiceMessage.extractReplyAddress(message);
-                    client.sendQueryError(replyAddress, "io.vantiq.extsrc.JDBCHandleConfiguration.invalidQueryRequest", 
-                            "Request must be a map", null);
-                }
-                
-                // Process query and send the results
-                source.executeQuery(message);
-            }
-        };
-        publishHandler = new Handler<ExtensionServiceMessage>() {
-            ExtensionWebSocketClient client = source.client;
-            
-            @Override
-            public void handleMessage(ExtensionServiceMessage message) {
-                // Should never happen, but just in case something changes in the backend
-                if ( !(message.getObject() instanceof Map) ) {
-                    String replyAddress = ExtensionServiceMessage.extractReplyAddress(message);
-                    client.sendQueryError(replyAddress, "io.vantiq.extsrc.JDBCConfigHandler.invalidPublishRequest", 
-                            "Request must be a map", null);
-                }
-                source.executePublish(message);
-            }
-        };
     }
     
     /**
@@ -97,29 +88,29 @@ public class JDBCHandleConfiguration extends Handler<ExtensionServiceMessage> {
         Map<String, Object> general;
         
         // Obtain entire config from the message object
-        if ( !(configObject.get("config") instanceof Map)) {
+        if ( !(configObject.get(CONFIG) instanceof Map)) {
             log.error("Configuration failed. No configuration suitable for JDBC Source.");
             failConfig();
             return;
         }
-        config = (Map) configObject.get("config");
+        config = (Map) configObject.get(CONFIG);
         
         // Retrieve the jdbcConfig and the vantiq config
-        if ( !(config.get("jdbcConfig") instanceof Map && config.get("vantiq") instanceof Map) ) {
+        if ( !(config.get(JDBC_CONFIG) instanceof Map && config.get(VANTIQ) instanceof Map) ) {
             log.error("Configuration failed. Configuration must contain 'jdbcConfig' and 'vantiq' fields.");
             failConfig();
             return;
         }
-        jdbcConfig = (Map) config.get("jdbcConfig");
-        vantiq = (Map) config.get("vantiq");
+        jdbcConfig = (Map) config.get(JDBC_CONFIG);
+        vantiq = (Map) config.get(VANTIQ);
         
         // Get the general options from the jdbcConfig
-        if ( !(jdbcConfig.get("general") instanceof Map)) {
+        if ( !(jdbcConfig.get(GENERAL) instanceof Map)) {
             log.error("Configuration failed. No general options specified.");
             failConfig();
             return;
         }
-        general = (Map) jdbcConfig.get("general");
+        general = (Map) jdbcConfig.get(GENERAL);
         
         boolean success = createDBConnection(general, vantiq);
         if (!success) {
@@ -139,7 +130,7 @@ public class JDBCHandleConfiguration extends Handler<ExtensionServiceMessage> {
      */
     boolean createDBConnection(Map<String, ?> generalConfig, Map<String, ?> vantiq) {
         // Ensuring that packageRows is set to be true, and failing the configuration otherwise
-        if (!(vantiq.get("packageRows") instanceof String) || !(vantiq.get("packageRows").toString().equalsIgnoreCase("true"))) {
+        if (!(vantiq.get(PACKAGE_ROWS) instanceof String) || !(vantiq.get(PACKAGE_ROWS).toString().equalsIgnoreCase("true"))) {
             log.error("Configuration failed. The packageRows field must be set to true.");
             return false;
         }
@@ -149,26 +140,29 @@ public class JDBCHandleConfiguration extends Handler<ExtensionServiceMessage> {
         String password;
         String dbURL;
         
-        if (generalConfig.get("username") instanceof String) {
-            username = (String) generalConfig.get("username");
+        if (generalConfig.get(USERNAME) instanceof String) {
+            username = (String) generalConfig.get(USERNAME);
         } else {
             log.error("Configuration failed. No db username was specified");
             return false;
         }
         
-        if (generalConfig.get("password") instanceof String) {
-            password = (String) generalConfig.get("password");
+        if (generalConfig.get(PASSWORD) instanceof String) {
+            password = (String) generalConfig.get(PASSWORD);
         } else {
             log.error("Configuration failed. No db password was specified");
             return false;
         }
         
-        if (generalConfig.get("dbURL") instanceof String) {
-            dbURL = (String) generalConfig.get("dbURL");
+        if (generalConfig.get(DB_URL) instanceof String) {
+            dbURL = (String) generalConfig.get(DB_URL);
         } else {
             log.error("Configuration failed. No db URL was specified");
             return false;
         }
+
+        // Creating the publish and query handlers
+        createQueryAndPublishHandlers(generalConfig);
         
         // Initialize JDBC Source with config values
         try {
@@ -176,7 +170,7 @@ public class JDBCHandleConfiguration extends Handler<ExtensionServiceMessage> {
                 source.jdbc.close();
             }
             JDBC jdbc = new JDBC();
-            jdbc.setupJDBC(dbURL, username, password);
+            jdbc.setupJDBC(dbURL, username, password, asynchronousProcessing);
             source.jdbc = jdbc; 
         } catch (VantiqSQLException e) {
             log.error("Configuration failed. Exception occurred while setting up JDBC Source: ", e);
@@ -184,11 +178,11 @@ public class JDBCHandleConfiguration extends Handler<ExtensionServiceMessage> {
         }
         
         // Create polling query if specified
-        if (generalConfig.get("pollTime") instanceof Integer) {
-            if (generalConfig.get("pollQuery") instanceof String) {
-                int pollTime = (Integer) generalConfig.get("pollTime");
+        if (generalConfig.get(POLL_TIME) instanceof Integer) {
+            if (generalConfig.get(POLL_QUERY) instanceof String) {
+                int pollTime = (Integer) generalConfig.get(POLL_TIME);
                 if (pollTime > 0) {
-                    String pollQuery = (String) generalConfig.get("pollQuery"); 
+                    String pollQuery = (String) generalConfig.get(POLL_QUERY);
                     TimerTask task = new TimerTask() {
                         @Override
                         public void run() {
@@ -213,6 +207,98 @@ public class JDBCHandleConfiguration extends Handler<ExtensionServiceMessage> {
         
         log.trace("JDBC source created");
         return true;
+    }
+
+    /**
+     * Method used to create the query and publish handlers
+     * @param generalConfig     The general configuration of the JDBC Source
+     */
+    private void createQueryAndPublishHandlers(Map<String, ?> generalConfig) {
+        // Checking if asynchronous processing was specified in the general configuration
+        if (generalConfig.get(ASYNCH_PROCESSING) instanceof Boolean && (Boolean) generalConfig.get(ASYNCH_PROCESSING)) {
+            asynchronousProcessing = true;
+            int maxRunningThreads = MAX_RUNNING_THREADS;
+            int maxQueuedTasks = MAX_QUEUED_TASKS;
+
+            if (generalConfig.get(MAX_RUNNING) instanceof Integer && (Integer) generalConfig.get(MAX_RUNNING) > 0) {
+                maxRunningThreads = (Integer) generalConfig.get(MAX_RUNNING);
+            }
+
+            if (generalConfig.get(MAX_QUEUED) instanceof Integer && (Integer) generalConfig.get(MAX_QUEUED) > 0) {
+                maxQueuedTasks = (Integer) generalConfig.get(MAX_QUEUED);
+            }
+
+            // Creating the thread pool executors
+            source.queryPool = new ThreadPoolExecutor(maxRunningThreads, maxRunningThreads, 0l, TimeUnit.MILLISECONDS,
+                    new LinkedBlockingQueue<Runnable>(maxQueuedTasks));
+            source.publishPool = new ThreadPoolExecutor(maxRunningThreads, maxRunningThreads, 0l, TimeUnit.MILLISECONDS,
+                    new LinkedBlockingQueue<Runnable>(maxQueuedTasks));
+
+            // Creating query/publish handlers with asynchronous processing
+            queryHandler = new Handler<ExtensionServiceMessage>() {
+                @Override
+                public void handleMessage(ExtensionServiceMessage message) {
+                    try {
+                        source.queryPool.execute(new Runnable() {
+                            @Override
+                            public void run() {
+                                handleQueryRequest(source.client, message);
+                            }
+                        });
+                    } catch (RejectedExecutionException e) {
+                        log.error("The queue of tasks has filled, and as a result the request was unable to be processed.", e);
+                        String replyAddress = ExtensionServiceMessage.extractReplyAddress(message);
+                        source.client.sendQueryError(replyAddress, "io.vantiq.extsrc.JDBCHandleConfiguration.queryHandler.queuedTasksFull",
+                                "The queue of tasks has filled, and as a result the request was unable to be processed.", null);
+                    }
+                }
+            };
+            publishHandler = new Handler<ExtensionServiceMessage>() {
+                @Override
+                public void handleMessage(ExtensionServiceMessage message) {
+                    try {
+                        source.publishPool.execute(new Runnable() {
+                            @Override
+                            public void run() {
+                                source.executePublish(message);
+                            }
+                        });
+                    } catch (RejectedExecutionException e) {
+                        log.error("The queue of tasks has filled, and as a result the request was unable to be processed.", e);
+                    }
+                }
+            };
+        } else {
+            // Otherwise, creating query/publish handlers with synchronous processing
+            queryHandler = new Handler<ExtensionServiceMessage>() {
+                @Override
+                public void handleMessage(ExtensionServiceMessage message) {
+                    handleQueryRequest(source.client, message);
+                }
+            };
+            publishHandler = new Handler<ExtensionServiceMessage>() {
+                @Override
+                public void handleMessage(ExtensionServiceMessage message) {
+                    source.executePublish(message);
+                }
+            };
+        }
+    }
+
+    /**
+     * Method called by the query handler to process the request
+     * @param client    The ExtensionWebSocketClient used to send a query response error if necessary
+     */
+    private void handleQueryRequest(ExtensionWebSocketClient client, ExtensionServiceMessage message) {
+        // Should never happen, but just in case something changes in the backend
+        if ( !(message.getObject() instanceof Map) ) {
+            String replyAddress = ExtensionServiceMessage.extractReplyAddress(message);
+            client.sendQueryError(replyAddress, "io.vantiq.extsrc.JDBCHandleConfiguration.invalidQueryRequest",
+                    "Request must be a map", null);
+        }
+
+        // Process query and send the results
+        source.executeQuery(message);
     }
     
     /**

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -129,7 +129,7 @@ public class TestJDBC extends TestJDBCBase {
         if (testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null) {
             // Create new instance of JDBC to drop tables, in case the global JDBC instance was closed
             JDBC dropTablesJDBC = new JDBC();
-            dropTablesJDBC.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
+            dropTablesJDBC.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
             
             // Delete first table
             try {
@@ -205,7 +205,7 @@ public class TestJDBC extends TestJDBCBase {
     @Test
     public void testProcessPublish() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
         
         int queryResult;
         
@@ -239,7 +239,7 @@ public class TestJDBC extends TestJDBCBase {
     @Test
     public void testProcessQuery() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
         
         HashMap[] queryResult;
         int deleteResult;
@@ -285,7 +285,7 @@ public class TestJDBC extends TestJDBCBase {
     @Test
     public void testExtendedTypes() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
         HashMap[] queryResult;
         int publishResult;
         
@@ -341,7 +341,7 @@ public class TestJDBC extends TestJDBCBase {
         assumeFalse(checkSourceExists());
         assumeFalse(checkTypeExists());
                 
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
         
         // Setup a VANTIQ JDBC Source, and start running the core
         setupSource(createSourceDef(false));
@@ -392,7 +392,7 @@ public class TestJDBC extends TestJDBCBase {
     @Test
     public void testNullValues() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
         
         int publishResult;
         HashMap[] queryResult;
@@ -493,7 +493,7 @@ public class TestJDBC extends TestJDBCBase {
     public void testCorrectErrors() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
         assumeTrue(testDBURL.contains("mysql"));
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
         HashMap[] queryResult;
         int publishResult;
         
@@ -556,7 +556,7 @@ public class TestJDBC extends TestJDBCBase {
     @Test
     public void testDBReconnect() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
         
         // Close the connection, and then try to query
         jdbc.close();
@@ -709,9 +709,10 @@ public class TestJDBC extends TestJDBCBase {
         // Select from the type and make sure all of our results are there as expected
         response = vantiq.select(testTypeName, null, null, null);
         ArrayList responseBody = (ArrayList) response.getBody();
+        System.out.println("The size is: " +  responseBody.size());
         assert responseBody.size() == 500;
 
-        // Delete the Source/Type/Procedure/Rule from VANTIQ
+        // Delete the Source/Type/Topic/Procedure/Rule from VANTIQ
         deleteSource();
         deleteType();
         deleteTopic();
@@ -757,7 +758,7 @@ public class TestJDBC extends TestJDBCBase {
         general.put("dbURL", testDBURL);
         if (isAsynch) {
             general.put("asynchronousProcessing", true);
-            general.put("maxRunningThreads", 10);
+            general.put("maxActiveTasks", 10);
             general.put("maxQueuedTasks", 20);
         }
         

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -709,7 +709,6 @@ public class TestJDBC extends TestJDBCBase {
         // Select from the type and make sure all of our results are there as expected
         response = vantiq.select(testTypeName, null, null, null);
         ArrayList responseBody = (ArrayList) response.getBody();
-        System.out.println("The size is: " +  responseBody.size());
         assert responseBody.size() == 500;
 
         // Delete the Source/Type/Topic/Procedure/Rule from VANTIQ

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -709,7 +709,6 @@ public class TestJDBC extends TestJDBCBase {
         // Select from the type and make sure all of our results are there as expected
         response = vantiq.select(testTypeName, null, null, null);
         ArrayList responseBody = (ArrayList) response.getBody();
-        System.out.println("size: " + responseBody.size());
         assert responseBody.size() == 500;
 
         // Delete the Source/Type/Procedure/Rule from VANTIQ

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -125,7 +125,7 @@ public class TestJDBC extends TestJDBCBase {
         if (testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null) {
             // Create new instance of JDBC to drop tables, in case the global JDBC instance was closed
             JDBC dropTablesJDBC = new JDBC();
-            dropTablesJDBC.setupJDBC(testDBURL, testDBUsername, testDBPassword);
+            dropTablesJDBC.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
             
             // Delete first table
             try {
@@ -187,7 +187,7 @@ public class TestJDBC extends TestJDBCBase {
     @Test
     public void testProcessPublish() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
         
         int queryResult;
         
@@ -221,7 +221,7 @@ public class TestJDBC extends TestJDBCBase {
     @Test
     public void testProcessQuery() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
         
         HashMap[] queryResult;
         int deleteResult;
@@ -267,7 +267,7 @@ public class TestJDBC extends TestJDBCBase {
     @Test
     public void testExtendedTypes() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
         HashMap[] queryResult;
         int publishResult;
         
@@ -323,7 +323,7 @@ public class TestJDBC extends TestJDBCBase {
         assumeFalse(checkSourceExists());
         assumeFalse(checkTypeExists());
                 
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
         
         // Setup a VANTIQ JDBC Source, and start running the core
         setupSource(createSourceDef());
@@ -374,7 +374,7 @@ public class TestJDBC extends TestJDBCBase {
     @Test
     public void testNullValues() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
         
         int publishResult;
         HashMap[] queryResult;
@@ -475,7 +475,7 @@ public class TestJDBC extends TestJDBCBase {
     public void testCorrectErrors() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
         assumeTrue(testDBURL.contains("mysql"));
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
         HashMap[] queryResult;
         int publishResult;
         
@@ -538,7 +538,7 @@ public class TestJDBC extends TestJDBCBase {
     @Test
     public void testDBReconnect() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
         
         // Close the connection, and then try to query
         jdbc.close();
@@ -564,7 +564,7 @@ public class TestJDBC extends TestJDBCBase {
         // Check that Source does not already exist in namespace, and skip test if it does
         assumeFalse(checkSourceExists());
         
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
         
         // Setup a VANTIQ JDBC Source, and start running the core
         setupSource(createSourceDef());

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCBase.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCBase.java
@@ -19,6 +19,9 @@ public class TestJDBCBase {
     static String jdbcDriverLoc;
     static String testSourceName;
     static String testTypeName;
+    static String testProcedureName;
+    static String testRuleName;
+    static String testTopicName;
     
     @BeforeClass
     public static void getProps() {
@@ -30,5 +33,8 @@ public class TestJDBCBase {
         jdbcDriverLoc = System.getenv("JDBC_DRIVER_LOC");
         testSourceName = System.getProperty("EntConTestSourceName", "testSourceName");
         testTypeName = System.getProperty("EntConTestTypeName", "testTypeName");
+        testProcedureName = System.getProperty("EntConTestProcedureName", "testProcedureName");
+        testRuleName = System.getProperty("EntConTestRuleName", "testRuleName");
+        testTopicName = System.getProperty("EntConTestTopicName", "/test/topic/name");
     }
 }

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCConfig.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCConfig.java
@@ -146,13 +146,13 @@ public class TestJDBCConfig extends TestJDBCBase {
         assertFalse("Should not fail with asynchronousProcessing set to true", configIsFailed());
 
         // Setting maxRunningThreads and maxQueuedTasks incorrectly
-        conf.put("maxRunningThreads", "jibberish");
+        conf.put("maxActiveTasks", "jibberish");
         conf.put("maxQueuedTasks", "moreJibberish");
         sendConfig(conf, vantiqConf);
         assertFalse("Should not fail when maxRunningThreads and maxQueuedTasks are set incorrectly", configIsFailed());
 
         // Setting maxRunningThreads and maxQueuedTasks correctly
-        conf.put("maxRunningThreads", 10);
+        conf.put("maxActiveTasks", 10);
         conf.put("maxQueuedTasks", 20);
         sendConfig(conf, vantiqConf);
         assertFalse("Should not fail when maxRunningThreads and maxQueuedTasks are set correctly", configIsFailed());

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCConfig.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCConfig.java
@@ -149,13 +149,13 @@ public class TestJDBCConfig extends TestJDBCBase {
         conf.put("maxActiveTasks", "jibberish");
         conf.put("maxQueuedTasks", "moreJibberish");
         sendConfig(conf, vantiqConf);
-        assertFalse("Should not fail when maxRunningThreads and maxQueuedTasks are set incorrectly", configIsFailed());
+        assertFalse("Should not fail when maxActiveTasks and maxQueuedTasks are set incorrectly", configIsFailed());
 
         // Setting maxRunningThreads and maxQueuedTasks correctly
         conf.put("maxActiveTasks", 10);
         conf.put("maxQueuedTasks", 20);
         sendConfig(conf, vantiqConf);
-        assertFalse("Should not fail when maxRunningThreads and maxQueuedTasks are set correctly", configIsFailed());
+        assertFalse("Should not fail when maxActiveTasks and maxQueuedTasks are set correctly", configIsFailed());
     }
     
 // ================================================= Helper functions =================================================

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCConfig.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCConfig.java
@@ -69,7 +69,7 @@ public class TestJDBCConfig extends TestJDBCBase {
         Map conf = minimalConfig();
         Map vantiqConf = new LinkedHashMap<>();
         sendConfig(conf, vantiqConf);
-        assertTrue("Should fail when missing 'general' configuration", configIsFailed());
+        assertTrue("Should fail when missing 'vantiq' configuration", configIsFailed());
     }
     
     @Test 
@@ -78,7 +78,7 @@ public class TestJDBCConfig extends TestJDBCBase {
         Map vantiqConf = createMinimalVantiq();
         vantiqConf.remove("packageRows");
         sendConfig(conf, vantiqConf);
-        assertTrue("Should fail when missing 'general' configuration", configIsFailed());
+        assertTrue("Should fail when missing 'packageRows' configuration", configIsFailed());
     }
     
     @Test
@@ -87,7 +87,7 @@ public class TestJDBCConfig extends TestJDBCBase {
         Map vantiqConf = createMinimalVantiq();
         vantiqConf.put("packageRows","false");
         sendConfig(conf, vantiqConf);
-        assertTrue("Should fail when missing 'general' configuration", configIsFailed());
+        assertTrue("Should fail when 'packageRows' is set to 'false'", configIsFailed());
     }
     
     @Test
@@ -121,6 +121,41 @@ public class TestJDBCConfig extends TestJDBCBase {
         conf.put("pollQuery", "SELECT * FROM Test");
         sendConfig(conf, vantiqConf);
         assertFalse("Should not fail with missing pollTime configuration", configIsFailed());
+    }
+
+    @Test
+    public void testAsynchronousProcessing() {
+        assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
+        nCore.start(5);
+
+        // Setting asynchronousProcessing incorrectly
+        Map conf = minimalConfig();
+        conf.put("asynchronousProcessing", "jibberish");
+        Map vantiqConf = createMinimalVantiq();
+        sendConfig(conf, vantiqConf);
+        assertFalse("Should not fail with invalid asynchronousProcessing value", configIsFailed());
+
+        // Setting asynchronousProcessing to false (same as not including it)
+        conf.put("asynchronousProcessing", false);
+        sendConfig(conf, vantiqConf);
+        assertFalse("Should not fail with asynchronousProcessing set to false", configIsFailed());
+
+        // Setting asynchronousProcessing to true
+        conf.put("asynchronousProcessing", true);
+        sendConfig(conf, vantiqConf);
+        assertFalse("Should not fail with asynchronousProcessing set to true", configIsFailed());
+
+        // Setting maxRunningThreads and maxQueuedTasks incorrectly
+        conf.put("maxRunningThreads", "jibberish");
+        conf.put("maxQueuedTasks", "moreJibberish");
+        sendConfig(conf, vantiqConf);
+        assertFalse("Should not fail when maxRunningThreads and maxQueuedTasks are set incorrectly", configIsFailed());
+
+        // Setting maxRunningThreads and maxQueuedTasks correctly
+        conf.put("maxRunningThreads", 10);
+        conf.put("maxQueuedTasks", 20);
+        sendConfig(conf, vantiqConf);
+        assertFalse("Should not fail when maxRunningThreads and maxQueuedTasks are set correctly", configIsFailed());
     }
     
 // ================================================= Helper functions =================================================

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCCore.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCCore.java
@@ -62,7 +62,7 @@ public class TestJDBCCore extends TestJDBCBase {
     @Test
     public void testPublishQuery() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
         
         Map<String, Object> request;
         ExtensionServiceMessage msg = new ExtensionServiceMessage("");
@@ -85,7 +85,7 @@ public class TestJDBCCore extends TestJDBCBase {
     @Test
     public void testExecuteQuery() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
         
         Map<String, Object> request;
         ExtensionServiceMessage msg = new ExtensionServiceMessage("");
@@ -108,7 +108,7 @@ public class TestJDBCCore extends TestJDBCBase {
     @Test
     public void testExitIfConnectionFails() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
         
         core.start(3);
         assertTrue("Should have succeeded", core.exitIfConnectionFails(core.client, 3));

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCCore.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCCore.java
@@ -62,7 +62,7 @@ public class TestJDBCCore extends TestJDBCBase {
     @Test
     public void testPublishQuery() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
         
         Map<String, Object> request;
         ExtensionServiceMessage msg = new ExtensionServiceMessage("");
@@ -85,7 +85,7 @@ public class TestJDBCCore extends TestJDBCBase {
     @Test
     public void testExecuteQuery() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
         
         Map<String, Object> request;
         ExtensionServiceMessage msg = new ExtensionServiceMessage("");
@@ -108,7 +108,7 @@ public class TestJDBCCore extends TestJDBCBase {
     @Test
     public void testExitIfConnectionFails() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
-        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false);
         
         core.start(3);
         assertTrue("Should have succeeded", core.exitIfConnectionFails(core.client, 3));


### PR DESCRIPTION
Closes Issue #167 

Adding ability to process query/publish requests asynchronously. Added tests to ensure behavior is correct.

Note: There is no need to do something of the "diagnoseConnection" sort for the connection pool, this is all handled internally by HikariCP.