### PR TITLE
Object Recognition Source:  Add center point to bounding box description

### DIFF
--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -378,7 +378,9 @@ Output from a source configured as above would look like the following:
         "top": 116.07966,
         "left": 293.64996,
         "bottom": 196.53435,
-        "right": 371.21164
+        "right": 371.21164,
+        "centerX": 332.4308,
+        "centerY": 156.21158
       },
       "label": "car"
     }
@@ -392,7 +394,9 @@ Output from a source configured as above would look like the following:
         "top": 166.07966,
         "left": 343.64996,
         "bottom": 246.53435,
-        "right": 421.21164
+        "right": 421.21164,
+        "centerX": 382.4308,
+        "centerY": 206.21158
       },
       "label": "car"
     }
@@ -462,7 +466,9 @@ Output from such a source will look like the following.
         "top": 30.737188,
         "left": 341.99405,
         "bottom": 428.0833,
-        "right": 796.15137
+        "right": 796.15137,
+        "centerX": 569.07271,
+        "centerY": 229.410244
       },
       "label": "train"
     }
@@ -486,6 +492,13 @@ Output from such a source will look like the following.
             391.99405
           ],
           "type": "Point"
+        },
+        "center": {
+          "coordinates": [
+            279.410244,
+            619.07271
+          ],
+          "type": "Point"
         }
       },
       "label": "train"
