### PR TITLE
Obj Rec - Adding ability to upload images as VANTIQ Images

### DIFF
--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -164,6 +164,7 @@ The Configuration document may look similar to the following example:
              "saveImage": "both",
              "saveRate": 1,
              "outputDir": "imageOut",
+             "uploadAsImage": true,
              "savedResolution": {
                 "longEdge": 400
              },
@@ -249,6 +250,9 @@ is set to be either "local" or "both".
 captured). If not specified, the value will default to 1 which saves every captured image.
 *   labelImage: Optional. If set to "true", images will be saved with bounding boxes and labels. If set to "false", or if not 
 set at all, the images will be saved with no bounding boxes or labels.
+*   uploadAsImage: Optional. If set to "true", images will be uploaded to VANTIQ as VANTIQ Images, (the default behavior 
+uploads images as VANTIQ Documents).
+    *   **NOTE**: This option is only relevant if "saveImage" has been set to either "vantiq" or "both".
 *   savedResolution: Optional. A map containing options for adjusting the resolution of the saved images.
     * *Options for savedResolution:*
     1. longEdge: Optional. This sets the maximum long edge dimension for saved images. Must be a non-negative integer that is 
@@ -327,6 +331,8 @@ it will be set to the default value, "processNextFrame".
         is defined here as a query parameter, it will override the value set in the source configuration, otherwise the source 
         configuration value will be used. The setting cannot be larger than that provided in the source configuration (since 
         that defines how the images are saved).
+        *   uploadAsImage: Optional. If set to "true", images will be uploaded to VANTIQ as VANTIQ Images, (the default 
+        behavior uploads images as VANTIQ Documents).
     
 *   **Delete locally saved images:**
     *   The user can specify an image or a set of images specified by their date & time to be deleted. The images will be 
@@ -356,6 +362,8 @@ it will be set to the default value, "processNextFrame".
         *   "cropBeforeAnalysis": Optional. This value can be set exactly like the "cropBeforeAnalysis" value in the source 
         configuration. If no cropBeforeAnalysis value is set as a query parameter, the source configuration's 
         cropBeforeAnalysis value will be used.
+        *   uploadAsImage: Optional. If set to "true", images will be uploaded to VANTIQ as VANTIQ Images, (the default 
+        behavior uploads images as VANTIQ Documents).
     
 **EXAMPLE QUERIES**:
 
@@ -367,11 +375,12 @@ SELECT * FROM SOURCE Camera1 AS results WITH
     	savedResolution: {longEdge:600}
 ```
 
-*   Upload Query using imageDate:
+*   Upload Query using imageDate, uploading as VANTIQ Images:
 ```
 SELECT * FROM SOURCE Camera1 AS results WITH
     	operation:"upload",
-    	imageDate:["2019-02-08--10-33-36", "2019-02-08--12-45-18"]
+    	imageDate:["2019-02-08--10-33-36", "2019-02-08--12-45-18"],
+        uploadAsImage: true
 ```
 
 *   Delete Query using imageName:
@@ -417,6 +426,15 @@ SELECT * FROM SOURCE Camera1 AS results WITH
             width: 600,
             height: 400
         }
+```
+
+* Process Next Frame Query, uploading as VANTIQ Image:
+```
+SELECT * FROM SOURCE Camera1 AS results WITH
+        operation:"processNextFrame",
+    	NNsaveImage:"vantiq",
+    	NNfileName:"testFile",
+        uploadAsImage: true
 ```
 
 *   Process Next Frame Query without specifying operation *(not recommended)*:

--- a/objectRecognitionSource/build.gradle
+++ b/objectRecognitionSource/build.gradle
@@ -249,7 +249,7 @@ dependencies {
     }
     
     // Used for uploading documents (images) to VANTIQ with VANTIQ SDK
