### PR TITLE
Fix lost message problem under heavy notification load

### DIFF
--- a/extjsdk/build.gradle
+++ b/extjsdk/build.gradle
@@ -1,11 +1,13 @@
-group 'io.vantiq'
-version 'unspecified'
-
 buildscript {
     repositories {jcenter() }
 }
 
-apply plugin: 'java'
+plugins {
+    id 'java'
+}
+
+group 'io.vantiq'
+version 'unspecified'
 
 sourceCompatibility = 1.8
 
@@ -20,6 +22,7 @@ ext {
     metricsVersion = '4.0.2'
     rxjavaVersion = '2.1.11'
     slf4jApiVersion = '1.7.25'
+    okhttpVersion = '3.4.1'
 }
 
 // Copies the README and licenses into the jar
@@ -29,32 +32,52 @@ jar.from(".") {
     into ""
 }
 
-
-
 repositories {
-    mavenCentral()
+    maven {
+        url "https://dl.bintray.com/vantiq/maven"
+    }
 }
 
 configurations {
     testArtifacts
 }
-  task testJar (type: Jar) {
+
+test {
+    useJUnit()
+}
+
+tasks.withType(Test) {
+    if (rootProject.hasProperty("TestAuthToken")) {
+        systemProperty "TestAuthToken", rootProject.findProperty("TestAuthToken") ?: "empty"
+    }
+    if (rootProject.hasProperty("TestVantiqServer")) {
+        systemProperty "TestVantiqServer", rootProject.findProperty("TestVantiqServer") ?: "empty"
+    }
+    // Use the build dir as a base to get our various test artifacts.
+    systemProperty "buildDir", "${buildDir}"
+}
+
+task testJar (type: Jar) {
     baseName = "${project.name}-test"
     from sourceSets.test.output
 }
-  artifacts {
+
+artifacts {
     testArtifacts testJar
 }
 
 dependencies {
     compile "org.slf4j:slf4j-api:1.7.25"
-    
-    compile 'com.squareup.okhttp3:okhttp:3.4.1'
-    compile 'com.squareup.okhttp3:okhttp-ws:3.4.1'
-    
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.0"
+
+
+    compile "com.squareup.okhttp3:okhttp:${okhttpVersion}"
+    compile "com.squareup.okhttp3:okhttp-ws:${okhttpVersion}"
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
+    // Used for uploading documents (images) to VANTIQ with VANTIQ SDK
+    testCompile 'io.vantiq:vantiq-sdk:1.0.24'
 }
 
 // Create a jar with all dependencies included

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -245,6 +245,10 @@ public class ExtensionWebSocketClient {
                 this.send(msg);
             } catch (InterruptedException ie) {
                 log.warn("Obtaining space to sent notifications was interrupted.", ie);
+            } catch (Exception e) {
+                // If we get an exception during the send, we're unlikely to get a response so release now.
+                outstandingNotifications.release();
+                throw e;
             }
         }
     }

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
@@ -252,7 +252,7 @@ public class ExtensionWebSocketListener implements WebSocketListener{
             if (statusCheck >= 300) {
                 log.error("Map of the received message: {}", msg);
             } else {
-                log.debug("Map of the received message: {}", msg);
+                log.trace("Map of the received message: {}", msg);
             }
         } else {
             log.debug("Map of the received message: {}", msg);
@@ -264,7 +264,7 @@ public class ExtensionWebSocketListener implements WebSocketListener{
         // Since we're acting through the WebSocket interface, this means it should be a Http response
         if (msg.get("op") == null) {
             Response message = Response.fromMap(msg);
-            log.debug("Http response received");
+            log.trace("Http response received");
             if (client.isAuthed()) {
                 // Is an error message before successful connection to the target source
                 // This is most likely a failure related to a source connection request
@@ -272,6 +272,8 @@ public class ExtensionWebSocketListener implements WebSocketListener{
                     log.warn("Error occurred attempting to connect to source.");
                     log.debug("Error message was: {}", message);
                     client.sourceFuture.complete(false);
+                } else {
+                    client.acknowledgeNotification();
                 }
                 if (this.httpHandler != null) {
                     try {
@@ -282,7 +284,7 @@ public class ExtensionWebSocketListener implements WebSocketListener{
                     }
                 }
                 else {
-                    log.debug("Http response received with no handler set");
+                    log.trace("Http response received with no handler set");
                 }
             }
             else {

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/RoundTripTestBase.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/RoundTripTestBase.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2020 Vantiq, Inc.
+ *
+ * All rights reserved.
+ *
+ * SPDX: MIT
+ */
+
+package io.vantiq.extjsdk;
+
+import org.junit.BeforeClass;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import io.vantiq.client.Vantiq;
+import io.vantiq.client.VantiqResponse;
+
+public class RoundTripTestBase {
+    public static final String UNUSED = "unused";
+
+    public static String testAuthToken = null;
+    public static String testVantiqServer = null;
+    public static String testSourceName = null;
+    public static String testTypeName = null;
+    public static String testRuleName = null;
+    public static final String TEST_IMPL_NAME = "TEST_SOURCE_IMPL";
+
+    static Vantiq vantiq;
+    
+    @BeforeClass
+    public static void getProps() {
+        testAuthToken = System.getProperty("TestAuthToken", null);
+        testVantiqServer = System.getProperty("TestVantiqServer", null);
+        testSourceName = System.getProperty("EntConTestSourceName", "testSourceName");
+        testTypeName = System.getProperty("EntConTestTypeName", "testTypeName");
+        testRuleName = System.getProperty("EntConTestRuleName", "testRuleName");
+        assumeTrue("Tests require system property 'buildDir' to be set -- should be extjsdk/build",
+                System.getProperty("buildDir") != null);
+
+        vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
+        vantiq.setAccessToken(testAuthToken);
+
+    }
+    
+    public static final String SOURCE_NAME = "testSourceName";
+
+    static final String NOT_FOUND_CODE = "io.vantiq.resource.not.found";
+    static final int WAIT_FOR_ASYNC_MILLIS = 5000;
+
+    public static boolean checkSourceExists() {
+        Map<String, String> where = new LinkedHashMap<String, String>();
+        where.put("name", SOURCE_NAME);
+        VantiqResponse response = vantiq.select("system.sources", null, where, null);
+        ArrayList responseBody = (ArrayList) response.getBody();
+        if (responseBody.isEmpty()) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public static void deleteSource() {
+        Map<String, Object> where = new LinkedHashMap<String, Object>();
+        where.put("name", SOURCE_NAME);
+        VantiqResponse response = vantiq.delete("system.sources", where);
+    }
+
+    public static void deleteType() {
+        Map<String, Object> where = new LinkedHashMap<String, Object>();
+        where.put("name", testTypeName);
+        VantiqResponse response = vantiq.delete("system.types", where);
+    }
+
+    public static boolean checkRuleExists() {
+        Map<String, String> where = new LinkedHashMap<String, String>();
+        where.put("name", testRuleName);
+        VantiqResponse response = vantiq.select("system.rules", null, where, null);
+        ArrayList responseBody = (ArrayList) response.getBody();
+        if (responseBody.isEmpty()) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public static void deleteRule() {
+        Map<String, Object> where = new LinkedHashMap<String, Object>();
+        where.put("name", testRuleName);
+        VantiqResponse response = vantiq.delete("system.rules", where);
+    }
+
+    public static void setupSource(Map<String,Object> sourceDef) {
+        VantiqResponse insertResponse = vantiq.insert("system.sources", sourceDef);
+    }
+    
+    public static void setupSourceImpl() {
+        Map<String,String> where = new LinkedHashMap<String,String>();
+        where.put("name", TEST_IMPL_NAME);
+        VantiqResponse implResp = vantiq.select("system.sourceimpls", null, where, null);
+        if (((List) implResp.getBody()).size() == 0) {
+            Map<String, Object> srcImpl = new LinkedHashMap<>();
+            srcImpl.put("name", TEST_IMPL_NAME);
+            srcImpl.put("baseType", "EXTENSION");
+            srcImpl.put("verticle", "service:extensionSource");
+            srcImpl.put("config", new LinkedHashMap());
+            implResp = vantiq.insert("system.sourceimpls", srcImpl);
+            assertTrue("Failure to insert source impl", implResp.getStatusCode() == 200);
+        }
+    }
+
+    public static void deleteSourceImpl() {
+        Map<String, Object> where = new LinkedHashMap<String, Object>();
+        where.put("name", TEST_IMPL_NAME);
+        VantiqResponse response = vantiq.delete("system.sourceimpls", where);
+    }
+
+
+    public static Map<String,Object> createSource() {
+        Map<String,Object> sourceDef = new LinkedHashMap<String,Object>();
+ 
+        sourceDef.put("name", SOURCE_NAME);
+        sourceDef.put("type", TEST_IMPL_NAME);
+        sourceDef.put("active", "true");
+        sourceDef.put("direction", "BOTH");
+        sourceDef.put("config", new LinkedHashMap());
+
+        return sourceDef;
+    }
+
+    public static void setupType() {
+        Map<String,Object> typeDef = new LinkedHashMap<String,Object>();
+        Map<String,Object> properties = new LinkedHashMap<String,Object>();
+        Map<String,Object> propertyDef = new LinkedHashMap<String,Object>();
+        propertyDef.put("type", "Integer");
+        propertyDef.put("required", true);
+        properties.put("msgId", propertyDef);
+        typeDef.put("properties", properties);
+        typeDef.put("name", testTypeName);
+        vantiq.insert("system.types", typeDef);
+    }
+
+    public static void setupRule() {
+        String rule = "RULE " + testRuleName + "\n"
+                + "WHEN MESSAGE ARRIVES FROM " + testSourceName + " AS message\n"
+                + "INSERT " + testTypeName + "(msgId: message.msgId)";
+
+        vantiq.insert("system.rules", rule);
+    }
+
+}

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestWithServer.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestWithServer.java
@@ -1,0 +1,64 @@
+package io.vantiq.extjsdk;
+
+import io.vantiq.client.VantiqResponse;
+import org.junit.AfterClass;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assume.assumeTrue;
+
+public class TestWithServer extends RoundTripTestBase {
+    
+    @AfterClass
+    public static void cleanup() {
+        deleteType();
+        deleteRule();
+        deleteSource();
+        deleteSourceImpl();
+    }
+    
+    @Test
+    public void testNotificationEnMasse() throws Exception {
+
+        int MAX_TRIES = 50;
+        int EXPECTED_ROW_COUNT = 5000;
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+
+        setupType();
+        setupSourceImpl();
+        setupSource(createSource());
+        setupRule();
+        
+        assert checkSourceExists();
+        assert checkRuleExists();
+        
+        ExtensionWebSocketClient client = new ExtensionWebSocketClient(SOURCE_NAME);
+        client.initiateFullConnection(testVantiqServer, testAuthToken).get();
+
+        List<String> simpleList = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            String junk = Instant.now().toString();
+            simpleList.add(junk);
+        }
+        for (int i = 0; i < EXPECTED_ROW_COUNT; i++) {
+            Map ntfy = new HashMap();
+            ntfy.put("data", simpleList);
+            ntfy.put("msgId", i);
+            client.sendNotification(ntfy);
+        }
+        
+        int rowCount = 0;
+        for (int i = 0; (rowCount < EXPECTED_ROW_COUNT) && (i < MAX_TRIES); i++) {
+            VantiqResponse vr = vantiq.select(testTypeName, null, null, null);
+            rowCount = ((List) vr.getBody()).size();
+            Thread.sleep(50);
+        }
+        System.out.println("RowCount: " + rowCount);
+        assert rowCount == EXPECTED_ROW_COUNT;
+    }
+}

--- a/extjsdk/src/test/resources/log4j2.xml
+++ b/extjsdk/src/test/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+
+    <Logger name="io.vantiq.extjsdk" level="DEBUG"/>
+
+    <Root level="DEBUG">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -8,6 +8,7 @@
 
 package io.vantiq.extsrc.jdbcSource;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
@@ -362,7 +363,7 @@ public class TestJDBC extends TestJDBCBase {
             queryResult = jdbc.processQuery(SELECT_QUERY_EXTENDED_TYPES);
             String timestampTest = (String) queryResult[0].get("ts");
             assert timestampTest.matches(timestampPattern);
-            assert timestampTest.equals(FORMATTED_TIMESTAMP);
+            assertTrue("Expected " + FORMATTED_TIMESTAMP + ", but got " + timestampTest,timestampTest.equals(FORMATTED_TIMESTAMP));
             String dateTest = (String) queryResult[0].get("testDate");
             assert dateTest.matches(datePattern);
             assert dateTest.equals(DATE);
@@ -415,7 +416,8 @@ public class TestJDBC extends TestJDBCBase {
         JsonArray responseBody = (JsonArray) response.getBody();
         JsonObject responseMap = (JsonObject) responseBody.get(0);
         String timestamp = (String) responseMap.get("ts").getAsString();
-        assert timestamp.equals(FORMATTED_TIMESTAMP);
+        assertTrue("Expected " + FORMATTED_TIMESTAMP + ", but got " + timestamp,
+                timestamp.equals(FORMATTED_TIMESTAMP));
 
         // Create a Type with DateTime property
         setupType();
@@ -519,7 +521,8 @@ public class TestJDBC extends TestJDBCBase {
                     assert queryResult[0].get("ts").equals(FORMATTED_TIMESTAMP);
                 }
                 if (i != 1) {
-                    assert queryResult[0].get("testDate").equals(DATE);
+                    assertTrue("Expected " + DATE + ", but got " + queryResult[0].get("testDate"),
+                            queryResult[0].get("testDate").equals(DATE));
                 }
                 if (i != 2) {
                     assert queryResult[0].get("testTime").equals(FORMATTED_TIME);
@@ -987,6 +990,11 @@ public class TestJDBC extends TestJDBCBase {
     }
 
     public static void setupSource(Map<String,Object> sourceDef) {
+
+        Map<String,String> where = new LinkedHashMap<String,String>();
+        where.put("name", "JDBC");
+        VantiqResponse implResp = vantiq.select("system.sourceimpls", null, where, null);
+
         VantiqResponse insertResponse = vantiq.insert("system.sources", sourceDef);
         if (insertResponse.isSuccess()) {
             core = new JDBCCore(testSourceName, testAuthToken, testVantiqServer);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetTestBase.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetTestBase.java
@@ -27,6 +27,7 @@ import io.vantiq.extsrc.objectRecognition.ObjRecTestBase;
 public class NeuralNetTestBase extends ObjRecTestBase {
     public static final String MODEL_DIRECTORY = System.getProperty("buildDir") + "/models";
     public static final String SOURCE_NAME = "testSourceName";
+    public static final String OR_SRC_TYPE = "OBJECT_RECOGNITION";
 
     static final String VANTIQ_DOCUMENTS = "system.documents";
     static final String VANTIQ_IMAGES = "system.images";

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
@@ -18,7 +18,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-mport org.junit.AfterClass;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Test;

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
@@ -520,39 +520,4 @@ public class TestNoProcessor extends NeuralNetTestBase {
             npProcessor.close();
         }
     }
-
-    @Test
-    public void testNotificationEnMass() throws Exception {
-
-        assumeTrue(testAuthToken != null && testVantiqServer != null);
-
-        ExtensionWebSocketClient client = new ExtensionWebSocketClient("testSrc");
-        client.initiateFullConnection(testVantiqServer, testAuthToken).get();
-        
-//        ObjectRecognitionCore("testSrc", testAuthToken, testVantiqServer, )
-//        Map config = new LinkedHashMap<>();
-//        NoProcessor npProcessor = new NoProcessor();
-//        
-//        config.put("saveImage", "local");
-//        config.put("outputDir", OUTPUT_DIR);
-//        config.put("saveRate", SAVE_RATE);
-//        npProcessor.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
-//        assertTrue("NoProcessor should still setup with empty config", npProcessor.isSetup);
-
-        List<String> simpleList = new ArrayList<>();
-        for (int i = 0; i < 20; i++) {
-            String junk = Integer.toString(i);
-            simpleList.add(junk);
-        }
-        for (int i = 0; i < 100000; i++) {
-            System.out.println("Sending entity #" + i);
-            Map ntfy = new HashMap();
-            ntfy.put("data", simpleList);
-            ntfy.put("msgId", Integer.toString(i));
-            client.sendNotification(ntfy);
-            Thread.sleep(0, 1);
-            //assertTrue( "testAssert", i > 5000);
-        }
-        assertTrue(false);
-    }
 }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
@@ -12,12 +12,16 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
+import java.io.Externalizable;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.vantiq.extjsdk.ExtensionWebSocketClient;
+import io.vantiq.extsrc.objectRecognition.ObjectRecognitionCore;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
@@ -30,6 +34,7 @@ import io.vantiq.client.VantiqError;
 import io.vantiq.client.VantiqResponse;
 import io.vantiq.extsrc.objectRecognition.exception.ImageProcessingException;
 import okhttp3.Response;
+import org.slf4j.LoggerFactory;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class TestNoProcessor extends NeuralNetTestBase {
@@ -50,13 +55,13 @@ public class TestNoProcessor extends NeuralNetTestBase {
     // A single processor is used for the entire class because it is very expensive to do initial setup
     @BeforeClass
     public static void classSetup() {
-        noProcessor = new NoProcessor();
+//        noProcessor = new NoProcessor();
 
         Map<String, Object> config = new LinkedHashMap<>();
-        noProcessor.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
-
-        vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
-        vantiq.setAccessToken(testAuthToken);
+//        noProcessor.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
+//
+//        vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
+//        vantiq.setAccessToken(testAuthToken);
     }
 
     @AfterClass
@@ -514,5 +519,40 @@ public class TestNoProcessor extends NeuralNetTestBase {
 
             npProcessor.close();
         }
+    }
+
+    @Test
+    public void testNotificationEnMass() throws Exception {
+
+        assumeTrue(testAuthToken != null && testVantiqServer != null);
+
+        ExtensionWebSocketClient client = new ExtensionWebSocketClient("testSrc");
+        client.initiateFullConnection(testVantiqServer, testAuthToken).get();
+        
+//        ObjectRecognitionCore("testSrc", testAuthToken, testVantiqServer, )
+//        Map config = new LinkedHashMap<>();
+//        NoProcessor npProcessor = new NoProcessor();
+//        
+//        config.put("saveImage", "local");
+//        config.put("outputDir", OUTPUT_DIR);
+//        config.put("saveRate", SAVE_RATE);
+//        npProcessor.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
+//        assertTrue("NoProcessor should still setup with empty config", npProcessor.isSetup);
+
+        List<String> simpleList = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            String junk = Integer.toString(i);
+            simpleList.add(junk);
+        }
+        for (int i = 0; i < 100000; i++) {
+            System.out.println("Sending entity #" + i);
+            Map ntfy = new HashMap();
+            ntfy.put("data", simpleList);
+            ntfy.put("msgId", Integer.toString(i));
+            client.sendNotification(ntfy);
+            Thread.sleep(0, 1);
+            //assertTrue( "testAssert", i > 5000);
+        }
+        assertTrue(false);
     }
 }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
@@ -12,17 +12,13 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
-import java.io.Externalizable;
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import io.vantiq.extjsdk.ExtensionWebSocketClient;
-import io.vantiq.extsrc.objectRecognition.ObjectRecognitionCore;
-import org.junit.AfterClass;
+mport org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -34,7 +30,6 @@ import io.vantiq.client.VantiqError;
 import io.vantiq.client.VantiqResponse;
 import io.vantiq.extsrc.objectRecognition.exception.ImageProcessingException;
 import okhttp3.Response;
-import org.slf4j.LoggerFactory;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class TestNoProcessor extends NeuralNetTestBase {
@@ -55,13 +50,13 @@ public class TestNoProcessor extends NeuralNetTestBase {
     // A single processor is used for the entire class because it is very expensive to do initial setup
     @BeforeClass
     public static void classSetup() {
-//        noProcessor = new NoProcessor();
+        noProcessor = new NoProcessor();
 
         Map<String, Object> config = new LinkedHashMap<>();
-//        noProcessor.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
-//
-//        vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
-//        vantiq.setAccessToken(testAuthToken);
+        noProcessor.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
+
+        vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
+        vantiq.setAccessToken(testAuthToken);
     }
 
     @AfterClass

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
@@ -314,7 +314,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         // Setting up the source definition
         sourceDef.put("config", sourceConfig);
         sourceDef.put("name", SOURCE_NAME);
-        sourceDef.put("type", "ObjectRecognition");
+        sourceDef.put("type", OR_SRC_TYPE);
         sourceDef.put("active", "true");
         sourceDef.put("direction", "BOTH");
         

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
@@ -138,7 +138,7 @@ public class TestParallelProcessing extends NeuralNetTestBase {
         // Setting up the source definition
         sourceDef.put("config", sourceConfig);
         sourceDef.put("name", testSourceName);
-        sourceDef.put("type", "ObjectRecognition");
+        sourceDef.put("type", OR_SRC_TYPE);
         sourceDef.put("active", "true");
         sourceDef.put("direction", "BOTH");
 

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -1994,7 +1994,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         // Setting up the source definition
         sourceDef.put("config", sourceConfig);
         sourceDef.put("name", testSourceName);
-        sourceDef.put("type", "ObjectRecognition");
+        sourceDef.put("type", OR_SRC_TYPE);
         sourceDef.put("active", "true");
         sourceDef.put("direction", "BOTH");
 

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -976,7 +976,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         // Setting up the source definition
         sourceDef.put("config", sourceConfig);
         sourceDef.put("name", SOURCE_NAME);
-        sourceDef.put("type", "ObjectRecognition");
+        sourceDef.put("type", OR_SRC_TYPE);
         sourceDef.put("active", "true");
         sourceDef.put("direction", "BOTH");
         

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueriesLocationMapper.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueriesLocationMapper.java
@@ -174,6 +174,7 @@ public class TestYoloQueriesLocationMapper extends NeuralNetTestBase {
 
     public static void setupSource(Map<String,Object> sourceDef) {
         VantiqResponse insertResponse = vantiq.insert("system.sources", sourceDef);
+        assertTrue("Cannot create source: " + insertResponse.toString(), insertResponse.isSuccess());
         if (insertResponse.isSuccess()) {
             core = new ObjectRecognitionCore(SOURCE_NAME, testAuthToken, testVantiqServer, MODEL_DIRECTORY);;
             core.start(CORE_START_TIMEOUT);
@@ -251,7 +252,7 @@ public class TestYoloQueriesLocationMapper extends NeuralNetTestBase {
         // Setting up the source definition
         sourceDef.put("config", sourceConfig);
         sourceDef.put("name", SOURCE_NAME);
-        sourceDef.put("type", "ObjectRecognition");
+        sourceDef.put("type",  OR_SRC_TYPE);
         sourceDef.put("active", "true");
         sourceDef.put("direction", "BOTH");
         log.debug("Source def'n: {}", sourceDef);


### PR DESCRIPTION
Fixes #199

Alters the ExtJSDK so that there's a limit of 5 outstanding notifications at a time -- outstanding means notifications that have been sent but have not yet gotten a response.  Without this, problematic programs sending 1K+ notifications in a loop would occasionally have messages dropped -- seemingly due to some limits within OkHTTP or the web socket system.

Also, updated extjsdk build.gradle file in prep for upgrading the OKHttp version.

Also, also, made some changes to objectrec & JDBC tests so some diagnosis is easier & that the source implementation name matches the file provided.