@@ -495,8 +508,9 @@ Output from such a source will look like the following.
 ```
 
 Here again, note the `mappedResults` element.
-Specifically, note that instead of the `top`, `left`, `bottom`, and `right` members, we have the two GeoJSON elements -- `bottomRight` and `topLeft`, each of which specifies a `Point` forming
-the bounding box delimters in the output coordinate space.
+Specifically, note that instead of the `centerX`, `centerY`, `top`, `left`, `bottom`, and `right` members,
+we have the three GeoJSON elements -- `center`, `bottomRight` and `topLeft`, each of which specifies a `Point` forming
+the bounding box delimiters in the output coordinate space.
 
 
 
@@ -861,8 +875,10 @@ and `<install location>/objectRecognitionSource/bin/objectRecognitionSource.bat`
 
 This is a TensorFlow implementation of YOLO (You Only Look Once). The identified objects have a `label`
 stating the type of the object identified, a `confidence` specifying on a scale of 0-1 how confident the neural net is
-that the identification is accurate, and a `location` containing the coordinates for the `top`,`left`, `bottom`,
-and `right` edges of the bounding box for the object. It can also save images with the bounding boxes drawn.  
+that the identification is accurate, and a `location` containing
+the coordinates for the center (`centerX` and `centerY`), `top`,`left`, `bottom`,
+and `right` edges of the bounding box for the object.
+It can also save images with the bounding boxes drawn.  
 
 The standard implementation expects a net trained on 416x416 images, and automatically resizes images to those 
 dimensions. If a `.meta` file is provided, then the input frame size stored in that file, ("height"/"width" fields), will be 

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
@@ -339,7 +339,10 @@ public class ObjectDetector {
             location.put("top", recognition.getScaledLocation(scaleX, scaleY).getTop());
             location.put("right", recognition.getScaledLocation(scaleX, scaleY).getRight());
             location.put("bottom", recognition.getScaledLocation(scaleX, scaleY).getBottom());
-        	map.put("location", location);
+            location.put("centerX", recognition.getScaledLocation(scaleX, scaleY).getCenterX());
+            location.put("centerY", recognition.getScaledLocation(scaleX, scaleY).getCenterY());
+
+            map.put("location", location);
         	
         	jsonRecognitions.add(map);
         	

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/classifier/YOLOClassifier.java
@@ -111,8 +111,9 @@ public class YOLOClassifier {
             double confidenceInClass = argMax.getMaxValue() * boundingBox.getConfidence();
             if (confidenceInClass > threshold) {
                 predictionQueue.add(new Recognition(argMax.getIndex(), labels.get(argMax.getIndex()), (float) confidenceInClass,
-                        new BoxPosition((float) (boundingBox.getX() - boundingBox.getWidth() / 2),
-                                (float) (boundingBox.getY() - boundingBox.getHeight() / 2),
+                        /* BoxPosition() now takes center points */
+                        new BoxPosition((float) boundingBox.getX(),
+                                (float) boundingBox.getY(),
                                 (float) boundingBox.getWidth(),
                                 (float) boundingBox.getHeight())));
             }

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/model/BoxPosition.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/model/BoxPosition.java
@@ -1,5 +1,8 @@
 package edu.ml.tensorflow.model;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Model to store the position of the bounding boxes
  */
@@ -10,12 +13,26 @@ public class BoxPosition {
     private float bottom;
     private float width;
     private float height;
+    private float centerX;
+    private float centerY;
 
-    public BoxPosition(float left, float top, float width, float height) {
-        this.left = left;
-        this.top = top;
+
+    /**
+     * Build from center point + height & width
+     *
+     * @param x float X coordinate of the center
+     * @param y float Y coordinate of the center
+     * @param width float width of box
+     * @param height float height of box
+     */
+    public BoxPosition(float x, float y, float width, float height) {
+
+        this.left = x - width / 2;
+        this.top = y - height / 2;
         this.width = width;
         this.height = height;
+        this.centerX = x;
+        this.centerY = y;
 
         init();
     }
@@ -25,6 +42,8 @@ public class BoxPosition {
         this.top = boxPosition.top;
         this.width = boxPosition.width;
         this.height = boxPosition.height;
+        this.centerX = boxPosition.centerX;
+        this.centerY = boxPosition.centerY;
 
         init();
     }
@@ -34,6 +53,8 @@ public class BoxPosition {
         this.top = boxPosition.top * scaleY;
         this.width = boxPosition.width * scaleX;
         this.height = boxPosition.height * scaleY;
+        this.centerX = boxPosition.centerX * scaleX;
+        this.centerY = boxPosition.centerY * scaleY;
 
         init();
     }
@@ -98,6 +119,34 @@ public class BoxPosition {
         return (int) bottom;
     }
 
+    public float getCenterX() {
+        return centerX;
+    }
+
+    public int getCenterXInt() {
+        return (int) centerX;
+    }
+    public float getCenterY() {
+        return centerY;
+    }
+
+    public int getCenterYInt() {
+        return (int) centerY;
+    }
+
+    public Map asExternalMap() {
+        HashMap<String, Object> location = new HashMap<>();
+
+        location.put("left", getLeft());
+        location.put("top", getTop());
+        location.put("right", getRight());
+        location.put("bottom", getBottom());
+        location.put("centerX", getCenterX());
+        location.put("centerY", getCenterY());
+
+        return location;
+    }
+    
     @Override
     public String toString() {
         return "BoxPosition{" +

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecCore.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecCore.java
@@ -390,12 +390,21 @@ public class TestObjRecCore extends ObjRecTestBase {
             Map<String, Double> inloc = (Map<String, Double>) testinp.get(i).get("location");
             @SuppressWarnings({"unchecked"})
             Map<String, Double> resloc = (Map<String, Double>) res.get(i).get("location");
+
+            assertEquals("mapped top", 
+                    inloc.get("top") + 50d, resloc.get("top"),ACCEPTABLE_DELTA);
+            assertEquals("mapped left", 
+                    inloc.get("left") + 50d, resloc.get("left"), ACCEPTABLE_DELTA);
+            assertEquals("mapped bottom", 
+                    inloc.get("bottom") + 50d, resloc.get("bottom"), ACCEPTABLE_DELTA);
+            assertEquals("mapped right", 
+                    inloc.get("right") + 50d, resloc.get("right"), ACCEPTABLE_DELTA);
+            assertEquals("mapped centerX",
+                    inloc.get("centerX") + 50d, resloc.get("centerX"), ACCEPTABLE_DELTA);
+            assertEquals("mapped centerY",
+                    inloc.get("centerY") + 50d, resloc.get("centerY"), ACCEPTABLE_DELTA);
             assertEquals("Wrong number of locations in result", inloc.size(), resloc.size());
 
-            assertEquals("mapped top", inloc.get("top") + 50d, resloc.get("top"), ACCEPTABLE_DELTA);
-            assertEquals("mapped left", inloc.get("left") + 50d, resloc.get("left"), ACCEPTABLE_DELTA);
-            assertEquals("mapped bottom", inloc.get("bottom") + 50d, resloc.get("bottom"), ACCEPTABLE_DELTA);
-            assertEquals("mapped right", inloc.get("right") + 50d, resloc.get("right"), ACCEPTABLE_DELTA);
         }
 
         core.createLocationMapper(doubleSrcPts, doubleDstPts);
@@ -414,12 +423,20 @@ public class TestObjRecCore extends ObjRecTestBase {
             Map<String, Double> inloc = (Map<String, Double>) testinp.get(i).get("location");
             @SuppressWarnings({"unchecked"})
             Map<String, Double> resloc = (Map<String, Double>) res.get(i).get("location");
-            assertEquals("Wrong number of locations in result", inloc.size(), resloc.size());
 
-            assertEquals("mapped top", inloc.get("top") * 2d, resloc.get("top"), ACCEPTABLE_DELTA);
-            assertEquals("mapped left", inloc.get("left") * 2d, resloc.get("left"), ACCEPTABLE_DELTA);
-            assertEquals("mapped bottom", inloc.get("bottom") * 2d, resloc.get("bottom"), ACCEPTABLE_DELTA);
-            assertEquals("mapped bottom", inloc.get("bottom") * 2d, resloc.get("bottom"), ACCEPTABLE_DELTA);
+            assertEquals("mapped top", 
+                    inloc.get("top") * 2d, resloc.get("top"), ACCEPTABLE_DELTA);
+            assertEquals("mapped left", 
+                    inloc.get("left") * 2d, resloc.get("left"), ACCEPTABLE_DELTA);
+            assertEquals("mapped bottom", 
+                    inloc.get("bottom") * 2d, resloc.get("bottom"), ACCEPTABLE_DELTA);
+            assertEquals("mapped bottom", 
+                    inloc.get("bottom") * 2d, resloc.get("bottom"), ACCEPTABLE_DELTA);
+            assertEquals("mapped centerX",
+                    inloc.get("centerX") * 2d, resloc.get("centerX"), ACCEPTABLE_DELTA);
+            assertEquals("mapped centerY",
+                    inloc.get("centerY") * 2d, resloc.get("centerY"), ACCEPTABLE_DELTA);
+            assertEquals("Wrong number of locations in result", inloc.size(), resloc.size());
         }
     }
 
@@ -444,13 +461,16 @@ public class TestObjRecCore extends ObjRecTestBase {
             @SuppressWarnings({"unchecked"})
             Map<String, Map<String, ?>> resloc = (Map<String, Map<String, ?>>) res.get(i).get("location");
 
-            // When converting to GeoJSON, results come back as 2 points (topLeft & bottomRight) as opposed
-            // to 4 single numbers
-            assertEquals("Wrong number of locations in result", 2, resloc.size());
+            // When converting to GeoJSON, results come back as 3 points (center, topLeft & bottomRight) as opposed
+            // to 6 single numbers (top, left, bottom, right, centerX, centerY)
+            
+            assertEquals("Wrong number of locations in result", 3, resloc.size());
             Map<String, ?> tlEnt = resloc.get("topLeft");
             assertNotNull("Missing topLeft", tlEnt);
             Map<String, ?> brEnt = resloc.get("bottomRight");
             assertNotNull("Missing bottomRight", brEnt);
+            Map<String, ?> centEnt = resloc.get("center");
+            assertNotNull("Missing center", centEnt);
 
             assertEquals("mapped topLeft type", "Point", tlEnt.get("type"));
             assertEquals("mapped bottomRight type", "Point", brEnt.get("type"));
@@ -461,11 +481,23 @@ public class TestObjRecCore extends ObjRecTestBase {
             Double[] brCoords = (Double[]) brEnt.get("coordinates");
             assertNotNull("No bottomRight coordinates", brCoords);
             assertEquals("Wrong number of bottomRight coordinates", 2, brCoords.length);
+            Double[] center = (Double[]) centEnt.get("coordinates");
+            assertNotNull("No center coordinates", centEnt);
+            assertEquals("Wrong number of center coordinates", 2, center.length);
 
-            assertEquals("mapped topLeft longitude", inloc.get("top") + 50d, tlCoords[0], ACCEPTABLE_DELTA);
-            assertEquals("mapped topLeft latitude", inloc.get("left") + 50d, tlCoords[1], ACCEPTABLE_DELTA);
-            assertEquals("mapped bottomRight longitude", inloc.get("bottom") + 50d, brCoords[0], ACCEPTABLE_DELTA);
-            assertEquals("mapped bottomRight latitude", inloc.get("right") + 50d, brCoords[1], ACCEPTABLE_DELTA);
+            assertEquals("mapped topLeft longitude", 
+                    inloc.get("top") + 50d, tlCoords[0], ACCEPTABLE_DELTA);
+            assertEquals("mapped topLeft latitude", 
+                    inloc.get("left") + 50d, tlCoords[1], ACCEPTABLE_DELTA);
+            assertEquals("mapped bottomRight longitude", 
+                    inloc.get("bottom") + 50d, brCoords[0], ACCEPTABLE_DELTA);
+            assertEquals("mapped bottomRight latitude", 
+                    inloc.get("right") + 50d, brCoords[1], ACCEPTABLE_DELTA);
+            assertEquals("mapped center longitude", 
+                    inloc.get("centerY") + 50d, center[0], ACCEPTABLE_DELTA);
+            assertEquals("mapped center latitude", 
+                    inloc.get("centerX") + 50d, center[1], ACCEPTABLE_DELTA);
+
         }
 
         core.createLocationMapper(doubleSrcPts, doubleDstPts, true);
@@ -488,11 +520,13 @@ public class TestObjRecCore extends ObjRecTestBase {
             // When converting to GeoJSON, results come back as 2 points (topLeft & bottomRight) as opposed
             // to 4 single numbers
             log.debug("Returned locations: {}", resloc);
-            assertEquals("Wrong number of locations in result", 2, resloc.size());
+            assertEquals("Wrong number of locations in result", 3, resloc.size());
             Map<String, ?> tlEnt = resloc.get("topLeft");
             assertNotNull("Missing topLeft", tlEnt);
             Map<String, ?> brEnt = resloc.get("bottomRight");
             assertNotNull("Missing bottomRight", brEnt);
+            Map<String, ?> centEnt = resloc.get("center");
+            assertNotNull("Missing center", centEnt);
 
             assertEquals("mapped topLeft type", "Point", tlEnt.get("type"));
             assertEquals("mapped bottomRight type", "Point", brEnt.get("type"));
@@ -503,11 +537,19 @@ public class TestObjRecCore extends ObjRecTestBase {
             Double[] brCoords = (Double[]) brEnt.get("coordinates");
             assertNotNull("No bottomRight coordinates", brCoords);
             assertEquals("Wrong number of bottomRight coordinates", 2, brCoords.length);
+            Double[] center = (Double[]) centEnt.get("coordinates");
+            assertNotNull("No center coordinates", centEnt);
+            assertEquals("Wrong number of center coordinates", 2, center.length);
 
             assertEquals("mapped topLeft longitude", inloc.get("top") * 2d, tlCoords[0], ACCEPTABLE_DELTA);
             assertEquals("mapped topLeft latitude", inloc.get("left") * 2d, tlCoords[1], ACCEPTABLE_DELTA);
             assertEquals("mapped bottomRight longitude", inloc.get("bottom") * 2d, brCoords[0], ACCEPTABLE_DELTA);
             assertEquals("mapped bottomRight latitude", inloc.get("right") * 2d, brCoords[1], ACCEPTABLE_DELTA);
+
+            assertEquals("mapped center longitude",
+                    inloc.get("centerY") * 2d, center[0], ACCEPTABLE_DELTA);
+            assertEquals("mapped center latitude",
+                    inloc.get("centerX") * 2d, center[1], ACCEPTABLE_DELTA);
         }
     }
 
@@ -545,6 +587,9 @@ public class TestObjRecCore extends ObjRecTestBase {
             aloc.put("left", pts[i][0]);
             aloc.put("bottom", pts[i+1][1]);
             aloc.put("right", pts[i+1][0]);
+            aloc.put("centerX", aloc.get("right").subtract(aloc.get("left")).divide(new BigDecimal(2.0), BigDecimal.ROUND_HALF_UP));
+            aloc.put("centerY", aloc.get("bottom").subtract(aloc.get("top")).divide(new BigDecimal(2.0), BigDecimal.ROUND_HALF_UP));
+
             res.add(aloc);
         }
         return res;
@@ -559,6 +604,8 @@ public class TestObjRecCore extends ObjRecTestBase {
         loc.put("left", 1d);
         loc.put("bottom", 3.0d);
         loc.put("right", 4.0d);
+        loc.put("centerY", ((double) loc.get("bottom") - (double) loc.get("top"))/2.0d);
+        loc.put("centerX", ((double) loc.get("right") - (double) loc.get("left"))/2.0d);
         aBox.put("location", loc);
         testinp.add(aBox);
         aBox = new HashMap<>();
@@ -573,6 +620,9 @@ public class TestObjRecCore extends ObjRecTestBase {
             loc.put("left", ((Number) aloc.get("left")).doubleValue());;
             loc.put("bottom", ((Number) aloc.get("bottom")).doubleValue());
             loc.put("right", ((Number) aloc.get("right")).doubleValue());
+            loc.put("centerY", ((double) loc.get("bottom") - (double) loc.get("top"))/2.0d);
+            loc.put("centerX", ((double) loc.get("right") - (double) loc.get("left"))/2.0d);
+
             aBox.put("location", loc);
             aBox.put("label", "another thingamajig# " + i++);
             testinp.add(aBox);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -9,6 +9,7 @@
 
 package io.vantiq.extsrc.objectRecognition.neuralNet;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -1748,16 +1749,17 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
         // If suppressNullValues is set to true, we shouldn't have any results stored in our type
         if (suppressNullValues) {
-            assert responseBody.size() == 0;
-
-        // Otherwise, we should have some results and they should be empty arrays
+            assertEquals("Get responseBody content when none expected: " + responseBody, 
+                    0, responseBody.size());
         } else {
+            // Otherwise, we should have some results and they should be empty arrays
             assert responseBody.size() > 0;
 
             for (int i = 0; i < responseBody.size(); i++) {
                 JsonObject resultObject = (JsonObject) responseBody.get(i);
                 assert resultObject.get("results") instanceof JsonArray;
-                assert ((JsonArray) resultObject.get("results")).size() == 0;
+                assertEquals("Get resultObject.results content when none expected: " + responseBody,
+                        0, ((JsonArray) resultObject.get("results")).size());
             }
         }
 
@@ -1807,40 +1809,54 @@ public class TestYoloProcessor extends NeuralNetTestBase {
     // ================================================= Helper functions =================================================
 
     String imageResultsAsString = "[" +
-            "{\"confidence\":0.8445639, " +
-                 "\"location\":{\"top\":255.70024, \"left\":121.859344, \"bottom\":372.2343, \"right\":350.1204}, \"label\":\"keyboard\"}," +
-            "{\"confidence\":0.7974271," +
-                "\"location\":{\"top\":91.255974, \"left\":164.41359, \"bottom\":275.69666, \"right\":350.50714}, \"label\":\"tvmonitor\"}," +
-            "{\"confidence\":0.6308692, " +
-                "\"location\":{\"top\":13.766539, \"left\":-0.614191, \"bottom\":367.22836, \"right\":122.28085}, \"label\":\"refrigerator\"}, " +
+            "{\"confidence\": 0.8445639, " +
+                 "\"location\": {\"top\": 255.70024, \"left\": 121.859344, \"bottom\": 372.2343, \"right\": 350.1204, " +
+                        "\"centerX\": 235.98985, \"centerY\": 313.9673 }, \"label\": \"keyboard\"}," +
+            "{\"confidence\": 0.7974271," +
+                "\"location\":{\"top\": 91.255974, \"left\": 164.41359, \"bottom\": 275.69666, \"right\": 350.50714," +
+                        "\"centerX\": 257.46036, \"centerY\": 183.47632 }, \"label\": \"tvmonitor\"}," +
+            "{\"confidence\": 0.6308692, " +
+                "\"location\":{\"top\": 13.766539, \"left\": -0.614191, \"bottom\": 367.22836, \"right\": 122.28085," +
+                        "\"centerX\": 60.83333, \"centerY\": 190.49745 }, \"label\": \"refrigerator\"}, " +
             "{\"confidence\":0.53600997," +
-                "\"location\":{\"top\":309.05722, \"left\":422.40067, \"bottom\":361.50223, \"right\":485.40735}, \"label\":\"mouse\"}" +
+                "\"location\":{\"top\": 309.05722, \"left\": 422.40067, \"bottom\": 361.50223, \"right\": 485.40735," +
+                        "\"centerX\": 453.90402, \"centerY\": 335.2797 }, \"label\": \"mouse\"}" +
     "]";
 
     // In this class, some tests are dependent upon whether there's a VANTIQ server defined.  When those tests run,
     // they alter the conditions of other tests.  To make running the tests a bit more friendly, we'll try
     // and be aware of these conditions and set our expectations accordingly.
 
+   
     String imageResultsAsStringWithoutServer = "[{\"confidence\":0.8445639, "
-               + "\"location\":{\"top\":169.16179, \"left\":6.4747205, \"bottom\":285.69586, \"right\":234.73576}, \"label\":\"keyboard\"},"
-            + "{\"confidence\":0.7974271, "
-                + "\"location\":{\"top\":33.56367, \"left\":241.33667, \"bottom\":218.00436, \"right\":427.43024}, \"label\":\"tvmonitor\"},"
-            + "{\"confidence\":0.6955277, "
-                + "\"location\":{\"top\":149.68317, \"left\":507.42972, \"bottom\":256.89297, \"right\":739.0765}, \"label\":\"keyboard\"},"
-            + "{\"confidence\":0.53600997, "
-               + "\"location\":{\"top\":222.51874, \"left\":76.24681, \"bottom\":274.96375, \"right\":139.2535}, \"label\":\"mouse\"}" +
+               + "\"location\": {\"top\": 169.16177, \"left\": 6.4747243, \"bottom\": 285.69586, \"right\": 234.73576," +
+                    "\"centerX\": 120.60525, \"centerY\": 227.42882 }, \"label\":\"keyboard\"},"
+            + "{\"confidence\": 0.7974271, "
+                + "\"location\": {\"top\": 33.56367, \"left\": 241.33667, \"bottom\": 218.00436, \"right\": 427.43024," +
+                    "\"centerX\": 334.38342, \"centerY\": 125.78402 }, \"label\": \"tvmonitor\"},"
+            + "{\"confidence\": 0.6955277, "
+                + "\"location\": {\"top\": 149.68317, \"left\": 507.42972, \"bottom\": 256.89297, \"right\": 739.0765," +
+                     "\"centerX\": 623.2531, \"centerY\": 203.28807 }, \"label\": \"keyboard\"},"
+            + "{\"confidence\": 0.53600997, "
+               + "\"location\": {\"top\": 222.51874, \"left\": 76.24681, \"bottom\": 274.96375, \"right\": 139.2535," +
+                    "\"centerX\": 107.75015, \"centerY\": 248.74124 }, \"label\": \"mouse\"}" +
     "]";
 
     
     String imageResultsAsString608 = "[{\"confidence\":0.8672237, "
-            + "\"location\":{\"top\":93.55155, \"left\":157.38762, \"bottom\":280.36542, \"right\":345.06442}, \"label\":\"tvmonitor\"},"
-        + "{\"confidence\":0.7927524, \"location\":{\"top\":263.62683, \"left\":123.48807, \"bottom\":371.69046, \"right\":331.86023}, \"label\":\"keyboard\"}, "
-        + "{\"confidence\":0.57419246, \"location\":{\"top\":146.11186, \"left\":319.9637, \"bottom\":317.0444, \"right\":423.20792}, \"label\":\"cup\"}" +
+            + "\"location\": {\"top\": 93.55155, \"left\": 157.38762, \"bottom\": 280.36542, \"right\": 345.06442, " +
+                 "\"centerX\": 251.22603, \"centerY\": 186.95847 }, \"label\": \"tvmonitor\"},"
+        + "{\"confidence\" :0.7927524, \"location\": {\"top\": 263.62683, \"left\": 123.48807, \"bottom\": 371.69046," +
+            "\"right\": 331.86023, \"centerX\": 227.67413, \"centerY\": 317.65866 }, \"label\": \"keyboard\"}, "
+        + "{\"confidence\": 0.57419246, \"location\": {\"top\": 146.11186, \"left\": 319.9637, \"bottom\": 317.0444," +
+            "\"right\": 423.20792, \"centerX\": 371.58582, \"centerY\": 231.57812 }, \"label\": \"cup\"}" +
     "]";
     
-    String croppedImageResultsAsString = "[{\"confidence\":0.91599655, \"location\":{\"top\":8.16388, \"left\":1.0525968, \"bottom\":118.984344, " 
-            +"\"right\":217.2165}, \"label\":\"keyboard\"}," +
-            "{\"confidence\":0.57027775, \"location\":{\"top\":2.1221037, \"left\":205.86801, \"bottom\":64.227806, \"right\":230.19707}, \"label\":\"cup\"}" +
+    String croppedImageResultsAsString = "[{\"confidence\": 0.91599655, \"location\": " +
+            "{\"top\": 8.16388, \"left\": 1.0525968, \"bottom\": 118.984344, " +
+                "\"right\": 217.2165, \"centerX\": 109.134544, \"centerY\": 63.574112 }, \"label\": \"keyboard\"}," +
+            "{\"confidence\": 0.57027775, \"location\": {\"top\": 2.1221037, \"left\": 205.86801, \"bottom\": 64.227806, " +
+                "\"right\": 230.19707, \"centerX\": 218.03256, \"centerY\": 33.174957 }, \"label\": \"cup\"}" +
        "]";
     
     String neuralNetJSON1 =


### PR DESCRIPTION
Fixes #205

As objects in an image are identified, we provide a _bounding box_ that surrounds the object in question.  In the next VANTIQ release, the new features make use of the center point.  The YOLO models already identify the center of the box.

This PR adds the center point (properties `centerX` & `centerY`) to the location information for any identified object.  We also update the location mapping functionality to convert the these center coordinates as well (and/or, adding a `center` GeoJSON Point where appropriate).  

Updated tests to include expected values for center points & verify their presence.  Updated README documentation as appropriate.

**NOTE**: This update is backwards compatible with the current OR source in that all existing properties are reported and maintain their semantics. We add the center properties (either `centerX` & `centerY` or the GeoJSON Point `center`) to the existing location.