-    compile 'io.vantiq:vantiq-sdk:1.0.17'
+    compile 'io.vantiq:vantiq-sdk:1.0.24'
 
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
@@ -195,25 +195,23 @@ public class ObjectDetector {
     /**
      * Detect objects on the given image
      * <br>Edited to return the results as a map and conditionally save the image
-     * @param image     The image in jpeg format
-     * @param outputDir The directory to which the image should be written, (under current working directory unless
-     *                  otherwise specified). If saveImage is null, no image is saved.
-     * @param saveImage The destination to which the image shall be saved, (either in VANTIQ, locally, or both). If null and
-     *                  filename is null, no image is saved. If null and fileName is non-null, images will be saved.
-     * @param fileName  The name of the file to which the image is saved, with ".jpg" appended if necessary. If
-     *                  {@code outputDir} is null and no default exists, no image is saved. If {@code fileName} is null
-     *                  and {@code outputDir} is non-null, then the file is saved as
-     *                  "&lt;year&gt;-&lt;month&gt;-&lt;day&gt;--&lt;hour&gt;-&lt;minute&gt;-&lt;second&gt;.jpg"
-     * @param vantiq    The Vantiq variable used to connect to the VANTIQ SDK. Either authenticated, or set to null.
-     * @return          A List of Maps, each of which has a {@code label} stating the type of the object identified, a
-     *                  {@code confidence} specifying on a scale of 0-1 how confident the neural net is that the
-     *                  identification is accurate, and a {@code location} containing the coordinates for the
-     *                  {@code top},{@code left}, {@code bottom}, and {@code right} edges of the bounding box for
-     *                  the object.
+     * @param image         The image in jpeg format
+     * @param outputDir     The directory to which the image should be written, (under current working directory unless
+     *                      otherwise specified). If saveImage is null, no image is saved.
+     * @param fileName      The name of the file to which the image is saved, with ".jpg" appended if necessary. If
+     *                      {@code outputDir} is null and no default exists, no image is saved. If {@code fileName} is null
+     *                      and {@code outputDir} is non-null, then the file is saved as
+     *                      "&lt;year&gt;-&lt;month&gt;-&lt;day&gt;--&lt;hour&gt;-&lt;minute&gt;-&lt;second&gt;.jpg"
+     * @param vantiq        The Vantiq variable used to connect to the VANTIQ SDK. Either authenticated, or set to null.
+     * @param uploadAsImage The boolean flag used to specify if images should be uploaded to VANTIQ as Documents or VANTIQ Images
+     * @return              A List of Maps, each of which has a {@code label} stating the type of the object identified, a
+     *                      {@code confidence} specifying on a scale of 0-1 how confident the neural net is that the
+     *                      identification is accurate, and a {@code location} containing the coordinates for the
+     *                      {@code top},{@code left}, {@code bottom}, and {@code right} edges of the bounding box for
+     *                      the object.
      */
-    public List<Map<String, ?>> detect(final byte[] image, String outputDir, String fileName, Vantiq vantiq) {
+    public List<Map<String, ?>> detect(final byte[] image, String outputDir, String fileName, Vantiq vantiq, boolean uploadAsImage) {
         try (Tensor<Float> normalizedImage = normalizeImage(image)) {
-            Date now = new Date(); // Saves the time before
             List<Recognition> recognitions = YOLOClassifier.getInstance(threshold, anchorArray, frameSize).classifyImage(executeYOLOGraph(normalizedImage), labels);
             BufferedImage buffImage = imageUtil.createImageFromBytes(image);
             
@@ -224,6 +222,7 @@ public class ObjectDetector {
                 imageUtil.vantiq = vantiq;
                 imageUtil.sourceName = sourceName;
                 imageUtil.frameSize = frameSize;
+                imageUtil.uploadAsImage = uploadAsImage;
                 lastFilename = fileName;
                 if (labelImage) {
                     buffImage = imageUtil.labelImage(buffImage, recognitions);

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
@@ -37,7 +37,7 @@ public class ImageUtil {
 
     /**
      * Label image with classes and predictions given by the TensorFLow YOLO Implementation
-     * @param bufferedImage         buffered image to label
+     * @param bufferedImage buffered image to label
      * @param recognitions  list of recognized objects
      */
     public BufferedImage labelImage(BufferedImage bufferedImage, final List<Recognition> recognitions) {
@@ -158,25 +158,6 @@ public class ImageUtil {
                     "objectRecognition/" + sourceName + '/'  + target,
                     responseHandler);
         }
-
-//        vantiq.upload(fileToUpload,
-//                "image/jpeg",
-//                "objectRecognition/" + sourceName + '/'  + target,
-//                new BaseResponseHandler() {
-//                    @Override public void onSuccess(Object body, Response response) {
-//                        super.onSuccess(body, response);
-//                        LOGGER.trace("Content Location = " + this.getBodyAsJsonObject().get("content"));
-//
-//                        if (outputDir == null) {
-//                            deleteImage(fileToUpload);
-//                        }
-//                    }
-//
-//                    @Override public void onError(List<VantiqError> errors, Response response) {
-//                        super.onError(errors, response);
-//                        LOGGER.error("Errors uploading image with VANTIQ SDK: " + errors);
-//                    }
-//        });
     }
     
     /**

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -72,31 +72,31 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
     boolean                 configComplete = false;
     
     // Constants for Source Configuration
-    private static final String CONFIG                              = "config";
-    private static final String OBJ_REC_CONFIG                      = "objRecConfig";
-    private static final String GENERAL                             = "general";
-    private static final String DATA_SOURCE                         = "dataSource";
-    private static final String FILE                                = "file";
-    private static final String CAMERA                              = "camera";
-    private static final String NETWORK                             = "network";
-    private static final String FTP                                 = "ftp";
-    private static final String NEURAL_NET                          = "neuralNet";
-    private static final String YOLO                                = "yolo";
-    private static final String NONE                                = "none";
-    private static final String DEFAULT                             = "default";
-    private static final String TEST                                = "test";
-    private static final String POLL_TIME                           = "pollTime";
-    private static final String POLL_RATE                           = "pollRate";
-    private static final String ALLOW_QUERIES                       = "allowQueries";
-    private static final String MAX_RUNNING_THREADS                 = "maxRunningThreads";
-    private static final String MAX_QUEUED_TASKS                    = "maxQueuedTasks";
-    private static final String SUPPRESS_EMPTY_NEURAL_NET_RESULTS   = "suppressEmptyNeuralNetResults";
+    private static final String CONFIG = "config";
+    private static final String OBJ_REC_CONFIG = "objRecConfig";
+    private static final String GENERAL = "general";
+    private static final String DATA_SOURCE = "dataSource";
+    private static final String FILE = "file";
+    private static final String CAMERA = "camera";
+    private static final String NETWORK = "network";
+    private static final String FTP = "ftp";
+    private static final String NEURAL_NET = "neuralNet";
+    private static final String YOLO = "yolo";
+    private static final String NONE = "none";
+    private static final String DEFAULT = "default";
+    private static final String TEST = "test";
+    private static final String POLL_TIME = "pollTime";
+    private static final String POLL_RATE = "pollRate";
+    private static final String ALLOW_QUERIES = "allowQueries";
+    private static final String MAX_RUNNING_THREADS = "maxRunningThreads";
+    private static final String MAX_QUEUED_TASKS = "maxQueuedTasks";
+    private static final String SUPPRESS_EMPTY_NEURAL_NET_RESULTS = "suppressEmptyNeuralNetResults";
 
     // Constants for Query Parameters
-    private static final String OPERATION           = "operation";
-    private static final String PROCESS_NEXT_FRAME  = "processnextframe";
-    private static final String UPLOAD              = "upload";
-    private static final String DELETE              = "delete";
+    private static final String OPERATION = "operation";
+    private static final String PROCESS_NEXT_FRAME = "processnextframe";
+    private static final String UPLOAD = "upload";
+    private static final String DELETE = "delete";
     
     Map<String, ?> lastDataSource = null;
     Map<String, ?> lastNeuralNet = null;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -72,31 +72,31 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
     boolean                 configComplete = false;
     
     // Constants for Source Configuration
-    private static final String CONFIG = "config";
-    private static final String OBJ_REC_CONFIG = "objRecConfig";
-    private static final String GENERAL = "general";
-    private static final String DATA_SOURCE = "dataSource";
-    private static final String FILE = "file";
-    private static final String CAMERA = "camera";
-    private static final String NETWORK = "network";
-    private static final String FTP = "ftp";
-    private static final String NEURAL_NET = "neuralNet";
-    private static final String YOLO = "yolo";
-    private static final String NONE = "none";
-    private static final String DEFAULT = "default";
-    private static final String TEST = "test";
-    private static final String POLL_TIME = "pollTime";
-    private static final String POLL_RATE = "pollRate";
-    private static final String ALLOW_QUERIES = "allowQueries";
-    private static final String MAX_RUNNING_THREADS = "maxRunningThreads";
-    private static final String MAX_QUEUED_TASKS = "maxQueuedTasks";
-    private static final String SUPPRESS_EMPTY_NEURAL_NET_RESULTS = "suppressEmptyNeuralNetResults";
-    
+    private static final String CONFIG                              = "config";
+    private static final String OBJ_REC_CONFIG                      = "objRecConfig";
+    private static final String GENERAL                             = "general";
+    private static final String DATA_SOURCE                         = "dataSource";
+    private static final String FILE                                = "file";
+    private static final String CAMERA                              = "camera";
+    private static final String NETWORK                             = "network";
+    private static final String FTP                                 = "ftp";
+    private static final String NEURAL_NET                          = "neuralNet";
+    private static final String YOLO                                = "yolo";
+    private static final String NONE                                = "none";
+    private static final String DEFAULT                             = "default";
+    private static final String TEST                                = "test";
+    private static final String POLL_TIME                           = "pollTime";
+    private static final String POLL_RATE                           = "pollRate";
+    private static final String ALLOW_QUERIES                       = "allowQueries";
+    private static final String MAX_RUNNING_THREADS                 = "maxRunningThreads";
+    private static final String MAX_QUEUED_TASKS                    = "maxQueuedTasks";
+    private static final String SUPPRESS_EMPTY_NEURAL_NET_RESULTS   = "suppressEmptyNeuralNetResults";
+
     // Constants for Query Parameters
-    private static final String OPERATION = "operation";
-    private static final String PROCESS_NEXT_FRAME = "processnextframe";
-    private static final String UPLOAD = "upload";
-    private static final String DELETE = "delete";
+    private static final String OPERATION           = "operation";
+    private static final String PROCESS_NEXT_FRAME  = "processnextframe";
+    private static final String UPLOAD              = "upload";
+    private static final String DELETE              = "delete";
     
     Map<String, ?> lastDataSource = null;
     Map<String, ?> lastNeuralNet = null;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -71,7 +71,7 @@ public class ObjectRecognitionCore {
     public Boolean suppressEmptyNeuralNetResults = false;
     
     final Logger log;
-    final static int    RECONNECT_INTERVAL = 5000;
+    final static int RECONNECT_INTERVAL = 5000;
 
     // Constants for Query Parameters
     private static final String IMAGE_NAME          = "imageName";
@@ -550,6 +550,11 @@ public class ObjectRecognitionCore {
                    imageUtil.queryResize = true;
                }
            }
+       }
+
+       // Check if images should be uploaded to VANTIQ as VANTIQ IMAGES
+       if (request.get(UPLOAD_AS_IMAGE) instanceof Boolean && (Boolean) request.get(UPLOAD_AS_IMAGE)) {
+            imageUtil.uploadAsImage = (Boolean) request.get(UPLOAD_AS_IMAGE);
        }
        
        return imageUtil;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -74,13 +74,14 @@ public class ObjectRecognitionCore {
     final static int    RECONNECT_INTERVAL = 5000;
 
     // Constants for Query Parameters
-    private static final String IMAGE_NAME = "imageName";
-    private static final String IMAGE_DATE = "imageDate";
-    private static final String SAVED_RESOLUTION = "savedResolution";
-    private static final String LONG_EDGE = "longEdge";
-    private static final String UPLOAD = "upload";
-    private static final String DELETE = "delete";
-    private static final String FILTER = "filter";
+    private static final String IMAGE_NAME          = "imageName";
+    private static final String IMAGE_DATE          = "imageDate";
+    private static final String SAVED_RESOLUTION    = "savedResolution";
+    private static final String LONG_EDGE           = "longEdge";
+    private static final String UPLOAD              = "upload";
+    private static final String DELETE              = "delete";
+    private static final String FILTER              = "filter";
+    private static final String UPLOAD_AS_IMAGE     = "uploadAsImage";
 
     /**
      * Stops sending messages to the source and tries to reconnect, closing on a failure

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -74,14 +74,14 @@ public class ObjectRecognitionCore {
     final static int RECONNECT_INTERVAL = 5000;
 
     // Constants for Query Parameters
-    private static final String IMAGE_NAME          = "imageName";
-    private static final String IMAGE_DATE          = "imageDate";
-    private static final String SAVED_RESOLUTION    = "savedResolution";
-    private static final String LONG_EDGE           = "longEdge";
-    private static final String UPLOAD              = "upload";
-    private static final String DELETE              = "delete";
-    private static final String FILTER              = "filter";
-    private static final String UPLOAD_AS_IMAGE     = "uploadAsImage";
+    private static final String IMAGE_NAME = "imageName";
+    private static final String IMAGE_DATE = "imageDate";
+    private static final String SAVED_RESOLUTION = "savedResolution";
+    private static final String LONG_EDGE = "longEdge";
+    private static final String UPLOAD = "upload";
+    private static final String DELETE = "delete";
+    private static final String FILTER = "filter";
+    private static final String UPLOAD_AS_IMAGE = "uploadAsImage";
 
     /**
      * Stops sending messages to the source and tries to reconnect, closing on a failure

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NoProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NoProcessor.java
@@ -25,18 +25,18 @@ import io.vantiq.extsrc.objectRecognition.exception.ImageProcessingException;
 public class NoProcessor implements NeuralNetInterface {
 
     // Constants for Source Configuration options
-    private static final String SAVE_IMAGE          = "saveImage";
-    private static final String BOTH                = "both";
-    private static final String LOCAL               = "local";
-    private static final String VANTIQ              = "vantiq";
-    private static final String OUTPUT_DIR          = "outputDir";
-    private static final String SAVE_RATE           = "saveRate";
-    private static final String UPLOAD_AS_IMAGE     = "uploadAsImage";
+    private static final String SAVE_IMAGE = "saveImage";
+    private static final String BOTH = "both";
+    private static final String LOCAL = "local";
+    private static final String VANTIQ = "vantiq";
+    private static final String OUTPUT_DIR = "outputDir";
+    private static final String SAVE_RATE = "saveRate";
+    private static final String UPLOAD_AS_IMAGE = "uploadAsImage";
 
     // Constants for Query Parameter options
-    private static final String NN_OUTPUT_DIR   = "NNoutputDir";
-    private static final String NN_FILENAME     = "NNfileName";
-    private static final String NN_SAVE_IMAGE   = "NNsaveImage";
+    private static final String NN_OUTPUT_DIR = "NNoutputDir";
+    private static final String NN_FILENAME = "NNfileName";
+    private static final String NN_SAVE_IMAGE = "NNsaveImage";
     
     // This will be used to create
     // "year-month-date-hour-minute-seconds"

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -78,6 +78,7 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
     ImageUtil imageUtil;
     float threshold = 0.5f;
     int saveRate = 1;
+    boolean uploadAsImage = false;
     
     // Variables for pre crop
     int x = -1;
@@ -89,30 +90,32 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
     ObjectDetector objectDetector = null;
     
     // Constants for Source Configuration options
-    private static final String CROP_BEFORE = "cropBeforeAnalysis";
-    private static final String X = "x";
-    private static final String Y = "y";
-    private static final String WIDTH = "width";
-    private static final String HEIGHT = "height";
-    private static final String META_FILE = "metaFile";
-    private static final String LABEL_FILE = "labelFile";
-    private static final String PB_FILE = "pbFile";
-    private static final String THRESHOLD = "threshold";
-    private static final String ANCHORS = "anchors";
-    private static final String SAVE_IMAGE = "saveImage";
-    private static final String BOTH = "both";
-    private static final String LOCAL = "local";
-    private static final String VANTIQ = "vantiq";
-    private static final String OUTPUT_DIR = "outputDir";
-    private static final String LABEL_IMAGE = "labelImage";
-    private static final String SAVE_RATE = "saveRate";
-    private static final String SAVED_RESOLUTION = "savedResolution";
-    private static final String LONG_EDGE = "longEdge";
-    
+    private static final String CROP_BEFORE         = "cropBeforeAnalysis";
+    private static final String X                   = "x";
+    private static final String Y                   = "y";
+    private static final String WIDTH               = "width";
+    private static final String HEIGHT              = "height";
+    private static final String META_FILE           = "metaFile";
+    private static final String LABEL_FILE          = "labelFile";
+    private static final String PB_FILE             = "pbFile";
+    private static final String THRESHOLD           = "threshold";
+    private static final String ANCHORS             = "anchors";
+    private static final String SAVE_IMAGE          = "saveImage";
+    private static final String BOTH                = "both";
+    private static final String LOCAL               = "local";
+    private static final String VANTIQ              = "vantiq";
+    private static final String OUTPUT_DIR          = "outputDir";
+    private static final String LABEL_IMAGE         = "labelImage";
+    private static final String SAVE_RATE           = "saveRate";
+    private static final String SAVED_RESOLUTION    = "savedResolution";
+    private static final String LONG_EDGE           = "longEdge";
+    private static final String UPLOAD_AS_IMAGE     = "uploadAsImage";
+
+
     // Constants for Query Parameter options
-    private static final String NN_OUTPUT_DIR = "NNoutputDir";
-    private static final String NN_FILENAME = "NNfileName";
-    private static final String NN_SAVE_IMAGE = "NNsaveImage";
+    private static final String NN_OUTPUT_DIR   = "NNoutputDir";
+    private static final String NN_FILENAME     = "NNfileName";
+    private static final String NN_SAVE_IMAGE   = "NNsaveImage";
 
     private static SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd--HH-mm-ss");
 
@@ -235,6 +238,11 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
            if (saveImage.equalsIgnoreCase(VANTIQ) || saveImage.equalsIgnoreCase(BOTH)) {
                vantiq = new io.vantiq.client.Vantiq(server);
                vantiq.setAccessToken(authToken);
+
+               // Check if images should be uploaded to VANTIQ as VANTIQ IMAGES
+               if (neuralNet.get(UPLOAD_AS_IMAGE) instanceof Boolean && (Boolean) neuralNet.get(UPLOAD_AS_IMAGE)) {
+                   uploadAsImage = (Boolean) neuralNet.get(UPLOAD_AS_IMAGE);
+               }
            }
            
            // Check if any resolution configurations have been set
@@ -258,6 +266,7 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
            imageUtil.vantiq = vantiq;
            imageUtil.saveImage = true;
            imageUtil.sourceName = sourceName;
+           imageUtil.uploadAsImage = uploadAsImage;
            if (neuralNet.get(SAVE_RATE) instanceof Integer) {
                saveRate = (Integer) neuralNet.get(SAVE_RATE);
            }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -90,32 +90,32 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
     ObjectDetector objectDetector = null;
     
     // Constants for Source Configuration options
-    private static final String CROP_BEFORE         = "cropBeforeAnalysis";
-    private static final String X                   = "x";
-    private static final String Y                   = "y";
-    private static final String WIDTH               = "width";
-    private static final String HEIGHT              = "height";
-    private static final String META_FILE           = "metaFile";
-    private static final String LABEL_FILE          = "labelFile";
-    private static final String PB_FILE             = "pbFile";
-    private static final String THRESHOLD           = "threshold";
-    private static final String ANCHORS             = "anchors";
-    private static final String SAVE_IMAGE          = "saveImage";
-    private static final String BOTH                = "both";
-    private static final String LOCAL               = "local";
-    private static final String VANTIQ              = "vantiq";
-    private static final String OUTPUT_DIR          = "outputDir";
-    private static final String LABEL_IMAGE         = "labelImage";
-    private static final String SAVE_RATE           = "saveRate";
-    private static final String SAVED_RESOLUTION    = "savedResolution";
-    private static final String LONG_EDGE           = "longEdge";
-    private static final String UPLOAD_AS_IMAGE     = "uploadAsImage";
+    private static final String CROP_BEFORE = "cropBeforeAnalysis";
+    private static final String X = "x";
+    private static final String Y = "y";
+    private static final String WIDTH = "width";
+    private static final String HEIGHT = "height";
+    private static final String META_FILE = "metaFile";
+    private static final String LABEL_FILE = "labelFile";
+    private static final String PB_FILE = "pbFile";
+    private static final String THRESHOLD = "threshold";
+    private static final String ANCHORS = "anchors";
+    private static final String SAVE_IMAGE = "saveImage";
+    private static final String BOTH = "both";
+    private static final String LOCAL = "local";
+    private static final String VANTIQ = "vantiq";
+    private static final String OUTPUT_DIR = "outputDir";
+    private static final String LABEL_IMAGE = "labelImage";
+    private static final String SAVE_RATE = "saveRate";
+    private static final String SAVED_RESOLUTION = "savedResolution";
+    private static final String LONG_EDGE = "longEdge";
+    private static final String UPLOAD_AS_IMAGE = "uploadAsImage";
 
 
     // Constants for Query Parameter options
-    private static final String NN_OUTPUT_DIR   = "NNoutputDir";
-    private static final String NN_FILENAME     = "NNfileName";
-    private static final String NN_SAVE_IMAGE   = "NNsaveImage";
+    private static final String NN_OUTPUT_DIR = "NNoutputDir";
+    private static final String NN_FILENAME = "NNfileName";
+    private static final String NN_SAVE_IMAGE = "NNsaveImage";
 
     private static SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd--HH-mm-ss");
 

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -370,6 +370,7 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
         String outputDir = null;
         String fileName = null;
         Vantiq vantiq = null;
+        boolean uploadAsImage = false;
 
         Date timestamp;
         if (processingParams != null && processingParams.get(IMAGE_TIMESTAMP) instanceof Date) {
@@ -387,6 +388,11 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
                 if (saveImage.equalsIgnoreCase(VANTIQ) || saveImage.equalsIgnoreCase(BOTH)) {
                     vantiq = new io.vantiq.client.Vantiq(server);
                     vantiq.setAccessToken(authToken);
+
+                    // Check if images should be uploaded to VANTIQ as VANTIQ IMAGES
+                    if (request.get(UPLOAD_AS_IMAGE) instanceof Boolean && (Boolean) request.get(UPLOAD_AS_IMAGE)) {
+                        uploadAsImage = (Boolean) request.get(UPLOAD_AS_IMAGE);
+                    }
                 }
                 if (!saveImage.equalsIgnoreCase(VANTIQ)) {
                     if (request.get(NN_OUTPUT_DIR) instanceof String) {
@@ -438,7 +444,7 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
         long after;
         long before = System.currentTimeMillis();
         try {
-            foundObjects = objectDetector.detect(image, outputDir, fileName, vantiq);
+            foundObjects = objectDetector.detect(image, outputDir, fileName, vantiq, uploadAsImage);
         } catch (IllegalArgumentException e) {
             throw new ImageProcessingException(this.getClass().getCanonicalName() + ".queryInvalidImage: " 
                     + "Data to be processed was invalid. Most likely it was not correctly encoded as a jpg.", e);

--- a/objectRecognitionSource/src/main/resources/log4j2.xml
+++ b/objectRecognitionSource/src/main/resources/log4j2.xml
@@ -4,12 +4,17 @@
     <Console name="Console" target="SYSTEM_OUT">
       <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
     </Console>
+    <!-- To save the log to a file, uncomment lines 8-10 and line 17. -->
+    <!--<File name = "OutputFile" filename="output.log" append="false">
+        <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </File>-->
   </Appenders>
   <Loggers>
     <Logger name="io.vantiq.extsrc.objectRecognition" level="debug"/>
     <Logger name="io.vantiq.extjsdk" level="debug"/>
     <Root level="error">
       <AppenderRef ref="Console"/>
+      <!--<AppenderRef ref="OutputFile"/>-->
     </Root>
   </Loggers>
 </Configuration>

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/ObjRecTestBase.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/ObjRecTestBase.java
@@ -67,15 +67,4 @@ public class ObjRecTestBase {
             throw new RuntimeException("Error deleting directory " + d.getAbsolutePath(), e);
         }
     }
-    
-    public static boolean checkUrl(String url) {
-        try {
-            URL urlProtocolTest = new URL((String) url);
-            InputStream urlReadTest = urlProtocolTest.openStream();
-            urlReadTest.close();
-        } catch (IOException e) {
-            return false;
-        }
-        return true;
-    }
 }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecConfig.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecConfig.java
@@ -208,6 +208,30 @@ public class TestObjRecConfig {
         sendConfig(conf);
         assertFalse("Should not fail when maxRunningThreads > maxQueuedTasks.", configIsFailed());
     }
+
+    @Test
+    public void testInvalidImageUploadConfig() {
+        Map conf = minimalConfig();
+        neuralNet.put("uploadAsImage", "jibberish");
+        sendConfig(conf);
+        assertFalse("Should not fail when image upload config is a string", configIsFailed());
+
+        neuralNet.put("uploadAsImage", 10);
+        sendConfig(conf);
+        assertFalse("Should not fail when image upload config is an int", configIsFailed());
+    }
+
+    @Test
+    public void testValidImageUploadConfig() {
+        Map conf = minimalConfig();
+        neuralNet.put("uploadAsImage", true);
+        sendConfig(conf);
+        assertFalse("Should not fail when image upload config is true", configIsFailed());
+
+        neuralNet.put("uploadAsImage", false);
+        sendConfig(conf);
+        assertFalse("Should not fail when image upload config is false", configIsFailed());
+    }
     
     @Test
     public void testMinimalConfig() {

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetTestBase.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetTestBase.java
@@ -28,6 +28,8 @@ public class NeuralNetTestBase extends ObjRecTestBase {
     public static final String MODEL_DIRECTORY = System.getProperty("buildDir") + "/models";
     public static final String SOURCE_NAME = "testSourceName";
 
+    static final String VANTIQ_DOCUMENTS = "system.documents";
+    static final String VANTIQ_IMAGES = "system.images";
     static final String NOT_FOUND_CODE = "io.vantiq.resource.not.found";
     static final int WAIT_FOR_ASYNC_MILLIS = 5000;
 
@@ -41,13 +43,13 @@ public class NeuralNetTestBase extends ObjRecTestBase {
         }
     }
 
-    public static void checkUploadToVantiq(String name, Vantiq vantiq) throws InterruptedException {
+    public static void checkUploadToVantiq(String name, Vantiq vantiq, String resourceName) throws InterruptedException {
         boolean done = false;
         int retries = 0;
         int maxRetries = WAIT_FOR_ASYNC_MILLIS / 50;
         while (!done) {
             done = true;
-            VantiqResponse vantiqResponse = vantiq.selectOne("system.documents", name);
+            VantiqResponse vantiqResponse = vantiq.selectOne(resourceName, name);
             if (vantiqResponse.hasErrors()) {
                 if (++retries < maxRetries) {
                     done = false;
@@ -64,13 +66,13 @@ public class NeuralNetTestBase extends ObjRecTestBase {
         }
     }
 
-    public static void checkNotUploadToVantiq(String name, Vantiq vantiq) throws InterruptedException {
+    public static void checkNotUploadToVantiq(String name, Vantiq vantiq, String resourceName) throws InterruptedException {
         boolean done = false;
         int retries = 0;
         int maxRetries = WAIT_FOR_ASYNC_MILLIS / 50;
         while (!done) {
             done = true;
-            VantiqResponse vantiqResponse = vantiq.selectOne("system.documents", name);
+            VantiqResponse vantiqResponse = vantiq.selectOne(resourceName, name);
             if (vantiqResponse.isSuccess()) {
                 if (++retries < maxRetries) {
                     done = false;

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
@@ -135,7 +135,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         
         // Check that file was saved to Vantiq
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Deleting file for next test
         deleteFileFromVantiq(IMAGE.get("filename"));
@@ -146,7 +146,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         
         // Check that file was saved to Vantiq
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Deleting file for next test
         deleteFileFromVantiq(IMAGE.get("filename"));
@@ -157,7 +157,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         
         // Check that file was saved to Vantiq
         Thread.sleep(1000);
-        checkUploadToVantiq(core.lastQueryFilename, vantiq);
+        checkUploadToVantiq(core.lastQueryFilename, vantiq, VANTIQ_DOCUMENTS);
         
         deleteFileFromVantiq(core.lastQueryFilename);
         vantiqUploadFiles.add(core.lastQueryFilename);
@@ -191,7 +191,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         
         // Check that file was saved to Vantiq
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Deleting file for next test
         deleteFileFromVantiq(IMAGE.get("filename"));
@@ -215,7 +215,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         
         // Check that file was saved to Vantiq
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Deleting file for next test
         deleteFileFromVantiq(IMAGE.get("filename"));
@@ -241,12 +241,36 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         
         // Check that file was saved to Vantiq
         Thread.sleep(1000);
-        checkUploadToVantiq(core.lastQueryFilename, vantiq);
+        checkUploadToVantiq(core.lastQueryFilename, vantiq, VANTIQ_DOCUMENTS);
         
         deleteFileFromVantiq(core.lastQueryFilename);
         vantiqUploadFiles.add(core.lastQueryFilename);
         
         deleteDirectory(OUTPUT_DIR);
+    }
+
+    @Test
+    public void testUploadAsImage() throws InterruptedException {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+
+        // Run query without setting "operation":"processNextFrame"
+        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        params.put("NNsaveImage", "vantiq");
+        params.put("uploadAsImage", true);
+        params.put("NNfileName", QUERY_FILENAME);
+
+        querySource(params);
+
+        // Check that file was saved to Vantiq as an Image
+        Thread.sleep(1000);
+        checkUploadToVantiq(IMAGE.get("filename"), vantiq, VANTIQ_IMAGES);
+
+        // Check that it wasn't saved to Vantiq as a Document
+        checkNotUploadToVantiq(IMAGE.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+
+        // Deleting file
+        deleteFileFromVantiq(IMAGE.get("filename"));
     }
     
     // ================================================= Helper functions =================================================
@@ -308,6 +332,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
     }
     
     public static void deleteFileFromVantiq(String filename) {
-        vantiq.deleteOne("system.documents", filename);
+        vantiq.deleteOne(VANTIQ_DOCUMENTS, filename);
+        vantiq.deleteOne(VANTIQ_IMAGES, filename);
     }
 }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
@@ -142,7 +142,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     public void deleteFromVantiq() throws InterruptedException {
         for (int i = 0; i < vantiqUploadFiles.size(); i++) {
             Thread.sleep(1000);
-            vantiq.deleteOne("system.documents", vantiqUploadFiles.get(i), new BaseResponseHandler() {
+            vantiq.deleteOne(VANTIQ_DOCUMENTS, vantiqUploadFiles.get(i), new BaseResponseHandler() {
 
                 @Override
                 public void onSuccess(Object body, Response response) {
@@ -174,13 +174,13 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         
         // Checking that images were not uploaded to VANTIQ
         Thread.sleep(1000);
-        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Using wrong type for imageName
         request.put("imageName", 5);
@@ -188,13 +188,13 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         
         // Checking that images were not uploaded to VANTIQ
         Thread.sleep(1000);
-        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Using wrong type for imageDate
         request.remove("imageName");
@@ -203,13 +203,13 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         
         // Checking that images were not uploaded to VANTIQ
         Thread.sleep(1000);
-        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Using an imageDate list that is null
         List<String> invalidImageDates = null;
@@ -218,13 +218,13 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         
         // Checking that images were not uploaded to VANTIQ
         Thread.sleep(1000);
-        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Using an imageDate list that has no values
         invalidImageDates = new ArrayList<String>();
@@ -232,13 +232,13 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         
         // Checking that images were not uploaded to VANTIQ
         Thread.sleep(1000);
-        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Using an imageDate list that contains non-dates
         invalidImageDates.add("Not a date");
@@ -248,13 +248,13 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         
         // Checking that images were not uploaded to VANTIQ
         Thread.sleep(1000);
-        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Using an imageDate list with only one date
         invalidImageDates.clear();
@@ -264,13 +264,13 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         
         // Checking that images were not uploaded to VANTIQ
         Thread.sleep(1000);
-        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Using an imageDate list with more than two dates
         invalidImageDates.add(IMAGE_2_DATE);
@@ -280,13 +280,13 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         
         // Checking that images were not uploaded to VANTIQ
         Thread.sleep(1000);
-        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
     }
     
     @Test
@@ -375,15 +375,15 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
                 
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Checking that none of the other images were uploaded to VANTIQ
-        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
     }
     
@@ -403,13 +403,13 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
                 
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_3.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_4.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
     }
     
     @Test
@@ -427,15 +427,15 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
                 
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Checking that none of the other images were uploaded to VANTIQ
-        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
     }
     
     @Test
@@ -453,15 +453,15 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
                 
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Checking that none of the other images were uploaded to VANTIQ
-        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
     }
     
     @Test
@@ -479,15 +479,15 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
                 
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_4.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Checking that none of the other images were uploaded to VANTIQ
-        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
     }
     
     @Test
@@ -505,15 +505,15 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
                 
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(3000);
-        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_3.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_4.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Checking that none of the other images were uploaded to VANTIQ
-        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
     }
     
     @Test

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -93,6 +93,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
     static VantiqResponse vantiqResponse;
 
     static List<String> vantiqSavedFiles = new ArrayList<>();
+    static List<String> vantiqSavedImageFiles = new ArrayList<>();
 
     static final String timestampPattern = "\\d{4}-\\d{2}-\\d{2}--\\d{2}-\\d{2}-\\d{2}\\.jpg";
 
@@ -116,9 +117,27 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
     @AfterClass
     public static void deleteFromVantiq() throws InterruptedException {
+        // Deleting files saved as documents
         for (int i = 0; i < vantiqSavedFiles.size(); i++) {
             Thread.sleep(1000);
-            vantiq.deleteOne("system.documents", vantiqSavedFiles.get(i), new BaseResponseHandler() {
+            vantiq.deleteOne(VANTIQ_DOCUMENTS, vantiqSavedFiles.get(i), new BaseResponseHandler() {
+
+                @Override
+                public void onSuccess(Object body, Response response) {
+                    super.onSuccess(body, response);
+                }
+
+                @Override
+                public void onError(List<VantiqError> errors, Response response) {
+                    super.onError(errors, response);
+                }
+
+            });
+        }
+        // Deleting files saved as images
+        for (int i = 0; i < vantiqSavedImageFiles.size(); i++) {
+            Thread.sleep(1000);
+            vantiq.deleteOne(VANTIQ_IMAGES, vantiqSavedImageFiles.get(i), new BaseResponseHandler() {
 
                 @Override
                 public void onSuccess(Object body, Response response) {
@@ -731,7 +750,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             
             // Checking that image was saved to VANTIQ
             Thread.sleep(1000);
-            checkUploadToVantiq(results.getLastFilename(), vantiq);
+            checkUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_DOCUMENTS);
             vantiqSavedFiles.add(results.getLastFilename());
             
             // Get the path to the saved image in VANTIQ
@@ -803,7 +822,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             
             // Checking that image was saved to VANTIQ
             Thread.sleep(2000);
-            checkUploadToVantiq(results.getLastFilename(), vantiq);
+            checkUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_DOCUMENTS);
             vantiqSavedFiles.add(results.getLastFilename());
             
             // Get the path to the saved image in VANTIQ
@@ -869,7 +888,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             assert d.listFiles()[0].getName().matches(timestampPattern);
 
             // Check it didn't save to VANTIQ
-            checkNotUploadToVantiq(results.getLastFilename(), vantiq);
+            checkNotUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_DOCUMENTS);
 
             results = null;
             results = ypImageSaver.processImage(getTestImage());
@@ -897,7 +916,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             assert d.listFiles()[1].getName().matches(timestampPattern);
 
             // Check it didn't save to VANTIQ
-            checkNotUploadToVantiq(results.getLastFilename(), vantiq);
+            checkNotUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_DOCUMENTS);
 
         } finally {
             // delete the directory even if the test fails
@@ -949,7 +968,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
             // Checking that image was saved to VANTIQ
             Thread.sleep(1000);
-            checkUploadToVantiq(results.getLastFilename(), vantiq);
+            checkUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_DOCUMENTS);
             vantiqSavedFiles.add(results.getLastFilename());
 
             results = null;
@@ -976,7 +995,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
             // Checking that image was saved to VANTIQ
             Thread.sleep(1000);
-            checkUploadToVantiq(results.getLastFilename(), vantiq);
+            checkUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_DOCUMENTS);
             vantiqSavedFiles.add(results.getLastFilename());
 
         } finally {
@@ -1028,7 +1047,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
             // Checking that image was saved to VANTIQ
             Thread.sleep(1000);
-            checkUploadToVantiq(results.getLastFilename(), vantiq);
+            checkUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_DOCUMENTS);
             vantiqSavedFiles.add(results.getLastFilename());
 
         } finally {
@@ -1106,7 +1125,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
             // Checking that image was saved in VANTIQ
             Thread.sleep(1000);
-            checkUploadToVantiq(results.getLastFilename(), vantiq);
+            checkUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_DOCUMENTS);
             vantiqSavedFiles.add(results.getLastFilename());
 
             request.put("NNsaveImage", "both");
@@ -1125,7 +1144,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
             // Checking that image was saved in VANTIQ
             Thread.sleep(1000);
-            checkUploadToVantiq(results.getLastFilename(), vantiq);
+            checkUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_DOCUMENTS);
             vantiqSavedFiles.add(results.getLastFilename());
 
             // Save with "local" instead of "both", and remove fileName
@@ -1152,7 +1171,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
             // Checking that image was not saved in VANTIQ
             Thread.sleep(1000);
-            checkNotUploadToVantiq(results.getLastFilename(), vantiq);
+            checkNotUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_DOCUMENTS);
 
             queryOutputFile += ".jpeg";
             request.put("NNfileName", queryOutputFile);
@@ -1419,7 +1438,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             
             // Checking that image was saved to VANTIQ
             Thread.sleep(1000);
-            checkUploadToVantiq(results.getLastFilename(), vantiq);
+            checkUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_DOCUMENTS);
             vantiqSavedFiles.add(results.getLastFilename());
             
             // Get the path to the saved image in VANTIQ
@@ -1494,7 +1513,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             
             // Checking that image was saved to VANTIQ
             Thread.sleep(2000);
-            checkUploadToVantiq(results.getLastFilename(), vantiq);
+            checkUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_DOCUMENTS);
             vantiqSavedFiles.add(results.getLastFilename());
             
             // Get the path to the saved image in VANTIQ
@@ -1738,6 +1757,42 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         deleteSource(vantiq);
         deleteType(vantiq);
         deleteRule(vantiq);
+    }
+
+    @Test
+    public void testUploadAsVantiqImage() throws ImageProcessingException, InterruptedException {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+
+        Map config = new LinkedHashMap<>();
+        Map preCrop = new LinkedHashMap<>();
+        YoloProcessor ypImageSaver = new YoloProcessor();
+
+        config.put("pbFile", PB_FILE);
+        config.put("metaFile", META_FILE);
+        config.put("outputDir", OUTPUT_DIR);
+        config.put("saveRate", SAVE_RATE);
+        config.put("saveImage", "vantiq");
+        config.put("uploadAsImage", true);
+        try {
+            ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
+        } catch (Exception e) {
+            fail("Could not setup the YoloProcessor");
+        }
+        try {
+
+            NeuralNetResults results = ypImageSaver.processImage(getTestImage());
+            assert results != null;
+            assert results.getResults() != null;
+
+            // Checking that image was saved to VANTIQ
+            Thread.sleep(1000);
+            checkUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_IMAGES);
+            vantiqSavedImageFiles.add(results.getLastFilename());
+
+        } finally {
+            ypImageSaver.close();
+        }
     }
 
     // ================================================= Helper functions =================================================

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -245,7 +245,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check that file was saved to Vantiq
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_8.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE_8.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Deleting file for next test
         deleteFileFromVantiq(IMAGE_8.get("filename"));
@@ -256,7 +256,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check that file was saved to Vantiq
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_8.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE_8.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Deleting file for next test
         deleteFileFromVantiq(IMAGE_8.get("filename"));
@@ -267,7 +267,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check that file was saved to Vantiq
         Thread.sleep(1000);
-        checkUploadToVantiq(core.lastQueryFilename, vantiq);
+        checkUploadToVantiq(core.lastQueryFilename, vantiq, VANTIQ_DOCUMENTS);
         
         deleteFileFromVantiq(core.lastQueryFilename);
         vantiqUploadFiles.add(core.lastQueryFilename);
@@ -301,7 +301,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check that file was saved to Vantiq
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_8.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE_8.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Deleting file for next test
         deleteFileFromVantiq(IMAGE_8.get("filename"));
@@ -325,7 +325,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check that file was saved to Vantiq
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_8.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE_8.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Deleting file for next test
         deleteFileFromVantiq(IMAGE_8.get("filename"));
@@ -351,7 +351,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check that file was saved to Vantiq
         Thread.sleep(1000);
-        checkUploadToVantiq(core.lastQueryFilename, vantiq);
+        checkUploadToVantiq(core.lastQueryFilename, vantiq, VANTIQ_DOCUMENTS);
         
         deleteFileFromVantiq(core.lastQueryFilename);
         vantiqUploadFiles.add(core.lastQueryFilename);
@@ -374,15 +374,15 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check the file was uploaded
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Checking that none of the other images were uploaded to VANTIQ
-        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
     }
     
     @Test
@@ -404,13 +404,13 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_3.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_4.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
     }
     
     @Test
@@ -432,15 +432,15 @@ public class TestYoloQueries extends NeuralNetTestBase {
                         
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Checking that none of the other images were uploaded to VANTIQ
-        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
     }
     
     @Test
@@ -462,15 +462,15 @@ public class TestYoloQueries extends NeuralNetTestBase {
                 
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Checking that none of the other images were uploaded to VANTIQ
-        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
     }
     
     @Test
@@ -492,15 +492,15 @@ public class TestYoloQueries extends NeuralNetTestBase {
                 
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE_4.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Checking that none of the other images were uploaded to VANTIQ
-        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
     }
     
     @Test
@@ -522,15 +522,15 @@ public class TestYoloQueries extends NeuralNetTestBase {
                 
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(3000);
-        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_3.get("filename"), vantiq);
-        checkUploadToVantiq(IMAGE_4.get("filename"), vantiq);
+        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         
         // Checking that none of the other images were uploaded to VANTIQ
-        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq);
-        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq);
+        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
     }
     
     @Test
@@ -799,6 +799,49 @@ public class TestYoloQueries extends NeuralNetTestBase {
         assert resizedImage.getWidth() == CROPPED_WIDTH;
         assert resizedImage.getHeight() == CROPPED_HEIGHT;
     }
+
+    @Test
+    public void testUploadAsImage() throws IOException, InterruptedException {
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+
+        // Only run test with intended vantiq availability
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+
+        addLocalTestImages();
+
+        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        params.put("operation", "upload");
+        params.put("uploadAsImage", true);
+
+        List<String> imageDate = new ArrayList<String>();
+        imageDate.add(START_DATE);
+        imageDate.add(END_DATE);
+        params.put("imageDate", imageDate);
+
+        querySource(params);
+
+        // Checking that all images were uploaded to VANTIQ as images
+        Thread.sleep(3000);
+        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_IMAGES);
+        checkUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_IMAGES);
+        checkUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_IMAGES);
+
+        // Checking that the other images were not uploaded to VANTIQ as images
+        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_IMAGES);
+        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_IMAGES);
+        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_IMAGES);
+        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_IMAGES);
+
+        // Checking that no images were uploaded to VANTIQ as documents
+        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+    }
     
     // ================================================= Helper functions =================================================
     
@@ -815,7 +858,8 @@ public class TestYoloQueries extends NeuralNetTestBase {
     }
     
     public static void deleteFileFromVantiq(String filename) {
-        vantiq.deleteOne("system.documents", filename);
+        vantiq.deleteOne(VANTIQ_DOCUMENTS, filename);
+        vantiq.deleteOne(VANTIQ_IMAGES, filename);
     }
     
     public void checkQueryError(Map<String,Object> params, String operation) {


### PR DESCRIPTION
Closes #183 

Currently, images can only be uploaded to VANTIQ as documents. This enhancement enables the user to upload images as VANTIQ Images. This feature can be configured in 3 different places:

1. In the source configuration, which affects all images saved via "polling"
2. In the query parameters for `processNextFrame` operation
3. In the query parameters for `upload` operation

All tests pass and build is successful.