### PR TITLE
Upgrade Eclipse Milo to current version.

### DIFF
--- a/opcuaSource/build.gradle
+++ b/opcuaSource/build.gradle
@@ -20,7 +20,7 @@ sourceCompatibility = 1.8
 
 ext {
     jacksonVersion = '2.9.3'
-    eclipseMiloVersion = '0.3.3'
+    eclipseMiloVersion = '0.4.1'
     lombokVersion = '1.16.18'
     logbackVersion = '1.2.3'
     junitVersion = '4.12'

--- a/opcuaSource/build.gradle
+++ b/opcuaSource/build.gradle
@@ -20,7 +20,7 @@ sourceCompatibility = 1.8
 
 ext {
     jacksonVersion = '2.9.3'
-    eclipseMiloVersion = '0.4.1'
+    eclipseMiloVersion = '0.4.2'
     lombokVersion = '1.16.18'
     logbackVersion = '1.2.3'
     junitVersion = '4.12'

--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Utils.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Utils.java
@@ -53,7 +53,7 @@ public class Utils {
             // OPC_PUBLIC_SERVER_4,  // not responding
             // OPC_PUBLIC_SERVER_5,  // returns that the service is unsupported.
             // OPC_PUBLIC_SERVER_6,  // unknown host
-            OPC_PUBLIC_SERVER_7,
+            OPC_PUBLIC_SERVER_7,     // Flaky support -- sometimes times out after discovery, sometimes before
             OPC_PUBLIC_SERVER_8
             // OPC_PUBLIC_SERVER_9    // #9 is offline
             );

--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Utils.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Utils.java
@@ -58,7 +58,7 @@ public class Utils {
             // OPC_PUBLIC_SERVER_9    // #9 is offline
             );
 
-    public static String OPC_INPROCESS_SERVER = "opc.tcp://localhost:12686/milo"; //"opc.tcp://localhost:12686/example";
+    public static String OPC_INPROCESS_SERVER = "opc.tcp://localhost:12686/milo";
     public static String OPC_PUBLIC_SERVER_NO_GOOD = "opc.tcp://opcuaserver.com:4840";
 
     public static String EXAMPLE_NS_SCALAR_INT32_IDENTIFIER = "HelloWorld/ScalarTypes/Int32";


### PR DESCRIPTION
Fixes #186 

Upgrade Eclipse Milo (the OPCUA SDK) to a more recent version.  Purportedly more stable, etc.

Some minor comment cleanup & addition to indicate flaky servers.