### PR TITLE
Naf obj suppress null #178

### DIFF
--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -149,7 +149,8 @@ The Configuration document may look similar to the following example:
           "general": {
              "pollTime": 3000,
              "maxRunningThreads": 5,
-             "maxQueuedTasks": 10
+             "maxQueuedTasks": 10,
+             "suppressNullValues": true
           },
           "dataSource": {
              "camera": "http://166.155.71.82:8080/mjpg/video.mjpg",
@@ -194,6 +195,9 @@ for polling requests from the specific VANTIQ source. Must be a positive integer
     *   **NOTE:** The default behavior of the Object Recognition Source is to process up to 10 captured frames in parallel at 
     a time. If you would like the source to only process one frame at a time, then `maxRunningThreads` and `maxQueuedTasks` 
     must both be set to 1.
+*   suppressNullValues: Optional. Only used if `pollTime` has been specified. Must be a boolean value. If set to `true`, only 
+the neural net results containing recognitions, (from polled frames), will be sent back to the VANTIQ Source as a 
+Notificiation.
 
 ### Options Available for Data Source
 
@@ -684,11 +688,18 @@ The Extension Source can be setup for polling, for queries, or for both.
 
 ## Testing<a name="testing" id="testing"></a>
     
-In order to properly run the tests, you must first add the VANTIQ server you wish to connect to and corresponding auth token to your gradle.properties file in the ~/.gradle directory as follows:
+In order to properly run the tests, you must first add the VANTIQ server you wish to connect to and corresponding auth token 
+to your gradle.properties file in the ~/.gradle directory. The Target VANTIQ Server and Auth Token will be used to create a 
+temporary VANTIQ Source, VANTIQ Type and VANTIQ Rule. They will be named _testSourceName_, _testTypeName_, and _testRuleName_ 
+respectively. These names can optionally be configured by adding `EntConTestSourceName`, `EntConTestTypeName` and 
+`EntConTestRuleName` to the gradle.properties file. The following shows what the gradle.properties file should look like:
 
 ``` 
     TestAuthToken=<yourAuthToken>
     TestVantiqServer=<desiredVantiqServer>
+    EntConTestSourceName=<yourDesiredSourceName>
+    EntConTestTypeName=<yourDesiredTypeName>
+    EntConTestRuleName=<yourDesiredRuleName>
 ```
 
 The test will download two large (~200 MB) files before running the test. If you do not want this to occur, do not run

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -90,7 +90,7 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
     private static final String ALLOW_QUERIES = "allowQueries";
     private static final String MAX_RUNNING_THREADS = "maxRunningThreads";
     private static final String MAX_QUEUED_TASKS = "maxQueuedTasks";
-    private static final String SUPPRESS_NULL_VALUES = "suppressNullValues";
+    private static final String SUPPRESS_EMPTY_NEURAL_NET_RESULTS = "suppressEmptyNeuralNetResults";
     
     // Constants for Query Parameters
     private static final String OPERATION = "operation";
@@ -364,8 +364,8 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
         int maxQueuedTasks = MAX_QUEUED_TASKS_DEFAULT;
 
         // First, we'll check the suppressNullValues option
-        if (general.get(SUPPRESS_NULL_VALUES) instanceof Boolean && (Boolean) general.get(SUPPRESS_NULL_VALUES)) {
-            source.suppressNullValues = (Boolean) general.get(SUPPRESS_NULL_VALUES);
+        if (general.get(SUPPRESS_EMPTY_NEURAL_NET_RESULTS) instanceof Boolean && (Boolean) general.get(SUPPRESS_EMPTY_NEURAL_NET_RESULTS)) {
+            source.suppressNullValues = (Boolean) general.get(SUPPRESS_EMPTY_NEURAL_NET_RESULTS);
         }
 
         // Next, we'll check the parallel image processing options

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -88,6 +88,9 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
     private static final String POLL_TIME = "pollTime";
     private static final String POLL_RATE = "pollRate";
     private static final String ALLOW_QUERIES = "allowQueries";
+    private static final String MAX_RUNNING_THREADS = "maxRunningThreads";
+    private static final String MAX_QUEUED_TASKS = "maxQueuedTasks";
+    private static final String SUPPRESS_NULL_VALUES = "suppressNullValues";
     
     // Constants for Query Parameters
     private static final String OPERATION = "operation";
@@ -100,8 +103,8 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
     
     Handler<ExtensionServiceMessage> queryHandler;
     
-    private static final int MAX_RUNNING_THREADS = 10;
-    private static final int MAX_QUEUED_TASKS = 20;
+    private static final int MAX_RUNNING_THREADS_DEFAULT = 10;
+    private static final int MAX_QUEUED_TASKS_DEFAULT = 20;
     
     /**
      * Initializes the Handler for a source. The source name will be used in the logger's name.
@@ -357,15 +360,21 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
     private boolean prepareCommunication(Map<String, ?> general) {
         int polling = -1; // initializing to an invalid input
         boolean queryable = false;
-        int maxRunningThreads = MAX_RUNNING_THREADS;
-        int maxQueuedTasks = MAX_QUEUED_TASKS;
-        
-        if (general.get("maxRunningThreads") instanceof Integer && (Integer) general.get("maxRunningThreads") > 0) {
-            maxRunningThreads = (Integer) general.get("maxRunningThreads");
+        int maxRunningThreads = MAX_RUNNING_THREADS_DEFAULT;
+        int maxQueuedTasks = MAX_QUEUED_TASKS_DEFAULT;
+
+        // First, we'll check the suppressNullValues option
+        if (general.get(SUPPRESS_NULL_VALUES) instanceof Boolean && (Boolean) general.get(SUPPRESS_NULL_VALUES)) {
+            source.suppressNullValues = (Boolean) general.get(SUPPRESS_NULL_VALUES);
+        }
+
+        // Next, we'll check the parallel image processing options
+        if (general.get(MAX_RUNNING_THREADS) instanceof Integer && (Integer) general.get(MAX_RUNNING_THREADS) > 0) {
+            maxRunningThreads = (Integer) general.get(MAX_RUNNING_THREADS);
         }
         
-        if (general.get("maxQueuedTasks") instanceof Integer && (Integer) general.get("maxQueuedTasks") > 0) {
-            maxQueuedTasks = (Integer) general.get("maxQueuedTasks");
+        if (general.get(MAX_QUEUED_TASKS) instanceof Integer && (Integer) general.get(MAX_QUEUED_TASKS) > 0) {
+            maxQueuedTasks = (Integer) general.get(MAX_QUEUED_TASKS);
         }
                 
         source.pool = new ThreadPoolExecutor(maxRunningThreads, maxRunningThreads, 0l, TimeUnit.MILLISECONDS, 

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -365,7 +365,7 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
 
         // First, we'll check the suppressNullValues option
         if (general.get(SUPPRESS_EMPTY_NEURAL_NET_RESULTS) instanceof Boolean && (Boolean) general.get(SUPPRESS_EMPTY_NEURAL_NET_RESULTS)) {
-            source.suppressNullValues = (Boolean) general.get(SUPPRESS_EMPTY_NEURAL_NET_RESULTS);
+            source.suppressEmptyNeuralNetResults = (Boolean) general.get(SUPPRESS_EMPTY_NEURAL_NET_RESULTS);
         }
 
         // Next, we'll check the parallel image processing options

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -68,7 +68,7 @@ public class ObjectRecognitionCore {
     
     public String outputDir;
     public String lastQueryFilename;
-    public Boolean suppressNullValues = false;
+    public Boolean suppressEmptyNeuralNetResults = false;
     
     final Logger log;
     final static int    RECONNECT_INTERVAL = 5000;
@@ -331,7 +331,7 @@ public class ObjectRecognitionCore {
                 Map message = createMapFromResults(imageResults, results);
 
                 // If suppressNullValues is set to true, then skip sending message results list is empty
-                if (suppressNullValues) {
+                if (suppressEmptyNeuralNetResults) {
                     if (message.get("results") instanceof List && ((List) message.get("results")).size() == 0) {
                         return;
                     }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -68,6 +68,7 @@ public class ObjectRecognitionCore {
     
     public String outputDir;
     public String lastQueryFilename;
+    public Boolean suppressNullValues = false;
     
     final Logger log;
     final static int    RECONNECT_INTERVAL = 5000;
@@ -328,6 +329,13 @@ public class ObjectRecognitionCore {
             if (!localNeuralNet.getClass().toString().contains("NoProcessor")) {
                 // Translate the results from the neural net and image into a message to send back 
                 Map message = createMapFromResults(imageResults, results);
+
+                // If suppressNullValues is set to true, then skip sending message results list is empty
+                if (suppressNullValues) {
+                    if (message.get("results") instanceof List && ((List) message.get("results")).size() == 0) {
+                        return;
+                    }
+                }
                 client.sendNotification(message);
             }
         } catch (ImageProcessingException e) {

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetTestBase.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetTestBase.java
@@ -23,7 +23,6 @@ import io.vantiq.client.Vantiq;
 import io.vantiq.client.VantiqError;
 import io.vantiq.client.VantiqResponse;
 import io.vantiq.extsrc.objectRecognition.ObjRecTestBase;
-import io.vantiq.extsrc.objectRecognition.ObjectRecognitionCore;
 
 public class NeuralNetTestBase extends ObjRecTestBase {
     public static final String MODEL_DIRECTORY = System.getProperty("buildDir") + "/models";

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetTestBase.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetTestBase.java
@@ -14,12 +14,16 @@ import static org.junit.Assert.fail;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import io.vantiq.client.Vantiq;
 import io.vantiq.client.VantiqError;
 import io.vantiq.client.VantiqResponse;
 import io.vantiq.extsrc.objectRecognition.ObjRecTestBase;
+import io.vantiq.extsrc.objectRecognition.ObjectRecognitionCore;
 
 public class NeuralNetTestBase extends ObjRecTestBase {
     public static final String MODEL_DIRECTORY = System.getProperty("buildDir") + "/models";
@@ -77,5 +81,59 @@ public class NeuralNetTestBase extends ObjRecTestBase {
                 }
             }
         }
+    }
+
+    public static boolean checkSourceExists(Vantiq vantiq) {
+        Map<String,String> where = new LinkedHashMap<String,String>();
+        where.put("name", testSourceName);
+        VantiqResponse response = vantiq.select("system.sources", null, where, null);
+        ArrayList responseBody = (ArrayList) response.getBody();
+        if (responseBody.isEmpty()) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public static void deleteSource(Vantiq vantiq) {
+        Map<String,Object> where = new LinkedHashMap<String,Object>();
+        where.put("name", testSourceName);
+        VantiqResponse response = vantiq.delete("system.sources", where);
+    }
+
+    public static boolean checkTypeExists(Vantiq vantiq) {
+        Map<String,String> where = new LinkedHashMap<String,String>();
+        where.put("name", testTypeName);
+        VantiqResponse response = vantiq.select("system.types", null, where, null);
+        ArrayList responseBody = (ArrayList) response.getBody();
+        if (responseBody.isEmpty()) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public static void deleteType(Vantiq vantiq) {
+        Map<String,Object> where = new LinkedHashMap<String,Object>();
+        where.put("name", testTypeName);
+        VantiqResponse response = vantiq.delete("system.types", where);
+    }
+
+    public static boolean checkRuleExists(Vantiq vantiq) {
+        Map<String,String> where = new LinkedHashMap<String,String>();
+        where.put("name", testRuleName);
+        VantiqResponse response = vantiq.select("system.rules", null, where, null);
+        ArrayList responseBody = (ArrayList) response.getBody();
+        if (responseBody.isEmpty()) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public static void deleteRule(Vantiq vantiq) {
+        Map<String,Object> where = new LinkedHashMap<String,Object>();
+        where.put("name", testRuleName);
+        VantiqResponse response = vantiq.delete("system.rules", where);
     }
 }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
@@ -132,7 +132,7 @@ public class TestParallelProcessing extends NeuralNetTestBase {
         objRecConfig.put("dataSource", dataSource);
         objRecConfig.put("neuralNet", neuralNet);
 
-        // Putting objRecConfig and vantiq config in the source configuration
+        // Putting objRecConfig in the source configuration
         sourceConfig.put("objRecConfig", objRecConfig);
 
         // Setting up the source definition

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
@@ -32,9 +32,9 @@ public class TestParallelProcessing extends NeuralNetTestBase {
     @AfterClass
     public static void tearDown() {
         // Double check that everything was deleted from VANTIQ
-        deleteSource();
-        deleteType();
-        deleteRule();
+        deleteSource(vantiq);
+        deleteType(vantiq);
+        deleteRule(vantiq);
     }
 
     @Test
@@ -60,9 +60,9 @@ public class TestParallelProcessing extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
 
         // Check that Source, Type, Topic, Procedure and Rule do not already exist in namespace, and skip test if they do
-        assumeFalse(checkSourceExists());
-        assumeFalse(checkTypeExists());
-        assumeFalse(checkRuleExists());
+        assumeFalse(checkSourceExists(vantiq));
+        assumeFalse(checkTypeExists(vantiq));
+        assumeFalse(checkRuleExists(vantiq));
 
         // Setup a VANTIQ Obj Rec Source, and start running the core
         setupSource(createSourceDef(useCustomTaskConfig));
@@ -87,23 +87,12 @@ public class TestParallelProcessing extends NeuralNetTestBase {
 
         // Delete the Source/Type/Rule from VANTIQ
         core.close();
-        deleteSource();
-        deleteType();
-        deleteRule();
+        deleteSource(vantiq);
+        deleteType(vantiq);
+        deleteRule(vantiq);
     }
 
     // ================================================= Helper functions =================================================
-    public static boolean checkSourceExists() {
-        Map<String,String> where = new LinkedHashMap<String,String>();
-        where.put("name", testSourceName);
-        VantiqResponse response = vantiq.select("system.sources", null, where, null);
-        ArrayList responseBody = (ArrayList) response.getBody();
-        if (responseBody.isEmpty()) {
-            return false;
-        } else {
-            return true;
-        }
-    }
 
     public static void setupSource(Map<String,Object> sourceDef) {
         VantiqResponse insertResponse = vantiq.insert("system.sources", sourceDef);
@@ -138,7 +127,7 @@ public class TestParallelProcessing extends NeuralNetTestBase {
         neuralNet.put("type", "test");
         neuralNet.put("sleepTime", 5000);
 
-        // Placing general config options in "jdbcConfig"
+        // Placing general config options in "objRecConfig"
         objRecConfig.put("general", general);
         objRecConfig.put("dataSource", dataSource);
         objRecConfig.put("neuralNet", neuralNet);
@@ -156,24 +145,6 @@ public class TestParallelProcessing extends NeuralNetTestBase {
         return sourceDef;
     }
 
-    public static void deleteSource() {
-        Map<String,Object> where = new LinkedHashMap<String,Object>();
-        where.put("name", testSourceName);
-        VantiqResponse response = vantiq.delete("system.sources", where);
-    }
-
-    public static boolean checkTypeExists() {
-        Map<String,String> where = new LinkedHashMap<String,String>();
-        where.put("name", testTypeName);
-        VantiqResponse response = vantiq.select("system.types", null, where, null);
-        ArrayList responseBody = (ArrayList) response.getBody();
-        if (responseBody.isEmpty()) {
-            return false;
-        } else {
-            return true;
-        }
-    }
-
     public static void setupType() {
         Map<String,Object> typeDef = new LinkedHashMap<String,Object>();
         Map<String,Object> properties = new LinkedHashMap<String,Object>();
@@ -186,35 +157,11 @@ public class TestParallelProcessing extends NeuralNetTestBase {
         vantiq.insert("system.types", typeDef);
     }
 
-    public static void deleteType() {
-        Map<String,Object> where = new LinkedHashMap<String,Object>();
-        where.put("name", testTypeName);
-        VantiqResponse response = vantiq.delete("system.types", where);
-    }
-
-    public static boolean checkRuleExists() {
-        Map<String,String> where = new LinkedHashMap<String,String>();
-        where.put("name", testRuleName);
-        VantiqResponse response = vantiq.select("system.rules", null, where, null);
-        ArrayList responseBody = (ArrayList) response.getBody();
-        if (responseBody.isEmpty()) {
-            return false;
-        } else {
-            return true;
-        }
-    }
-
     public static void setupRule() {
         String rule = "RULE " + testRuleName + "\n"
-                    + "WHEN MESSAGE ARRIVES FROM " + testSourceName +  " AS message\n"
+                    + "WHEN MESSAGE ARRIVES FROM " + testSourceName + " AS message\n"
                     + "INSERT " + testTypeName + "(id: 1)";
 
         vantiq.insert("system.rules", rule);
-    }
-
-    public static void deleteRule() {
-        Map<String,Object> where = new LinkedHashMap<String,Object>();
-        where.put("name", testRuleName);
-        VantiqResponse response = vantiq.delete("system.rules", where);
     }
 }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -84,7 +84,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
     static final int KEYBOARD_CROPPED_HEIGHT = 125;
 
     // Used to test suppressNullValues
-    static final String NULL_IP_CAMERA_ADDRESS = "http://183.77.203.213:80/-wvhttp-01-/GetOneShot?image_size=640x480&frame_count=1000000000";
+    static final String NO_RECOGNIZED_OBJECTS_CAMERA_ADDRESS = "http://183.77.203.213:80/-wvhttp-01-/GetOneShot?image_size=640x480&frame_count=1000000000";
     static final int CORE_START_TIMEOUT = 10;
 
     static ObjectRecognitionCore core;
@@ -1880,10 +1880,10 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
         // Setting up general config options
         general.put("pollTime", 1000);
-        general.put("suppressNullValues", suppressNullValues);
+        general.put("suppressEmptyNeuralNetResults", suppressNullValues);
 
         // Setting up dataSource config options
-        dataSource.put("camera", NULL_IP_CAMERA_ADDRESS);
+        dataSource.put("camera", NO_RECOGNIZED_OBJECTS_CAMERA_ADDRESS);
         dataSource.put("type", "network");
 
         // Setting up neuralNet config options

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -1896,7 +1896,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         objRecConfig.put("dataSource", dataSource);
         objRecConfig.put("neuralNet", neuralNet);
 
-        // Putting objRecConfig and vantiq config in the source configuration
+        // Putting objRecConfig in the source configuration
         sourceConfig.put("objRecConfig", objRecConfig);
 
         // Setting up the source definition

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -128,7 +128,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
             core.stop();
             core = null;
         }
-        deleteSource();
+        deleteSource(vantiq);
         deleteDirectory(OUTPUT_DIR);
         
         for (int i = 0; i < vantiqUploadFiles.size(); i++) {
@@ -813,12 +813,6 @@ public class TestYoloQueries extends NeuralNetTestBase {
     
     public static void querySource(Map<String,Object> params) {
         vantiq.query(SOURCE_NAME, params);
-    }
-    
-    public static void deleteSource() {
-        Map<String,Object> where = new LinkedHashMap<String,Object>();
-        where.put("name", SOURCE_NAME);
-        vantiq.delete("system.sources", where);
     }
     
     public static void deleteFileFromVantiq(String filename) {

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -42,7 +42,6 @@ public class TestYoloQueries extends NeuralNetTestBase {
     static final String PB_FILE = "coco-" + COCO_MODEL_VERSION + ".pb";
     static final String META_FILE = "coco-" + COCO_MODEL_VERSION + ".meta";
     static final String OUTPUT_DIR = System.getProperty("buildDir") + "/resources/out";
-    static final String SOURCE_NAME = "UnlikelyToExistTestObjectRecognitionSource";
     static final String IP_CAMERA_ADDRESS = "http://207.192.232.2:8000/mjpg/video.mjpg";
 
     static final String IMAGE_1_DATE = "2019-02-05--02-35-10";


### PR DESCRIPTION
Closes #178 

This enhancement adds a new general config option, `suppressNullValues`. If this flag is set to true, then any polling data with no recognitions will not be sent to the source.

Also pulled some duplicated test code out and put it into NeuralNetTestBase.

All tests pass as expected, and build is successful.