### PR TITLE
Naf jdbc batch #169

### DIFF
--- a/jdbcSource/README.md
+++ b/jdbcSource/README.md
@@ -207,8 +207,10 @@ try {
 
 Another method to interact with the JDBC Source is to use VAIL to publish to the source. To do this, you will need to
 specify the SQL Query you wish to execute against your database as part of the Publish Parameters. The SQL Queries used here 
-can be **CREATE**, **INSERT**, **DELETE**, **DROP**, or other commands supported by your SQL database. The following are 
-examples of Procedures created in VANTIQ Modelo publishing to a JDBC source.
+can be **CREATE**, **INSERT**, **DELETE**, **DROP**, or other commands supported by your SQL database. The SQL Query must 
+either be represented as a String, or as a List of Strings. If the query is represented as a list, then all of the queries in 
+the list will be executed together as a batch. The following are examples of Procedures created in VANTIQ Modelo publishing to 
+a JDBC source.
 
 **Creating a table:**
 
@@ -251,6 +253,39 @@ try {
         // 'query' field. The field must be named 'query'.
         PUBLISH {"query":sqlQuery} to SOURCE JDBC1
     }
+} catch (error) {
+    // Catching any errors and throwing the exception.
+    exception(error.code, error.message)
+}
+```
+
+**Inserting to table as a batch:**
+
+```
+PROCEDURE insertBatchJDBC()
+
+try {
+    var myList = []
+    
+    // The for-loop is used to insert multiple rows of data
+    FOR i in range(0, 5) {
+    	// Creating the values that will be inserted
+        var id = i.toString()
+	var age = (20+i).toString()
+	var first = "Firstname" + i.toString()
+	var last = "Lastname" + i.toString()
+
+	// The SQL Statement that the JDBC Source will execute
+	// Notice that when inserting Strings, the values must be surrounded by ''. This 
+	// can be seen around the 'first' and 'last' values.
+        var sqlQuery = "INSERT INTO Test VALUES (" + id + ", " + age + ", '" + first + "', '" + last + "');"
+	
+	// Adding the SQL Statement to the list.
+	push(myList, sqlQuery)
+    }
+    
+    // Using a VAIL PUBLISH statement with the list as our 'query' parameter
+    PUBLISH {query:myList} to SOURCE JDBC1
 } catch (error) {
     // Catching any errors and throwing the exception.
     exception(error.code, error.message)

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
@@ -134,7 +134,7 @@ public class JDBC {
     }
     
     /**
-     * The method used to execute the provided query, triggered by a PUBLISH on the respective source from VANTIQ.
+     * The method used to execute the provided query, triggered by a PUBLISH on the respective VANTIQ source.
      * @param sqlQuery          A String representation of the query, retrieved from the PUBLISH message.
      * @return                  The integer value that is returned by the executeUpdate() method representing the row count.
      * @throws VantiqSQLException
@@ -165,8 +165,15 @@ public class JDBC {
         return publishSuccess;
     }
 
-
-    public int[] processBatchPublish(List queryList) throws VantiqSQLException {
+    /**
+     * The method used to execute the provided list of queries, triggered by a PUBLISH on the respective VANTIQ source. These queries
+     * are processed as a batch.
+     * @param queryList             The list of queries to be processed as a batch.
+     * @return
+     * @throws VantiqSQLException
+     * @throws ClassCastException
+     */
+    public int[] processBatchPublish(List queryList) throws VantiqSQLException, ClassCastException {
         int[] publishSuccess = null;
 
         if (isAsync) {

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
@@ -9,6 +9,7 @@
 package io.vantiq.extsrc.jdbcSource;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -220,8 +221,8 @@ public class JDBCCore {
     }
     
     /**
-     * Executes the query that is provided as a String in the options specified by the "query" key in the
-     * object of the Publish message.
+     * Executes the query that is provided in the Publish Message. If query is an Array of Strings, then it is executed as a Batch request.
+     * If the query is a single String, then it is executed normally.
      * @param message   The Query message.
      */
     public void executePublish(ExtensionServiceMessage message) {
@@ -243,8 +244,12 @@ public class JDBCCore {
                 String queryString = (String) request.get("query");
                 int data = localJDBC.processPublish(queryString);
                 log.trace("The returned integer value from Publish Query is the following: ", data);
+            } else if (request.get("query") instanceof List) {
+                List queryArray = (List) request.get("query");
+                int[] data = localJDBC.processBatchPublish(queryArray);
+                log.trace("The returned integer array from Publish Query is the following: ", data);
             } else {
-                log.error("Query could not be executed because query was not a String");
+                log.error("Query could not be executed because query was not a String or a List");
             }
         } catch (VantiqSQLException e) {
             log.error("Could not execute requested query.", e);

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
@@ -254,6 +254,9 @@ public class JDBCCore {
         } catch (VantiqSQLException e) {
             log.error("Could not execute requested query.", e);
             log.error("Request was: {}", request);
+        } catch (ClassCastException e) {
+            log.error("Could not execute requested query. This is most likely because the query list did not contain Strings.", e);
+            log.error("Request was: {}", request);
         } catch (Exception e) {
             log.error("An unexpected error occurred when executing the requested query.", e);
             log.error("Request was: {}", request);

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCHandleConfiguration.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCHandleConfiguration.java
@@ -297,6 +297,7 @@ public class JDBCHandleConfiguration extends Handler<ExtensionServiceMessage> {
     /**
      * Method called by the query handler to process the request
      * @param client    The ExtensionWebSocketClient used to send a query response error if necessary
+     * @param message   The message sent to the Extension Source
      */
     private void handleQueryRequest(ExtensionWebSocketClient client, ExtensionServiceMessage message) {
         // Should never happen, but just in case something changes in the backend
@@ -309,7 +310,7 @@ public class JDBCHandleConfiguration extends Handler<ExtensionServiceMessage> {
         // Process query and send the results
         source.executeQuery(message);
     }
-    
+
     /**
      * Closes the source {@link JDBCCore} and marks the configuration as completed. The source will
      * be reactivated when the source reconnects, due either to a Reconnect message (likely created by an update to the

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -93,6 +93,17 @@ public class TestJDBC extends TestJDBCBase {
     // Queries for asynchronous processing test
     static final String CREATE_TABLE_ASYNCH = "CREATE TABLE TestAsynchProcessing(id int, first varchar (255), last varchar (255));";
     static final String DROP_TABLE_ASYNCH = "DROP TABLE TestAsynchProcessing";
+
+    // Queries for invalid batch processing tests
+    static final String CREATE_TABLE_INVALID_BATCH = "CREATE TABLE TestInvalidBatch(id int, first varchar (255), last varchar (255));";
+    static final String SELECT_TABLE_INVALID_BATCH = "SELECT * FROM TestInvalidBatch";
+    static final String DROP_TABLE_INVALID_BATCH = "DROP TABLE TestInvalidBatch";
+
+    // Queries for valid batch processing tests
+    static final String CREATE_TABLE_BATCH = "CREATE TABLE TestBatch(id int, first varchar (255), last varchar (255));";
+    static final String INSERT_TABLE_BATCH = "INSERT INTO TestBatch VALUES (1, 'First', 'Second');";
+    static final String SELECT_TABLE_BATCH = "SELECT * FROM TestBatch;";
+    static final String DROP_TABLE_BATCH = "DROP TABLE TestBatch";
     
     static final String timestampPattern = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}-\\d{4}";
     static final String datePattern = "\\d{4}-\\d{2}-\\d{2}";
@@ -176,6 +187,20 @@ public class TestJDBC extends TestJDBCBase {
             // Delete seventh table
             try {
                 dropTablesJDBC.processPublish(DROP_TABLE_ASYNCH);
+            } catch (VantiqSQLException e) {
+                // Shouldn't throw Exception
+            }
+
+            // Delete eighth table
+            try {
+                dropTablesJDBC.processPublish(DROP_TABLE_INVALID_BATCH);
+            } catch (VantiqSQLException e) {
+                // Shouldn't throw Exception
+            }
+
+            // Delete ninth table
+            try {
+                dropTablesJDBC.processPublish(DROP_TABLE_BATCH);
             } catch (VantiqSQLException e) {
                 // Shouldn't throw Exception
             }
@@ -712,8 +737,8 @@ public class TestJDBC extends TestJDBCBase {
         // Execute Procedure to trigger asynchronous publish/queries (assign to variable to ensure that procedure has finished before selecting from type)
         VantiqResponse response = vantiq.execute(testProcedureName, new LinkedHashMap<>());
 
-        // Sleep for 2 seconds to make sure all queries have finished
-        Thread.sleep(2000);
+        // Sleep for 5 seconds to make sure all queries have finished
+        Thread.sleep(5000);
 
         // Select from the type and make sure all of our results are there as expected
         response = vantiq.select(testTypeName, null, null, null);
@@ -735,12 +760,95 @@ public class TestJDBC extends TestJDBCBase {
 
     @Test
     public void testInvalidBatchProcessing() {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+        assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
 
+        // Check that Source, Type, Topic, Procedure and Rule do not already exist in namespace, and skip test if they do
+        assumeFalse(checkSourceExists());
+
+        // Setup a VANTIQ JDBC Source, and start running the core
+        setupSource(createSourceDef(false, false));
+
+        // Create table
+        Map<String,Object> create_params = new LinkedHashMap<String,Object>();
+        create_params.put("query", CREATE_TABLE_INVALID_BATCH);
+        vantiq.publish("sources", testSourceName, create_params);
+
+        // Creating a list of integers to insert as a batch
+        ArrayList<Object> invalidBatch = new ArrayList<>();
+        for (int i = 0; i<50; i++) {
+            invalidBatch.add(10);
+        }
+
+        // Attempt to insert data into the table, which should fail
+        Map<String,Object> insert_params = new LinkedHashMap<String,Object>();
+        insert_params.put("query", invalidBatch);
+        vantiq.publish("sources", testSourceName, insert_params);
+
+        // Query the table and make sure it is empty
+        Map<String,Object> query_params = new LinkedHashMap<String,Object>();
+        query_params.put("query", SELECT_TABLE_INVALID_BATCH);
+        VantiqResponse response = vantiq.query(testSourceName, query_params);
+        JsonArray responseBody = (JsonArray) response.getBody();
+        assert responseBody.size() == 0;
+
+        // Now try a list of jibberish queries
+        for (int i = 0; i<50; i++) {
+            invalidBatch.add("jibberish");
+        }
+
+        // Attempt to insert data into the table, which should fail
+        insert_params.put("query", invalidBatch);
+        vantiq.publish("sources", testSourceName, insert_params);
+
+        // Query the table and make sure it is empty
+        response = vantiq.query(testSourceName, query_params);
+        responseBody = (JsonArray) response.getBody();
+        assert responseBody.size() == 0;
+
+        // Delete the Source
+        deleteSource();
     }
 
     @Test
     public void testBatchProcessing() {
-        
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+        assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
+
+        // Check that Source, Type, Topic, Procedure and Rule do not already exist in namespace, and skip test if they do
+        assumeFalse(checkSourceExists());
+
+        // Setup a VANTIQ JDBC Source, and start running the core
+        setupSource(createSourceDef(false, false));
+
+        // Create table
+        Map<String,Object> create_params = new LinkedHashMap<String,Object>();
+        create_params.put("query", CREATE_TABLE_BATCH);
+        vantiq.publish("sources", testSourceName, create_params);
+
+        // Creating a list of strings to insert as a batch
+        ArrayList<String> batch = new ArrayList<String>();
+        for (int i = 0; i<50; i++) {
+            batch.add(INSERT_TABLE_BATCH);
+        }
+
+        // Inserting data into the table as a batch
+        Map<String,Object> insert_params = new LinkedHashMap<String,Object>();
+        insert_params.put("query", batch);
+        VantiqResponse response = vantiq.publish("sources", testSourceName, insert_params);
+        assert !response.hasErrors();
+
+        // Select the data from table and make sure the response is valid
+        Map<String,Object> query_params = new LinkedHashMap<String,Object>();
+        query_params.put("query", SELECT_TABLE_BATCH);
+        response = vantiq.query(testSourceName, query_params);
+        JsonArray responseBody = (JsonArray) response.getBody();
+        assert responseBody.size() == 50;
+
+        // Delete the Source
+        deleteSource();
     }
     // ================================================= Helper functions =================================================
 

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -732,7 +732,16 @@ public class TestJDBC extends TestJDBCBase {
         deleteProcedure();
         deleteRule();
     }
-    
+
+    @Test
+    public void testInvalidBatchProcessing() {
+
+    }
+
+    @Test
+    public void testBatchProcessing() {
+        
+    }
     // ================================================= Helper functions =================================================
 
     public static boolean checkSourceExists() {


### PR DESCRIPTION
Closes Issue #169 

An enhancement that enables batch inserts.

If a publish request provides the query as a list of strings, then the list will be processed as a batch. Otherwise, all previous behavior is identical. Each database has a different value for the max batch size, so I don't think we can try to enforce any maximum from our end. Instead, if the max size is reached then we will throw a VantiqSQLException and handle it normally.