### PR TITLE
Disallow List or Array parameter to sendNotification()

### DIFF
--- a/extjsdk/README.md
+++ b/extjsdk/README.md
@@ -97,7 +97,8 @@ There are three types of messages that can be sent to a source: Notifications, Q
 Notifications are JSON messages that the source will pass on to any Vantiq rules saying
 `WHEN MESSAGE ARRIVES FROM SOURCE <source name>`. To send one, simply call
 `client.sendNotification(<object to be sent>)`, which will translate the message into JSON and add everything Vantiq
-needs to recognize the message. 
+needs to recognize the message.
+Note that neither `List` or array objects can be sent as notifications.
 
 #### <a name="queryResponse" id="queryResponse"></a>Query Responses
 Query responses are responses to a `SELECT` request from Vantiq that targets a source, and can either be a Map or an

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -20,8 +20,10 @@ import okhttp3.*;
 import okhttp3.ws.WebSocket;
 import okhttp3.ws.WebSocketCall;
 
+import java.lang.reflect.Array;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
@@ -227,11 +229,15 @@ public class ExtensionWebSocketClient {
     /**
      * Sends a notification to the specified source if it is connected.
      *
-     * @param data  The data to be sent to the source
+     * @param data  The data to be sent to the source.  Data cannot be an array or List.
      */
     // Fills in a notification message to sourceName with data
     // Requires this client to be connected to the source
     public void sendNotification(Object data) {
+
+        if (data != null && (data.getClass().isArray() || data instanceof List)) {
+            throw new IllegalArgumentException("Notifications cannot be lists or arrays.");
+        }
         if (isConnected()) {
             Map<String,Object> m = new LinkedHashMap<>();
             m.put("op", ExtensionServiceMessage.OP_NOTIFICATION);

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
@@ -20,12 +20,15 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.fail;
 
 
 public class TestExtensionWebSocketClient extends ExtjsdkTestBase{
@@ -286,6 +289,36 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase{
         assert socket.compareData("op", ExtensionServiceMessage.OP_NOTIFICATION);
         assert socket.compareData("object.msg", "str");
         assert socket.compareData("resourceId", srcName);
+    }
+
+    @Test
+    public void testBadNotificationArguments() {
+        markSourceConnected(true);
+
+        Integer[] intArray = new Integer[3];
+        intArray[0] = 1;
+        intArray[1] = 2;
+        intArray[2] = 3;
+
+        try {
+            client.sendNotification(intArray);
+            fail("Send of Array should fail.");
+        } catch (IllegalArgumentException iae) {
+            // Expected
+        } // Other invalid exceptions will escape & cause failure.
+
+        List<String> stringList = new ArrayList<>();
+        stringList.add("This ");
+        stringList.add("should ");
+        stringList.add("not ");
+        stringList.add("work.");
+
+        try {
+            client.sendNotification(stringList);
+            fail("Send of List should fail.");
+        } catch (IllegalArgumentException iae) {
+            // Expected
+        } // Other invalid exceptions will escape & cause failure.
     }
     
 // ============================== Helper functions ==============================

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -509,6 +509,7 @@ public class TestJDBC extends TestJDBCBase {
             // Insert data into database
             try {
                 publishResult = jdbc.processPublish(queryString);
+                assertTrue("publish failed: " + publishResult, publishResult > 0);
             } catch (Exception e) {
                 fail("No exception should be thrown when inserting null values: " + e.getMessage());
             }
@@ -516,6 +517,7 @@ public class TestJDBC extends TestJDBCBase {
             // Make sure collected data is identical to input data, and fail if any type of exception is caught
             try {
                 queryResult = jdbc.processQuery(QUERY_NULL_VALUES);
+                assert queryResult.length == 1;
                 assert queryResult[0].size() == 5;
                 if (i != 0) {
                     assert queryResult[0].get("ts").equals(FORMATTED_TIMESTAMP);
@@ -525,7 +527,8 @@ public class TestJDBC extends TestJDBCBase {
                             queryResult[0].get("testDate").equals(DATE));
                 }
                 if (i != 2) {
-                    assert queryResult[0].get("testTime").equals(FORMATTED_TIME);
+                    assertTrue("Expected " + FORMATTED_TIME + ", but got " + queryResult[0].get("testTime"),
+                         queryResult[0].get("testTime").equals(FORMATTED_TIME));
                 }
                 if (i != 3) {
                     assert queryResult[0].get("testInt").toString().equals(TEST_INT);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -234,7 +234,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         try {
             ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
         } catch (Exception e) {
-            fail("Should not fail with meta file but no label file.");
+            fail("Should not fail with meta file but no label file: " + e.getClass().getName() + "::" + e.getMessage());
         }
 
         // Meta file included and anchors included
@@ -243,7 +243,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         try {
             ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
         } catch (Exception e) {
-            fail("Should not fail with meta file and anchors.");
+            fail("Should not fail with meta file and anchors: " + e.getClass().getName() + "::" + e.getMessage());
         }
 
         // Label file included, no meta file
@@ -254,7 +254,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         try {
             ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
         } catch (Exception e) {
-            fail("Should not fail with label file but no meta file.");
+            fail("Should not fail with label file but no meta file: " + e.getClass().getName() + "::" + e.getMessage());
         }
 
         // Label file included and anchors included
@@ -263,7 +263,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         try {
             ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
         } catch (Exception e) {
-            fail("Should not fail with label file and anchors.");
+            fail("Should not fail with label file and anchors: " + e.getClass().getName() + "::" + e.getMessage());
         }
 
         // Label and meta file included, anchors included
@@ -272,7 +272,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         try {
             ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
         } catch (Exception e) {
-            fail("Should not fail with label and meta file, and anchors.");
+            fail("Should not fail with label and meta file, and anchors: " + e.getClass().getName() + "::" + e.getMessage());
         }
 
     }
@@ -288,7 +288,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         try {
             ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
         } catch (Exception e) {
-            fail("Should not fail setup.");
+            fail("Should not fail setup: " + e.getClass().getName() + "::" + e.getMessage());
         }
         
         // useMetaIfAvailable flag should be true, since Config Size value is unchanged (default is 416)
@@ -302,7 +302,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         try {
             ypImageSaver2.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
         } catch (Exception e) {
-            fail("Should not fail setup.");
+            fail("Should not fail setup: " + e.getClass().getName() + "::" + e.getMessage());
         }
         
         // useMetaIfAvailable flag should still be true regardless of meta file presence
@@ -339,7 +339,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             ypImageSaver.setupImageProcessing(neuralNetConfig, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
             verifyProcessing(ypImageSaver, expectedResults);
         } catch (Exception e) {
-            fail("Should not fail with valid config.");
+            fail("Should not fail with valid config: " + e.getClass().getName() + "::" + e.getMessage());
         } finally {
             if (ypImageSaver != null) {
                 ypImageSaver.close();
@@ -355,7 +355,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             ypImageSaver.setupImageProcessing(neuralNetConfig, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
             verifyProcessing(ypImageSaver, expectedResults);
         } catch (Exception e) {
-            fail("Should not fail with valid config.");
+            fail("Should not fail with valid config: " + e.getClass().getName() + "::" + e.getMessage());
         } finally {
             if (ypImageSaver != null) {
                 ypImageSaver.close();
@@ -371,7 +371,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             ypImageSaver.setupImageProcessing(neuralNetConfig, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
             verifyProcessing(ypImageSaver, expectedResults);
         } catch (Exception e) {
-            fail("Should not fail with valid config.");
+            fail("Should not fail with valid config: " + e.getClass().getName() + "::" + e.getMessage());
         } finally {
             if (ypImageSaver != null) {
                 ypImageSaver.close();
@@ -387,7 +387,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             ypImageSaver.setupImageProcessing(neuralNetConfig, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
             verifyProcessing(ypImageSaver, expectedResults);
         } catch (Exception e) {
-            fail("Should not fail with valid config.");
+            fail("Should not fail with valid config: " + e.getClass().getName() + "::" + e.getMessage());
         } finally {
             if (ypImageSaver != null) {
                 ypImageSaver.close();
@@ -410,7 +410,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             ypImageSaver.setupImageProcessing(neuralNetConfig, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
             verifyProcessing(ypImageSaver, imageResultsAsString608);
         } catch (Exception e) {
-            fail("Should not fail with valid config.");
+            fail("Should not fail with valid config: " + e.getClass().getName() + "::" + e.getMessage());
         } finally {
             if (ypImageSaver != null) {
                 ypImageSaver.close();
@@ -431,7 +431,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         try {
             ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
         } catch (Exception e) {
-            fail("Should not fail with valid anchors.");
+            fail("Should not fail with valid anchors: " + e.getClass().getName() + "::" + e.getMessage());
         }
 
         // Checking mix of integers and floating points
@@ -442,7 +442,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         try {
             ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
         } catch (Exception e) {
-            fail("Should not fail with invalid anchors");
+            fail("Should not fail with invalid anchors: " + e.getClass().getName() + "::" + e.getMessage());
         }
     }
 
@@ -460,7 +460,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         try {
             ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
         } catch (Exception e) {
-            fail("Should not fail with invalid anchors");
+            fail("Should not fail with invalid anchors: " + e.getClass().getName() + "::" + e.getMessage());
         }
 
         // anchorList is too long
@@ -471,7 +471,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         try {
             ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
         } catch (Exception e) {
-            fail("Should not fail with invalid anchors");
+            fail("Should not fail with invalid anchors: " + e.getClass().getName() + "::" + e.getMessage());
         }
 
         // anchorList contains non-numbers
@@ -482,7 +482,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         try {
             ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
         } catch (Exception e) {
-            fail("Should not fail with invalid anchors");
+            fail("Should not fail with invalid anchors: " + e.getClass().getName() + "::" + e.getMessage());
         }
     }
 
@@ -1699,7 +1699,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
             verifyProcessing(ypImageSaver, croppedImageResultsAsString);
         } catch (Exception e) {
-            fail("Should not fail with valid config.");
+            fail("Should not fail with valid config: " + e.getClass().getName() + "::" + e.getMessage());
         } finally {
             if (ypImageSaver != null) {
                 ypImageSaver.close();


### PR DESCRIPTION
Fixes #198 

sendNotification() now checks it's parameter for vaildity -- if a list or array, throws illegalArgumentException as these aren't permitted.

Also added some aids to diagnosis for some problematic tests.