### PR TITLE
OPC UA: Upgrade connector to a more modern Milo (SDK) version

### DIFF
--- a/opcuaSource/README.md
+++ b/opcuaSource/README.md
@@ -67,13 +67,28 @@ For OPC UA sources, the document contains the following properties
  - `discoveryEndpoint` -- This is the URL for the OPC UA server's discovery endpoint. This is the URL that the source will use to connect to the OPC UA server.
  - `securityPolicy` -- This is the specification (URI) of the security policy to be used to communicate with the OPC UA server. The security policy includes information about how (and whether) signing and encryption is done. The list of security policy URI's can be found in the OPC UA documentation.
  - `monitoredItems` -- This is the list of items to be monitored by the OPC UA source.  More detail can be found below.
+ 
+##### The Discovery Process and Server Connections
+
+The `discoveryEndpoint` is queried to find endpoints that are compatible with the `securityPolicy` specified. Once a match is found, that discovered endpoint becomes the point
+with which the connector will work.
+
+The OPC UA specification states that the OPC UA server may
+not know what addresses are usable by clients, so the endpoints reported by the discovery process may not be valid locally.
+Consequently, the connector will validate each
+endpoint by checking if the host name is resolvable, that the resultant internet address is reachable, and that the given address is
+not a loopback address.
+If any of these tests fail, the connector will replace the host name reported by the discovery process with the host used
+for discovery.
+This is as per the OPC UA specification.
+
+#### Special Requirements
 
 Additionally, there are some properties that can be added to deal with unusual situations.
 
- - `replaceDiscoveredLocalhost` -- If this is set to "true", any endpoints returned by the `discoveryEndpoint` that have a host that is a loopback address will be replaced with the host name from `discoveryEndpoint`. This is useful when the discovery server not configured cooperatively.
+ - `replaceDiscoveredLocalhost` -- Deprecated/Ignored -- this is now generic functionality with no special specification necessary.
  - `serverEndpointOverride` -- If this is set, any server address returned by the `discoveryEndpoint` will be replaced with this value. Again, this is useful when the discovery server is not configured cooperatively.
  
-
 ##### <a id="monitored_items"></a> Monitored Items
 
 The OPC UA source can be configured to monitor items (nodes) within the OPC UA server.  Specifically, the source will watch for data value changes for the nodes listed, reporting changes back to the VANTIQ system in the form of a message from the source.

