### PR TITLE
Naf jdbc override query #171

### DIFF
--- a/jdbcSource/README.md
+++ b/jdbcSource/README.md
@@ -157,9 +157,14 @@ will be sent as a unique Notification.
 ## Select Statements
 
 In order to interact with the JDBC Source, one option is to use VAIL to select from the source. To do this, you will need 
-to specify the SQL Query you wish to execute against your database as part of the WITH clause. The SQL Queries used here must 
-only be **SELECT STATEMENTS**. The data will be returned to VANTIQ as a set of messages, where each message contains some 
-number of rows.
+to specify the SQL Query you wish to execute against your database as part of the WITH clause. *Typically*, the SQL Queries 
+used here must only be **SELECT STATEMENTS**. The data will be returned to VANTIQ as a set of messages, where each message 
+contains some number of rows.
+
+However, if the `isUpdate` parameter is specified and set to `true`, the SQL Queries can be any valid SQL Update Statement 
+(i.e. `CREATE`, `INSERT`, `DELETE`, `DROP`, etc...). This feature mimics the behavior of the Publish Statements, which are 
+defined [below](#publish). In this case, the VAIL Select Statements will return an empty map if the statement was executed 
+successfully, or a query error otherwise.
 
 A query parameter named `bundleFactor` determines how many rows are bundled into each message. Generally, the default value of 
 500 will be fine. However, in cases where rows may be very large, a smaller value may be required.
@@ -172,6 +177,7 @@ rows will be placed into a single message (the use of this is discouraged as it 
 From the perspective of consuming the rows, there is no visible difference here. The `bundleFactor` parameter is present to 
 allow control when returning very large rows.
 
+The following example uses a Vail Select Statement to **query** a database:
 ```
 PROCEDURE queryJDBC()
 
@@ -203,7 +209,28 @@ try {
 }
 ```
 
-## Publish Statements
+The following example uses a Vail Select Statement to **update** a database:
+```
+try {
+    // The SQL Statement that the JDBC Source will execute
+    var sqlQuery = "create table Test(id int not null, age int not null, first varchar (255), last varchar (255));"
+    
+    // Normal SELECT Statement in VAIL, passing the 'sqlQuery' as a parameter in the 
+    // 'query' field. The field must be named 'query'.
+    SELECT * FROM SOURCE JDBC1 AS results WITH 
+    query:sqlQuery,
+    isUpdate:true
+    
+    {
+    	log.info("The result is an empty map: " + results.toString())
+    }
+} catch (error) {
+    // Catching any errors and throwing the exception.
+    exception(error.code, error.message)
+}
+```
+
+## Publish Statements <a name="publish" id="publish"></a>
 
 Another method to interact with the JDBC Source is to use VAIL to publish to the source. To do this, you will need to
 specify the SQL Query you wish to execute against your database as part of the Publish Parameters. The SQL Queries used here 

--- a/jdbcSource/README.md
+++ b/jdbcSource/README.md
@@ -158,13 +158,12 @@ will be sent as a unique Notification.
 
 In order to interact with the JDBC Source, one option is to use VAIL to select from the source. To do this, you will need 
 to specify the SQL Query you wish to execute against your database as part of the WITH clause. *Typically*, the SQL Queries 
-used here must only be **SELECT STATEMENTS**. The data will be returned to VANTIQ as a set of messages, where each message 
+used here would be **SELECT STATEMENTS**. The data will be returned to VANTIQ as a set of messages, where each message 
 contains some number of rows.
 
-However, if the `isUpdate` parameter is specified and set to `true`, the SQL Queries can be any valid SQL Update Statement 
-(i.e. `CREATE`, `INSERT`, `DELETE`, `DROP`, etc...). This feature mimics the behavior of the Publish Statements, which are 
-defined [below](#publish). In this case, the VAIL Select Statements will return an empty map if the statement was executed 
-successfully, or a query error otherwise.
+However, the SQL Queries here can also be any valid SQL Update Statement (i.e. `CREATE`, `INSERT`, `DELETE`, `DROP`, etc...). 
+This feature mimics the behavior of the Publish Statements, which are defined [below](#publish). In this case, the VAIL Select 
+Statements will return an empty map if the statement was executed successfully, or a query error otherwise.
 
 A query parameter named `bundleFactor` determines how many rows are bundled into each message. Generally, the default value of 
 500 will be fine. However, in cases where rows may be very large, a smaller value may be required.
@@ -219,7 +218,6 @@ try {
     // 'query' field. The field must be named 'query'.
     SELECT * FROM SOURCE JDBC1 AS results WITH 
     query:sqlQuery,
-    isUpdate:true
     
     {
     	log.info("The result is an empty map: " + results.toString())

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
@@ -48,6 +48,7 @@ public class JDBCCore {
     final Logger log;
     final static int RECONNECT_INTERVAL = 5000;
     final static int DEFAULT_BUNDLE_SIZE = 500;
+    final static String SELECT_STATEMENT_IDENTIFIER = "select";
     
     // Used to check row bundling in tests
     public HashMap[] lastRowBundle = null;
@@ -193,17 +194,12 @@ public class JDBCCore {
             }
         }
 
-        // Check if query request is actually an update
-        boolean isUpdate = false;
-        if (request.get("isUpdate") instanceof Boolean && (Boolean) request.get("isUpdate")) {
-            isUpdate = (Boolean) request.get("isUpdate");
-        }
-
         // Gather query results and send the appropriate response, or send a query error if an exception is caught
         try {
             if (request.get("query") instanceof String) {
                 String queryString = (String) request.get("query");
-                if (isUpdate) {
+                // Check if SQL Query is an update statement, or query statement
+                if (!queryString.trim().toLowerCase().startsWith(SELECT_STATEMENT_IDENTIFIER)) {
                     int data = localJDBC.processPublish(queryString);
                     log.trace("The returned integer value from Publish Query is the following: ", data);
 
@@ -213,8 +209,17 @@ public class JDBCCore {
                     HashMap[] queryArray = localJDBC.processQuery(queryString);
                     sendDataFromQuery(queryArray, message);
                 }
-            } else if (isUpdate && request.get("query") instanceof List) {
+            } else if (request.get("query") instanceof List) {
                 List queryArray = (List) request.get("query");
+                // Check that each batch element is a SQL Update Statement
+                for (int i = 0; i < queryArray.size(); i++) {
+                    if (queryArray.get(i).toString().trim().toLowerCase().startsWith(SELECT_STATEMENT_IDENTIFIER)) {
+                        client.sendQueryError(replyAddress, this.getClass().getName() + ".invalidBatchElement",
+                                "The Query Request could not be executed because at least one batch element "
+                                + "was not a string representation of a SQL Update Statement.", null);
+                        return;
+                    }
+                }
                 int[] data = localJDBC.processBatchPublish(queryArray);
                 log.trace("The returned integer array from Publish Query is the following: ", data);
 
@@ -223,7 +228,7 @@ public class JDBCCore {
             } else {
                 log.error("Query could not be executed because query was not a String.");
                 client.sendQueryError(replyAddress, this.getClass().getName() + ".queryNotString", 
-                        "The Query Request could not be executed because the query property is"
+                        "The Query Request could not be executed because the query property is "
                         + "not a string.", null);
             }
         } catch (VantiqSQLException e) {

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -104,6 +104,13 @@ public class TestJDBC extends TestJDBCBase {
     static final String INSERT_TABLE_BATCH = "INSERT INTO TestBatch VALUES (1, 'First', 'Second');";
     static final String SELECT_TABLE_BATCH = "SELECT * FROM TestBatch;";
     static final String DROP_TABLE_BATCH = "DROP TABLE TestBatch";
+
+    // Queries for updating DB using VANTIQ Query
+    static final String CREATE_TABLE_QUERY = "CREATE TABLE TestQueryUpdate(id int, name varchar (255));";
+    static final String INSERT_TABLE_QUERY = "INSERT INTO TestQueryUpdate VALUES (1, 'Name');";
+    static final String SELECT_TABLE_QUERY = "SELECT * FROM TestQueryUpdate;";
+    static final String DELETE_ROWS_QUERY = "DELETE FROM TestQueryUpdate;";
+    static final String DROP_TABLE_QUERY = "DROP TABLE TestQueryUpdate;";
     
     static final String timestampPattern = "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}-\\d{4}";
     static final String datePattern = "\\d{4}-\\d{2}-\\d{2}";
@@ -204,11 +211,18 @@ public class TestJDBC extends TestJDBCBase {
             } catch (VantiqSQLException e) {
                 // Shouldn't throw Exception
             }
+
+            // Delete tenth table
+            try {
+                dropTablesJDBC.processPublish(DROP_TABLE_QUERY);
+            } catch (VantiqSQLException e) {
+                // Shouldn't throw Exception
+            }
             
             // Close the new JDBC Instance
             dropTablesJDBC.close();
 
-            // Delete all VANTIQ Resources incase they are still there
+            // Delete all VANTIQ Resources in case they are still there
             deleteSource();
             deleteType();
             deleteTopic();
@@ -764,7 +778,7 @@ public class TestJDBC extends TestJDBCBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
 
-        // Check that Source, Type, Topic, Procedure and Rule do not already exist in namespace, and skip test if they do
+        // Check that Source does not already exist in namespace, and skip test if they do
         assumeFalse(checkSourceExists());
 
         // Setup a VANTIQ JDBC Source, and start running the core
@@ -817,7 +831,7 @@ public class TestJDBC extends TestJDBCBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
 
-        // Check that Source, Type, Topic, Procedure and Rule do not already exist in namespace, and skip test if they do
+        // Check that Source does not already exist in namespace, and skip test if they do
         assumeFalse(checkSourceExists());
 
         // Setup a VANTIQ JDBC Source, and start running the core
@@ -850,6 +864,96 @@ public class TestJDBC extends TestJDBCBase {
         // Delete the Source
         deleteSource();
     }
+
+    @Test
+    public void testInvalidQueryUpdate() {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+        assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
+
+        // Check that Source does not already exist in namespace, and skip test if they do
+        assumeFalse(checkSourceExists());
+
+        // Setup a VANTIQ JDBC Source, and start running the core
+        setupSource(createSourceDef(false, false));
+
+        // Try creating table using query, but isUpdate is a String
+        Map<String,Object> create_params = new LinkedHashMap<String,Object>();
+        create_params.put("query", CREATE_TABLE_QUERY);
+        create_params.put("isUpdate", "true");
+        VantiqResponse response = vantiq.query(testSourceName, create_params);
+        assert response.hasErrors();
+
+        // Try creating table using query, but isUpdate is an int
+        create_params.put("isUpdate", 1);
+        response = vantiq.query(testSourceName, create_params);
+        assert response.hasErrors();
+
+        // Try creating table using query, but isUpdate is a map
+        create_params.put("isUpdate", new LinkedHashMap<>());
+        response = vantiq.query(testSourceName, create_params);
+        assert response.hasErrors();
+
+        // Try creating table using query, but isUpdate is a list
+        create_params.put("isUpdate", new ArrayList<>());
+        response = vantiq.query(testSourceName, create_params);
+        assert response.hasErrors();
+
+        // Delete the Source
+        deleteSource();
+    }
+
+    @Test
+    public void testQueryUpdate() {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+        assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
+
+        // Check that Source does not already exist in namespace, and skip test if they do
+        assumeFalse(checkSourceExists());
+
+        // Setup a VANTIQ JDBC Source, and start running the core
+        setupSource(createSourceDef(false, false));
+
+        // Create table using query
+        Map<String,Object> create_params = new LinkedHashMap<String,Object>();
+        create_params.put("query", CREATE_TABLE_QUERY);
+        create_params.put("isUpdate", true);
+        VantiqResponse response = vantiq.query(testSourceName, create_params);
+        assert !response.hasErrors();
+
+        // Inserting data into the table using query
+        Map<String,Object> insert_params = new LinkedHashMap<String,Object>();
+        insert_params.put("query", INSERT_TABLE_QUERY);
+        insert_params.put("isUpdate", true);
+        response = vantiq.query(testSourceName, insert_params);
+        assert !response.hasErrors();
+
+        // Select the data from table and make sure the previous queries worked
+        Map<String,Object> query_params = new LinkedHashMap<String,Object>();
+        query_params.put("query", SELECT_TABLE_QUERY);
+        response = vantiq.query(testSourceName, query_params);
+        JsonArray responseBody = (JsonArray) response.getBody();
+        JsonObject bodyObject = responseBody.get(0).getAsJsonObject();
+        assert bodyObject.get("id").getAsInt() == 1;
+        assert bodyObject.get("name").getAsString().equals("Name");
+
+        // Delete data from table using query
+        Map<String,Object> delete_params = new LinkedHashMap<String,Object>();
+        delete_params.put("query", DELETE_ROWS_QUERY);
+        delete_params.put("isUpdate", true);
+        response = vantiq.query(testSourceName, delete_params);
+        assert !response.hasErrors();
+
+        // Double check that the delete worked
+        response = vantiq.query(testSourceName, query_params);
+        responseBody = (JsonArray) response.getBody();
+        assert responseBody.size() == 0;
+
+        // Delete the Source
+        deleteSource();
+    }
+
     // ================================================= Helper functions =================================================
 
     public static boolean checkSourceExists() {


### PR DESCRIPTION
Closes #171 

Adds an enhancement which allows Vail Select Statements to update the database, in addition to querying the database. This is accomplished by adding the `isUpdate` parameter to the select statements.

All tests pass as expected.