### PR TITLE
Improve returned results for object rec.

### DIFF
--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
@@ -20,7 +20,6 @@ import java.util.PriorityQueue;
 public class YOLOClassifier {
     private final static float OVERLAP_THRESHOLD = 0.5f;
     private final static int MAX_RECOGNIZED_CLASSES = 24;
-    private final static int MAX_RESULTS = 24;
     public final static int NUMBER_OF_BOUNDING_BOX = 5;
     
     // Default anchor values used to properly label recognitions on original image
@@ -128,7 +127,7 @@ public class YOLOClassifier {
             Recognition bestRecognition = priorityQueue.poll();
             recognitions.add(bestRecognition);
             
-            for (int i = 0; i < Math.min(priorityQueue.size(), MAX_RESULTS); ++i) {
+            while (priorityQueue.size() > 0) {
                 Recognition recognition = priorityQueue.poll();
                 boolean overlaps = false;
                 for (Recognition previousRecognition : recognitions) {

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
@@ -122,12 +122,12 @@ public class YOLOClassifier {
     private List<Recognition> getRecognition(final PriorityQueue<Recognition> priorityQueue) {
         List<Recognition> recognitions = new ArrayList();
 
-        if (priorityQueue.size() > 0) {
+        if (!priorityQueue.isEmpty()) {
             // Best recognition
             Recognition bestRecognition = priorityQueue.poll();
             recognitions.add(bestRecognition);
             
-            while (priorityQueue.size() > 0) {
+            while (!priorityQueue.isEmpty()) {
                 Recognition recognition = priorityQueue.poll();
                 boolean overlaps = false;
                 for (Recognition previousRecognition : recognitions) {

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -1797,16 +1797,36 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
     // ================================================= Helper functions =================================================
 
-    String imageResultsAsString = "[{\"confidence\":0.8445639, \"location\":{\"top\":255.70024, \"left\":121.859344, \"bottom\":372.2343, "
-            + "\"right\":350.1204}, \"label\":\"keyboard\"}, {\"confidence\":0.7974271, \"location\":{\"top\":91.255974, \"left\":164.41359, "
-            + "\"bottom\":275.69666, \"right\":350.50714}, \"label\":\"tvmonitor\"}]";
+    String imageResultsAsString = "[" +
+            "{\"confidence\":0.8445639, " +
+                 "\"location\":{\"top\":255.70024, \"left\":121.859344, \"bottom\":372.2343, \"right\":350.1204}, \"label\":\"keyboard\"}," +
+            "{\"confidence\":0.7974271," +
+                "\"location\":{\"top\":91.255974, \"left\":164.41359, \"bottom\":275.69666, \"right\":350.50714}, \"label\":\"tvmonitor\"}," +
+            "{\"confidence\":0.6308692, " +
+                "\"location\":{\"top\":13.766539, \"left\":-0.614191, \"bottom\":367.22836, \"right\":122.28085}, \"label\":\"refrigerator\"}, " +
+            "{\"confidence\":0.53600997," +
+                "\"location\":{\"top\":309.05722, \"left\":422.40067, \"bottom\":361.50223, \"right\":485.40735}, \"label\":\"mouse\"}" + 
+    "]";
     
-    String imageResultsAsString608 = "[{\"confidence\":0.8672237, \"location\":{\"top\":93.55155, \"left\":157.38762, \"bottom\":280.36542, "
-            + "\"right\":345.06442}, \"label\":\"tvmonitor\"}, {\"confidence\":0.7927524, \"location\":{\"top\":263.62683, \"left\":123.48807, "
-            + "\"bottom\":371.69046, \"right\":331.86023}, \"label\":\"keyboard\"}]";
+    String imageResultsAsString_inIDE = "[{\"confidence\":0.8445639, "
+               + "\"location\":{\"top\":169.16179, \"left\":6.4747205, \"bottom\":285.69586, \"right\":234.73576}, \"label\":\"keyboard\"},"
+            + "{\"confidence\":0.7974271, "
+                + "\"location\":{\"top\":33.56367, \"left\":241.33667, \"bottom\":218.00436, \"right\":427.43024}, \"label\":\"tvmonitor\"},"
+            + "{\"confidence\":0.6955277, "
+                + "\"location\":{\"top\":149.68317, \"left\":507.42972, \"bottom\":256.89297, \"right\":739.0765}, \"label\":\"keyboard\"},"
+            + "{\"confidence\":0.53600997, "
+               + "\"location\":{\"top\":222.51874, \"left\":76.24681, \"bottom\":274.96375, \"right\":139.2535}, \"label\":\"mouse\"}]";
+
+    
+    String imageResultsAsString608 = "[{\"confidence\":0.8672237, "
+            + "\"location\":{\"top\":93.55155, \"left\":157.38762, \"bottom\":280.36542, \"right\":345.06442}, \"label\":\"tvmonitor\"},"
+        + "{\"confidence\":0.7927524, \"location\":{\"top\":263.62683, \"left\":123.48807, \"bottom\":371.69046, \"right\":331.86023}, \"label\":\"keyboard\"}, "
+        + "{\"confidence\":0.57419246, \"location\":{\"top\":146.11186, \"left\":319.9637, \"bottom\":317.0444, \"right\":423.20792}, \"label\":\"cup\"}]";
     
     String croppedImageResultsAsString = "[{\"confidence\":0.91599655, \"location\":{\"top\":8.16388, \"left\":1.0525968, \"bottom\":118.984344, " 
-            +"\"right\":217.2165}, \"label\":\"keyboard\"}]";
+            +"\"right\":217.2165}, \"label\":\"keyboard\"}," +
+            "{\"confidence\":0.57027775, \"location\":{\"top\":2.1221037, \"left\":205.86801, \"bottom\":64.227806, \"right\":230.19707}, \"label\":\"cup\"}" +
+       "]";
     
     String neuralNetJSON1 =
             "{"
@@ -1878,7 +1898,9 @@ public class TestYoloProcessor extends NeuralNetTestBase {
     }
 
     void resultsEquals(List<Map<String, ?>> list, List<Map> expectedRes) {
-        assert list.size() == expectedRes.size();
+        System.out.println("list: " + list);
+        assertTrue("list Size: " + list.size() + ", expected: "+ expectedRes.size(),
+                list.size() == expectedRes.size());
         for (int i = 0; i < list.size(); i++) {
             mapEquals(list.get(i), expectedRes.get(i));
         }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -1748,6 +1748,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             for (int i = 0; i < responseBody.size(); i++) {
                 JsonObject resultObject = (JsonObject) responseBody.get(i);
                 assert resultObject.get("results") instanceof JsonArray;
+                System.out.println("Results: " + resultObject.get("results"));
                 assert ((JsonArray) resultObject.get("results")).size() == 0;
             }
         }
@@ -1967,6 +1968,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         neuralNet.put("type", "yolo");
         neuralNet.put("metaFile", META_FILE);
         neuralNet.put("pbFile", PB_FILE);
+        neuralNet.put("threshold", 60); // Overcome strange interpretation of camera images
 
         // Placing general config options in "objRecConfig"
         objRecConfig.put("general", general);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -315,11 +315,20 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
     @Test
     public void testResults() throws ImageProcessingException {
-        verifyProcessing(ypJson, imageResultsAsString);
+        String expectedResults = imageResultsAsStringWithoutServer;
+        if (testAuthToken != null && testVantiqServer != null) {
+            expectedResults = imageResultsAsString;
+        }
+        verifyProcessing(ypJson, expectedResults);
     }
 
     @Test
     public void testRealJSONConfig() throws ImageProcessingException, JsonParseException, JsonMappingException, IOException {
+
+        String expectedResults = imageResultsAsStringWithoutServer;
+        if (testAuthToken != null && testVantiqServer != null) {
+            expectedResults = imageResultsAsString;
+        }
         YoloProcessor ypImageSaver = new YoloProcessor();
         ExtensionServiceMessage msg = createRealConfig(neuralNetJSON1);
         Map config = (Map) msg.getObject();
@@ -328,7 +337,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         // Config with meta file, label file, pb file, and anchors
         try {
             ypImageSaver.setupImageProcessing(neuralNetConfig, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
-            verifyProcessing(ypImageSaver, imageResultsAsString);
+            verifyProcessing(ypImageSaver, expectedResults);
         } catch (Exception e) {
             fail("Should not fail with valid config.");
         } finally {
@@ -344,7 +353,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
         try {
             ypImageSaver.setupImageProcessing(neuralNetConfig, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
-            verifyProcessing(ypImageSaver, imageResultsAsString);
+            verifyProcessing(ypImageSaver, expectedResults);
         } catch (Exception e) {
             fail("Should not fail with valid config.");
         } finally {
@@ -360,7 +369,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
         try {
             ypImageSaver.setupImageProcessing(neuralNetConfig, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
-            verifyProcessing(ypImageSaver, imageResultsAsString);
+            verifyProcessing(ypImageSaver, expectedResults);
         } catch (Exception e) {
             fail("Should not fail with valid config.");
         } finally {
@@ -376,7 +385,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
         try {
             ypImageSaver.setupImageProcessing(neuralNetConfig, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
-            verifyProcessing(ypImageSaver, imageResultsAsString);
+            verifyProcessing(ypImageSaver, expectedResults);
         } catch (Exception e) {
             fail("Should not fail with valid config.");
         } finally {
@@ -1748,7 +1757,6 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             for (int i = 0; i < responseBody.size(); i++) {
                 JsonObject resultObject = (JsonObject) responseBody.get(i);
                 assert resultObject.get("results") instanceof JsonArray;
-                System.out.println("Results: " + resultObject.get("results"));
                 assert ((JsonArray) resultObject.get("results")).size() == 0;
             }
         }
@@ -1806,23 +1814,29 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             "{\"confidence\":0.6308692, " +
                 "\"location\":{\"top\":13.766539, \"left\":-0.614191, \"bottom\":367.22836, \"right\":122.28085}, \"label\":\"refrigerator\"}, " +
             "{\"confidence\":0.53600997," +
-                "\"location\":{\"top\":309.05722, \"left\":422.40067, \"bottom\":361.50223, \"right\":485.40735}, \"label\":\"mouse\"}" + 
+                "\"location\":{\"top\":309.05722, \"left\":422.40067, \"bottom\":361.50223, \"right\":485.40735}, \"label\":\"mouse\"}" +
     "]";
-    
-    String imageResultsAsString_inIDE = "[{\"confidence\":0.8445639, "
+
+    // In this class, some tests are dependent upon whether there's a VANTIQ server defined.  When those tests run,
+    // they alter the conditions of other tests.  To make running the tests a bit more friendly, we'll try
+    // and be aware of these conditions and set our expectations accordingly.
+
+    String imageResultsAsStringWithoutServer = "[{\"confidence\":0.8445639, "
                + "\"location\":{\"top\":169.16179, \"left\":6.4747205, \"bottom\":285.69586, \"right\":234.73576}, \"label\":\"keyboard\"},"
             + "{\"confidence\":0.7974271, "
                 + "\"location\":{\"top\":33.56367, \"left\":241.33667, \"bottom\":218.00436, \"right\":427.43024}, \"label\":\"tvmonitor\"},"
             + "{\"confidence\":0.6955277, "
                 + "\"location\":{\"top\":149.68317, \"left\":507.42972, \"bottom\":256.89297, \"right\":739.0765}, \"label\":\"keyboard\"},"
             + "{\"confidence\":0.53600997, "
-               + "\"location\":{\"top\":222.51874, \"left\":76.24681, \"bottom\":274.96375, \"right\":139.2535}, \"label\":\"mouse\"}]";
+               + "\"location\":{\"top\":222.51874, \"left\":76.24681, \"bottom\":274.96375, \"right\":139.2535}, \"label\":\"mouse\"}" +
+    "]";
 
     
     String imageResultsAsString608 = "[{\"confidence\":0.8672237, "
             + "\"location\":{\"top\":93.55155, \"left\":157.38762, \"bottom\":280.36542, \"right\":345.06442}, \"label\":\"tvmonitor\"},"
         + "{\"confidence\":0.7927524, \"location\":{\"top\":263.62683, \"left\":123.48807, \"bottom\":371.69046, \"right\":331.86023}, \"label\":\"keyboard\"}, "
-        + "{\"confidence\":0.57419246, \"location\":{\"top\":146.11186, \"left\":319.9637, \"bottom\":317.0444, \"right\":423.20792}, \"label\":\"cup\"}]";
+        + "{\"confidence\":0.57419246, \"location\":{\"top\":146.11186, \"left\":319.9637, \"bottom\":317.0444, \"right\":423.20792}, \"label\":\"cup\"}" +
+    "]";
     
     String croppedImageResultsAsString = "[{\"confidence\":0.91599655, \"location\":{\"top\":8.16388, \"left\":1.0525968, \"bottom\":118.984344, " 
             +"\"right\":217.2165}, \"label\":\"keyboard\"}," +
@@ -1899,7 +1913,6 @@ public class TestYoloProcessor extends NeuralNetTestBase {
     }
 
     void resultsEquals(List<Map<String, ?>> list, List<Map> expectedRes) {
-        System.out.println("list: " + list);
         assertTrue("list Size: " + list.size() + ", expected: "+ expectedRes.size(),
                 list.size() == expectedRes.size());
         for (int i = 0; i < list.size(); i++) {


### PR DESCRIPTION
Fixes #193 

Update YOLOClassifier to process all the recognitions.  It was previously limited in some cases, and tended to process only half of them then.

Update tests to take this into account.

Ancillary: Add threshold to null suppression tests.  Either _because it does_ or because of the aforementioned change, these tests were failing more often (it tended to recognize a bed in the corner of the picture with 50% confidence).  Set threshold to 60% to mute these spurious failures.