--- a/opcuaSource/build.gradle
+++ b/opcuaSource/build.gradle
@@ -20,7 +20,7 @@ sourceCompatibility = 1.8
 
 ext {
     jacksonVersion = '2.9.3'
-    eclipseMiloVersion = '0.2.1'
+    eclipseMiloVersion = '0.3.3'
     lombokVersion = '1.16.18'
     logbackVersion = '1.2.3'
     junitVersion = '4.12'
@@ -46,7 +46,10 @@ dependencies {
 
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
     compile "commons-cli:commons-cli:${commonsCliVersion}"
+    
     compile "org.eclipse.milo:sdk-client:${eclipseMiloVersion}"
+    compile "org.eclipse.milo:stack-client:${eclipseMiloVersion}"
+    compile "org.eclipse.milo:stack-core:${eclipseMiloVersion}"
 
     // To force the inclusion of the bouncy castle provider libraries into the application build,
     // we must re-declare these on Milo SDK-client's behalf. The dependency declared

--- a/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/opcUaSource/OpcUaSource.java
+++ b/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/opcUaSource/OpcUaSource.java
@@ -17,6 +17,7 @@ import io.vantiq.extsrc.opcua.uaOperations.OpcExtConfigException;
 import io.vantiq.extsrc.opcua.uaOperations.OpcExtRuntimeException;
 import io.vantiq.extsrc.opcua.uaOperations.OpcUaESClient;
 import lombok.extern.slf4j.Slf4j;
+
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.IdType;

--- a/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/uaOperations/OpcConstants.java
+++ b/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/uaOperations/OpcConstants.java
@@ -23,7 +23,7 @@ public class OpcConstants {
     public static final String CONFIG_MESSAGE_SECURITY_MODE = "messageSecurityMode";
     public static final String CONFIG_DISCOVERY_ENDPOINT = "discoveryEndpoint";
     public static final String CONFIG_SERVER_ENDPOINT = "serverEndpointOverride";
-    public static final String CONFIG_REPLACE_DISCOVERED_LOCALHOST = "replaceDiscoveredLocalhost";
+    public static final String CONFIG_TEST_DISCOVERY_UNREACHABLE = "testDiscoveryUnreachable";
     public static final String CONFIG_STORAGE_DIRECTORY = "storageDirectory";
     public static final String CONFIG_IDENTITY_ANONYMOUS = "identityAnonymous";
     public static final String CONFIG_IDENTITY_CERTIFICATE = "identityCertificate";

--- a/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/uaOperations/OpcUaESClient.java
+++ b/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/uaOperations/OpcUaESClient.java
@@ -10,6 +10,7 @@ package io.vantiq.extsrc.opcua.uaOperations;
 
 import com.google.common.collect.ImmutableList;
 import lombok.extern.slf4j.Slf4j;
+
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.client.api.config.OpcUaClientConfig;
 import org.eclipse.milo.opcua.sdk.client.api.identity.AnonymousProvider;
@@ -19,7 +20,7 @@ import org.eclipse.milo.opcua.sdk.client.api.identity.X509IdentityProvider;
 import org.eclipse.milo.opcua.sdk.client.api.nodes.VariableNode;
 import org.eclipse.milo.opcua.sdk.client.api.subscriptions.UaMonitoredItem;
 import org.eclipse.milo.opcua.sdk.client.api.subscriptions.UaSubscription;
-import org.eclipse.milo.opcua.stack.client.UaTcpStackClient;
+import org.eclipse.milo.opcua.stack.client.DiscoveryClient;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
@@ -39,6 +40,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoringParameters;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+
 import org.slf4j.helpers.MessageFormatter;
 
 import java.io.File;
@@ -49,7 +51,6 @@ import java.net.UnknownHostException;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -58,6 +59,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 
@@ -297,7 +299,7 @@ public class OpcUaESClient {
         if (secPolURI == null || secPolURI.isEmpty()) {
             // No security policy will default to #NONE.  We will, however, log a warning
             log.warn(ERROR_PREFIX + ".defaultingSecurityPolicy: No OPC UA Security policy was specified in the configuration.  Defaulting to #NONE");
-            secPolURI = SecurityPolicy.None.getSecurityPolicyUri();
+            secPolURI = SecurityPolicy.None.getUri();
         }
         try {
             URI.create(secPolURI);  // To verify wellformedness
@@ -329,7 +331,7 @@ public class OpcUaESClient {
             log.warn(ERROR_PREFIX + ".defaultMessageSecurityMode: No OPC UA message security mode was specified in the configuration. " +
                     "Using default value of '{}' based on the securityPolicy value of '{}'",
                     msgSecModeSpec,
-                    secPol.getSecurityPolicyUri());
+                    secPol.getUri());
         }
         try {
             msgSecMode = MessageSecurityMode.valueOf(msgSecModeSpec);
@@ -408,7 +410,7 @@ public class OpcUaESClient {
 
         IdentityProvider idProvider = constructIdentityProvider(config);
 
-        EndpointDescription[] endpoints;
+        List<EndpointDescription> endpoints;
 
         discoveryEndpoint = (String) config.get(OpcConstants.CONFIG_DISCOVERY_ENDPOINT);
         serverEndpoint = (String) config.get(OpcConstants.CONFIG_SERVER_ENDPOINT);
@@ -420,7 +422,7 @@ public class OpcUaESClient {
 
         OpcUaClientConfig opcConfig;
         try {
-            endpoints = UaTcpStackClient
+            endpoints = DiscoveryClient
                     .getEndpoints(discoveryEndpoint)
                     .get();
         } catch (Throwable ex) {
@@ -428,7 +430,7 @@ public class OpcUaESClient {
                 // try the explicit discovery endpoint as well
                 String discoveryUrl = discoveryEndpoint + "/discovery";
                 log.info("Trying explicit discovery URL: {}", discoveryUrl);
-                endpoints = UaTcpStackClient
+                endpoints = DiscoveryClient
                         .getEndpoints(discoveryUrl)
                         .get();
             } catch (ExecutionException e) {
@@ -452,14 +454,14 @@ public class OpcUaESClient {
         }
 
 
-        EndpointDescription[] validEndpoints = (EndpointDescription[]) Arrays.stream(endpoints)
-                .filter(e -> (e.getSecurityPolicyUri().equals(securityPolicy.getSecurityPolicyUri())
+        List<EndpointDescription> validEndpoints = endpoints.stream()
+                .filter(e -> (e.getSecurityPolicyUri().equals(securityPolicy.getUri())
                         && e.getSecurityMode().equals(msgSecMode)))
-                .toArray(EndpointDescription[]::new);
+                .collect(Collectors.toList());
 
         if (log.isDebugEnabled()) {
             log.debug("Discovered endpoints that accept the security configuration: [security policy: {}, message security mode: {}]",
-                    securityPolicy.getSecurityPolicyUri(),
+                    securityPolicy.getUri(),
                     msgSecMode);
             for (EndpointDescription e : validEndpoints) {
                 URI secPolUri = new URI(e.getSecurityPolicyUri());
@@ -475,7 +477,7 @@ public class OpcUaESClient {
         // First, we'll look for an endpoint that doesn't contain localhost.  This is, generally,
         // a not too useful configuration since localhost is always a relative address.
 
-        EndpointDescription endpoint = Arrays.stream(validEndpoints)
+        EndpointDescription endpoint = validEndpoints.stream()
                 .filter(e -> {
                     try {
                         // Note:  Must use URI here.  If you use URL, it will fail with
@@ -504,7 +506,7 @@ public class OpcUaESClient {
             // Discovery server returned either no reasonable endpoints or none that weren't a loopback.
             // Here, we'll allow loopbacks as a last resort (though we may try & fix them up below)
 
-            endpoint = Arrays.stream(validEndpoints)
+            endpoint = validEndpoints.stream()
                     .findFirst().orElse(null);
             // Here, if we have no endpoint, then we can't go anywhere so we give up.
             // Otherwise, we'll check if we're supposed to fix up a poorly configured
@@ -553,7 +555,7 @@ public class OpcUaESClient {
 
         if (endpoint == null) {
             throw new Exception("No acceptable endpoints returned for security policy: " +
-                    securityPolicy.getSecurityPolicyUri() + " and security mode " + msgSecMode);
+                    securityPolicy.getUri() + " and security mode " + msgSecMode);
         }
 
         if (serverEndpoint != null) {
@@ -585,7 +587,7 @@ public class OpcUaESClient {
                 .setRequestTimeout(uint(5000))
                 .build();
 
-        return new OpcUaClient(opcConfig);
+        return OpcUaClient.create(opcConfig);
     }
 
     /**

--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Connection.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Connection.java
@@ -326,7 +326,6 @@ public class Connection extends OpcUaTestBase {
                     null,
                     false,
                     false,
-                    true,
                     true);
             makeConnection(false,
                     SecurityPolicy.None.getUri(),
@@ -335,8 +334,7 @@ public class Connection extends OpcUaTestBase {
                     null,
                     false,
                     false,
-                    true,
-                    false);
+                    true);
         } catch (ExecutionException e) {
             fail("Unexpected Exception: " + e.getClass().getName() + " -- " + e.getMessage());
         }
@@ -696,13 +694,42 @@ public class Connection extends OpcUaTestBase {
     public void makeConnection(boolean runAsync, String secPolicy, String msgSecMode,
                                String identityType, String identityValue, boolean inProcessOnly, boolean startProcessOnly) throws ExecutionException {
         try {
-            makeConnection(runAsync, secPolicy, msgSecMode, identityType, identityValue, inProcessOnly, startProcessOnly, false, false);
+            makeConnection(runAsync,
+                    secPolicy,
+                    msgSecMode,
+                    identityType,
+                    identityValue,
+                    inProcessOnly,
+                    startProcessOnly,
+                    false);
+        } catch (ExecutionException e) {
+            fail("Unexpected Exception: " + e.getClass().getName() + " -- " + e.getMessage());
+        }
+    }
+    public void makeConnection(boolean runAsync,
+                               String secPolicy,
+                               String msgSecMode,
+                               String identityType,
+                               String identityValue,
+                               boolean inProcessOnly,
+                               boolean startProcessOnly,
+                               boolean useServerAddress) throws ExecutionException {
+        try {
+            makeConnection(runAsync,
+                    secPolicy,
+                    msgSecMode,
+                    identityType,
+                    identityValue,
+                    inProcessOnly,
+                    startProcessOnly,
+                    useServerAddress,
+                    false);
         } catch (ExecutionException e) {
             fail("Unexpected Exception: " + e.getClass().getName() + " -- " + e.getMessage());
         }
     }
 
-    private static int invocationCount = 0;
+        private static int invocationCount = 0;
     public void makeConnection(boolean runAsync,
                                String secPolicy,
                                String msgSecMode,
@@ -711,13 +738,16 @@ public class Connection extends OpcUaTestBase {
                                boolean inProcessOnly,
                                boolean startProcessOnly,
                                boolean useServerAddress,
-                               boolean replaceLocalHost) throws ExecutionException {
+                               boolean fakeUnreachable) throws ExecutionException {
         HashMap config = new HashMap();
         Map<String, Object> opcConfig = new HashMap<>();
 
         config.put(OpcConstants.CONFIG_OPC_UA_INFORMATION, opcConfig);
         opcConfig.put(OpcConstants.CONFIG_STORAGE_DIRECTORY, STANDARD_STORAGE_DIRECTORY);
         opcConfig.put(OpcConstants.CONFIG_SECURITY_POLICY, secPolicy);
+        if (fakeUnreachable) {
+            opcConfig.put(OpcConstants.CONFIG_TEST_DISCOVERY_UNREACHABLE, true);
+        }
 
         if (msgSecMode != null && !msgSecMode.isEmpty()) {
             opcConfig.put(OpcConstants.CONFIG_MESSAGE_SECURITY_MODE, msgSecMode);
@@ -742,19 +772,6 @@ public class Connection extends OpcUaTestBase {
 
             if (useServerAddress && Utils.OPC_PUBLIC_SERVER_1.equals(discEP)) {
                 opcConfig.put(OpcConstants.CONFIG_SERVER_ENDPOINT, discEP);
-            }
-
-            if (replaceLocalHost) {
-
-                // Here, we'll alternate testing with both Boolean & Text to be maximally flexible
-                // in terms of the JSON configuration. This setting is to deal with erroneous configurations
-                // anyway, so let's not make things any more difficult than we have to.
-
-                if (invocationCount++ % 2 == 0) {
-                    opcConfig.put(OpcConstants.CONFIG_REPLACE_DISCOVERED_LOCALHOST, Boolean.valueOf(true));
-                } else {
-                    opcConfig.put(OpcConstants.CONFIG_REPLACE_DISCOVERED_LOCALHOST, "true");
-                }
             }
 
             try {

--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Monitoring.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Monitoring.java
@@ -56,7 +56,7 @@ public class Monitoring extends OpcUaTestBase {
 
         config.put(OpcConstants.CONFIG_OPC_UA_INFORMATION, opcConfig);
         opcConfig.put(OpcConstants.CONFIG_STORAGE_DIRECTORY, STANDARD_STORAGE_DIRECTORY);
-        opcConfig.put(OpcConstants.CONFIG_SECURITY_POLICY, SecurityPolicy.None.getSecurityPolicyUri());
+        opcConfig.put(OpcConstants.CONFIG_SECURITY_POLICY, SecurityPolicy.None.getUri());
         opcConfig.put(OpcConstants.CONFIG_DISCOVERY_ENDPOINT, Utils.OPC_INPROCESS_SERVER);
 
         // Here, we'll create a simple map set that creates a monitored
@@ -155,14 +155,14 @@ public class Monitoring extends OpcUaTestBase {
 
         config.put(OpcConstants.CONFIG_OPC_UA_INFORMATION, opcConfig);
         opcConfig.put(OpcConstants.CONFIG_STORAGE_DIRECTORY, STANDARD_STORAGE_DIRECTORY);
-        opcConfig.put(OpcConstants.CONFIG_SECURITY_POLICY, SecurityPolicy.None.getSecurityPolicyUri());
+        opcConfig.put(OpcConstants.CONFIG_SECURITY_POLICY, SecurityPolicy.None.getUri());
         opcConfig.put(OpcConstants.CONFIG_DISCOVERY_ENDPOINT, Utils.OPC_INPROCESS_SERVER);
 
         // Here, we'll create a simple map set that creates a monitored
         opcConfig.put(OpcConstants.CONFIG_OPC_MONITORED_ITEMS, misMap);
         Map miMap = new HashMap<>();
         miMap.put(OpcConstants.CONFIG_MI_NAMESPACE_URN,
-                ExampleNamespace.NAMESPACE_URI);
+                exampleNamespace);
         miMap.put(OpcConstants.CONFIG_MI_IDENTIFIER,
                 Utils.EXAMPLE_NS_SCALAR_INT32_IDENTIFIER);
 
@@ -194,7 +194,7 @@ public class Monitoring extends OpcUaTestBase {
 
             int repetitionCount = 20;
             WriteToOPCUA.performWrites(client,
-                    ExampleNamespace.NAMESPACE_URI,
+                    exampleNamespace,
                     Utils.EXAMPLE_NS_SCALAR_INT32_IDENTIFIER,
                     Utils.EXAMPLE_NS_SCALAR_INT32_TYPE, repetitionCount, msDelayBetweenUpdates);
 
@@ -224,18 +224,25 @@ public class Monitoring extends OpcUaTestBase {
 
         config.put(OpcConstants.CONFIG_OPC_UA_INFORMATION, opcConfig);
         opcConfig.put(OpcConstants.CONFIG_STORAGE_DIRECTORY, STANDARD_STORAGE_DIRECTORY);
-        opcConfig.put(OpcConstants.CONFIG_SECURITY_POLICY, SecurityPolicy.Basic128Rsa15.getSecurityPolicyUri());
-        opcConfig.put(OpcConstants.CONFIG_MESSAGE_SECURITY_MODE, MessageSecurityMode.SignAndEncrypt.toString());
+
+        // ExampleServer no longer has the same means to handle untrusted certs.  So, for now,
+        // we'll just use no security.  We test login elsewhere, so this shouldn't impact
+        // much in terms of testing.
+
+        // TODO: Add better credential generation/validation as the Milo SDK improves and/or stabilizes
+        // TODO: Use SecurityPolicy.Basic256Sha256.getUri());
+        // TODO: Use MessageSecurityMode.SignAndEncrypt.toString());
+
+        opcConfig.put(OpcConstants.CONFIG_SECURITY_POLICY, SecurityPolicy.None.getUri());
+        opcConfig.put(OpcConstants.CONFIG_MESSAGE_SECURITY_MODE, MessageSecurityMode.None.toString());
         opcConfig.put(OpcConstants.CONFIG_DISCOVERY_ENDPOINT, Utils.OPC_INPROCESS_SERVER);
 
         // Here, we'll create a simple map set that creates a monitored item list
         opcConfig.put(OpcConstants.CONFIG_OPC_MONITORED_ITEMS, misMap);
 
-        Map miMap = new HashMap<>();
-        miMap.put(OpcConstants.CONFIG_MI_NAMESPACE_URN,
-                ExampleNamespace.NAMESPACE_URI);
-        miMap.put(OpcConstants.CONFIG_MI_IDENTIFIER,
-                Utils.EXAMPLE_NS_SCALAR_INT32_IDENTIFIER);
+        Map<String, String> miMap = new HashMap<>();
+        miMap.put(OpcConstants.CONFIG_MI_NAMESPACE_URN, exampleNamespace);
+        miMap.put(OpcConstants.CONFIG_MI_IDENTIFIER, Utils.EXAMPLE_NS_SCALAR_INT32_IDENTIFIER);
 
         // This time, we'll leave the string designation out since it's the default...
 
@@ -243,7 +250,7 @@ public class Monitoring extends OpcUaTestBase {
 
         miMap = new HashMap<>();
         miMap.put(OpcConstants.CONFIG_MI_NAMESPACE_URN,
-                ExampleNamespace.NAMESPACE_URI);
+                exampleNamespace);
         miMap.put(OpcConstants.CONFIG_MI_IDENTIFIER,
                 Utils.EXAMPLE_NS_SCALAR_STRING_IDENTIFIER);
 
@@ -323,12 +330,12 @@ public class Monitoring extends OpcUaTestBase {
             int repetitionCount = 10;
             int msDelayBetweenUpdates = 1500;
             WriteToOPCUA.performWrites(client,
-                    ExampleNamespace.NAMESPACE_URI,
+                    exampleNamespace,
                     Utils.EXAMPLE_NS_SCALAR_INT32_IDENTIFIER,
                     Utils.EXAMPLE_NS_SCALAR_INT32_TYPE, repetitionCount, msDelayBetweenUpdates);
 
             WriteToOPCUA.performWrites(client,
-                    ExampleNamespace.NAMESPACE_URI,
+                    exampleNamespace,
                     Utils.EXAMPLE_NS_SCALAR_STRING_IDENTIFIER,
                     Utils.EXAMPLE_NS_SCALAR_STRING_TYPE, repetitionCount, msDelayBetweenUpdates);
 

--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Utils.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Utils.java
@@ -34,34 +34,28 @@ public class Utils {
     // This list is gathered from the somewhat maintained Wiki page:
     // https://github.com/node-opcua/node-opcua/wiki/publicly-available-OPC-UA-Servers-and-Clients
     //
-    // At present, we'll check the write value stuff only on our internal server.
+    // At present, we'll check the "write value" stuff only on our internal server.
 
     public static String OPC_PUBLIC_SERVER_1 = "opc.tcp://opcuaserver.com:48010";
-    // requires credentials & registration :-(
     public static String OPC_PUBLIC_SERVER_2 = "opc.tcp://opcua.rocks:4840";
     public static String OPC_PUBLIC_SERVER_3 = "opc.tcp://opcua-demo.factry.io:51210";
     public static String OPC_PUBLIC_SERVER_4 = "opc.tcp://commsvr.com:51234/UA/CAS_UA_Server";
-    // not responding
     public static String OPC_PUBLIC_SERVER_5 = "opc.tcp://uademo.prosysopc.com:53530";
-    // Configuration error:  Discovery is not returning the domain
     public static String OPC_PUBLIC_SERVER_6 = "opc.tcp://demo.ascolab.com:4841";
-    // unknown host
     public static String OPC_PUBLIC_SERVER_7 = "opc.tcp://milo.digitalpetri.com:62541/milo";
     public static String OPC_PUBLIC_SERVER_8 = "opc.tcp://opcuademo.sterfive.com:26543";
-        // #8 is currently broken -- discovery returns invalid nodes
     public static String OPC_PUBLIC_SERVER_9 = "http://opcua.demo-this.com:51211/UA/SampleServer";
-        // #9 is offline
 
     public static List<String> OPC_PUBLIC_SERVERS = Arrays.asList(
-            // OPC_PUBLIC_SERVER_1,
+            // OPC_PUBLIC_SERVER_1,  // requires credentials & registration :-(
             OPC_PUBLIC_SERVER_2,
             OPC_PUBLIC_SERVER_3,
-            // OPC_PUBLIC_SERVER_4,
-            // OPC_PUBLIC_SERVER_5,
-            // OPC_PUBLIC_SERVER_6,
+            // OPC_PUBLIC_SERVER_4,  // not responding
+            // OPC_PUBLIC_SERVER_5,  // returns that the service is unsupported.
+            // OPC_PUBLIC_SERVER_6,  // unknown host
             OPC_PUBLIC_SERVER_7,
             OPC_PUBLIC_SERVER_8
-            // OPC_PUBLIC_SERVER_9
+            // OPC_PUBLIC_SERVER_9    // #9 is offline
             );
 
     public static String OPC_INPROCESS_SERVER = "opc.tcp://localhost:12686/milo"; //"opc.tcp://localhost:12686/example";

--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Utils.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Utils.java
@@ -12,6 +12,8 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -28,16 +30,41 @@ import org.junit.Assume;
 @Slf4j
 public class Utils {
 
-    // This set of public servers is known to work as of 5 July 2018
     // In the future, errors may occur if these are taken offline, etc.
+    // This list is gathered from the somewhat maintained Wiki page:
+    // https://github.com/node-opcua/node-opcua/wiki/publicly-available-OPC-UA-Servers-and-Clients
     //
     // At present, we'll check the write value stuff only on our internal server.
 
     public static String OPC_PUBLIC_SERVER_1 = "opc.tcp://opcuaserver.com:48010";
-    // This server has gone offline.  We'll re-check on it at a later date
-    public static String OPC_PUBLIC_SERVER_2 = "opc.tcp://opcuademo.sterfive.com:26543";
-    public static String OPC_PUBLIC_SERVER_3 = "http://opcua.demo-this.com:51211/UA/SampleServer";
-    public static String OPC_INPROCESS_SERVER = "opc.tcp://localhost:12686/example";
+    // requires credentials & registration :-(
+    public static String OPC_PUBLIC_SERVER_2 = "opc.tcp://opcua.rocks:4840";
+    public static String OPC_PUBLIC_SERVER_3 = "opc.tcp://opcua-demo.factry.io:51210";
+    public static String OPC_PUBLIC_SERVER_4 = "opc.tcp://commsvr.com:51234/UA/CAS_UA_Server";
+    // not responding
+    public static String OPC_PUBLIC_SERVER_5 = "opc.tcp://uademo.prosysopc.com:53530";
+    // Configuration error:  Discovery is not returning the domain
+    public static String OPC_PUBLIC_SERVER_6 = "opc.tcp://demo.ascolab.com:4841";
+    // unknown host
+    public static String OPC_PUBLIC_SERVER_7 = "opc.tcp://milo.digitalpetri.com:62541/milo";
+    public static String OPC_PUBLIC_SERVER_8 = "opc.tcp://opcuademo.sterfive.com:26543";
+        // #8 is currently broken -- discovery returns invalid nodes
+    public static String OPC_PUBLIC_SERVER_9 = "http://opcua.demo-this.com:51211/UA/SampleServer";
+        // #9 is offline
+
+    public static List<String> OPC_PUBLIC_SERVERS = Arrays.asList(
+            // OPC_PUBLIC_SERVER_1,
+            OPC_PUBLIC_SERVER_2,
+            OPC_PUBLIC_SERVER_3,
+            // OPC_PUBLIC_SERVER_4,
+            // OPC_PUBLIC_SERVER_5,
+            // OPC_PUBLIC_SERVER_6,
+            OPC_PUBLIC_SERVER_7,
+            OPC_PUBLIC_SERVER_8
+            // OPC_PUBLIC_SERVER_9
+            );
+
+    public static String OPC_INPROCESS_SERVER = "opc.tcp://localhost:12686/milo"; //"opc.tcp://localhost:12686/example";
     public static String OPC_PUBLIC_SERVER_NO_GOOD = "opc.tcp://opcuaserver.com:4840";
 
     public static String EXAMPLE_NS_SCALAR_INT32_IDENTIFIER = "HelloWorld/ScalarTypes/Int32";
@@ -155,7 +182,7 @@ public class Utils {
                 // We'll skip the remainder of this test for this server
                 Assume.assumeTrue("Timeout connecting to external server.  Skipping remainder of connection test", e.getMessage().contains("Bad_Timeout"));
             }else {
-                fail("Unexpected OpcExtConfig Failure: " + Utils.errFromExc(e));
+                fail("Unexpected OpcExtConfig Failure for endpoint " + discoveryPoint + ": " + Utils.errFromExc(e));
             }
         }
         catch (ExecutionException e) {

--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/WriteToOPCUA.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/WriteToOPCUA.java
@@ -13,6 +13,7 @@ import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
 
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -37,15 +38,26 @@ public class WriteToOPCUA extends OpcUaTestBase {
 
         config.put(OpcConstants.CONFIG_OPC_UA_INFORMATION, opcConfig);
         opcConfig.put(OpcConstants.CONFIG_STORAGE_DIRECTORY, STANDARD_STORAGE_DIRECTORY);
-        opcConfig.put(OpcConstants.CONFIG_SECURITY_POLICY, SecurityPolicy.Basic256Sha256.getSecurityPolicyUri());
-        opcConfig.put(OpcConstants.CONFIG_MESSAGE_SECURITY_MODE, MessageSecurityMode.SignAndEncrypt.toString());
+
+        // ExampleServer no longer has the same means to handle untrusted certs.  So, for now,
+        // we'll just use no security.  We test login elsewhere, so this shouldn't impact
+        // much in terms of testing.
+
+        // TODO: Add better credential generation/validation as the Milo SDK improves and/or stabilizes
+        // TODO: Use SecurityPolicy.Basic256Sha256.getUri());
+        // TODO: Use MessageSecurityMode.SignAndEncrypt.toString());
+
+        opcConfig.put(OpcConstants.CONFIG_SECURITY_POLICY, SecurityPolicy.None.getUri());
+        //SecurityPolicy.Basic256Sha256.getUri());
+        opcConfig.put(OpcConstants.CONFIG_MESSAGE_SECURITY_MODE, MessageSecurityMode.None.toString());
+        //MessageSecurityMode.SignAndEncrypt.toString());
         opcConfig.put(OpcConstants.CONFIG_DISCOVERY_ENDPOINT, Utils.OPC_INPROCESS_SERVER);
 
         OpcUaESClient client = Utils.makeConnection(config, false);
         Assert.assertNotNull("No client returned", client);
 
         performWrites(client,
-                ExampleNamespace.NAMESPACE_URI,
+                exampleNamespace,
                 Utils.EXAMPLE_NS_SCALAR_INT32_IDENTIFIER,
                 Utils.EXAMPLE_NS_SCALAR_INT32_TYPE,
                 42,
@@ -60,14 +72,14 @@ public class WriteToOPCUA extends OpcUaTestBase {
 
         config.put(OpcConstants.CONFIG_OPC_UA_INFORMATION, opcConfig);
         opcConfig.put(OpcConstants.CONFIG_STORAGE_DIRECTORY, STANDARD_STORAGE_DIRECTORY);
-        opcConfig.put(OpcConstants.CONFIG_SECURITY_POLICY, SecurityPolicy.None.getSecurityPolicyUri());
+        opcConfig.put(OpcConstants.CONFIG_SECURITY_POLICY, SecurityPolicy.None.getUri());
         opcConfig.put(OpcConstants.CONFIG_DISCOVERY_ENDPOINT, Utils.OPC_INPROCESS_SERVER);
 
         OpcUaESClient client = Utils.makeConnection(config, false);
         Assert.assertNotNull("No client returned", client);
 
         performWrites(client,
-                ExampleNamespace.NAMESPACE_URI,
+                exampleNamespace,
                 Utils.EXAMPLE_NS_SCALAR_STRING_IDENTIFIER,
                 Utils.EXAMPLE_NS_SCALAR_STRING_TYPE,
                 42,
@@ -118,13 +130,13 @@ public class WriteToOPCUA extends OpcUaTestBase {
 
         config.put(OpcConstants.CONFIG_OPC_UA_INFORMATION, opcConfig);
         opcConfig.put(OpcConstants.CONFIG_STORAGE_DIRECTORY, STANDARD_STORAGE_DIRECTORY);
-        opcConfig.put(OpcConstants.CONFIG_SECURITY_POLICY, SecurityPolicy.None.getSecurityPolicyUri());
+        opcConfig.put(OpcConstants.CONFIG_SECURITY_POLICY, SecurityPolicy.None.getUri());
         opcConfig.put(OpcConstants.CONFIG_DISCOVERY_ENDPOINT, Utils.OPC_INPROCESS_SERVER);
 
         OpcUaESClient client = Utils.makeConnection(config, false);
 
         try {
-            client.writeValue(ExampleNamespace.NAMESPACE_URI + "IAmNotThere", "HelloWorld/ScalarTypes/Int32", "Int32", new Integer(42));
+            client.writeValue(exampleNamespace + "IAmNotThere", "HelloWorld/ScalarTypes/Int32", "Int32", new Integer(42));
         }
         catch (OpcExtRuntimeException e) {
             if (!e.getMessage().startsWith(OpcUaESClient.ERROR_PREFIX + ".badNamespaceURN")) {
@@ -136,7 +148,7 @@ public class WriteToOPCUA extends OpcUaTestBase {
         }
 
         try {
-            client.writeValue(ExampleNamespace.NAMESPACE_URI, "HelloWorld/ScalarTypes/Int32" + "/IAmNotThere", "Int32", 42);
+            client.writeValue(exampleNamespace, "HelloWorld/ScalarTypes/Int32" + "/IAmNotThere", "Int32", 42);
         }
         catch (OpcExtRuntimeException e) {
             if (!e.getMessage().startsWith(OpcUaESClient.ERROR_PREFIX + ".writeError")) {
@@ -149,7 +161,7 @@ public class WriteToOPCUA extends OpcUaTestBase {
 
         try {
             // The following will fail because we're trying to write a float/double to an integer type
-            client.writeValue(ExampleNamespace.NAMESPACE_URI, "HelloWorld/ScalarTypes/Int32", "Int32", 3.14159);
+            client.writeValue(exampleNamespace, "HelloWorld/ScalarTypes/Int32", "Int32", 3.14159);
         }
         catch (OpcExtRuntimeException e) {
             if (!e.getMessage().startsWith(OpcUaESClient.ERROR_PREFIX + ".writeError")) {
@@ -161,7 +173,7 @@ public class WriteToOPCUA extends OpcUaTestBase {
         }
 
         try {
-            client.writeValue(ExampleNamespace.NAMESPACE_URI, "HelloWorld/ScalarTypes/Int32", "Int32", "I am most assuredly NOT an integer of any length!");
+            client.writeValue(exampleNamespace, "HelloWorld/ScalarTypes/Int32", "Int32", "I am most assuredly NOT an integer of any length!");
         }
         catch (OpcExtRuntimeException e) {
             if (!e.getMessage().startsWith(OpcUaESClient.ERROR_PREFIX + ".writeError")) {


### PR DESCRIPTION
Upgraded Milo version used to version 0.3.3.  As of version 0.3 (.0?), the API changed a bit (it is still version 0...), so some code changes were necessary. Whilst there, updated the set of public OPC UA servers against which we test connections (and reported some bugs to them where appropriate).

Generalized our _loopback address reported by discovery handling_ to fix up any discovered addresses that include loopback or unresolvable or unreachable addresses.  This is, apparently, as per spec.  The spec says that the server need not be aware of how it can be reached, so the client must fix up URLs by using the host used for discovery.  So we now handle that..

