### PR TITLE
Add SDK support for getting base configuration information

### DIFF
--- a/CSVSource/README.md
+++ b/CSVSource/README.md
@@ -36,7 +36,7 @@ The documentation has been split into two parts, [Setting Up Your Machine](#mach
 4.  Navigate to `<repo location>/vantiq-extension-sources/CSVSource/build/distributions`. The zip and tar files both contain 
     the same files, so choose whichever you prefer.
 5.  Uncompress the file in the location that you would like to install the program.
-6.  Run `<install location>/CSVSource/bin/CSVSource` with a local server.config file or specifying the [server config file](#serverConfig) as the first argument.
+6.  Run `<install location>/CSVSource/bin/CSVSource` with a local server.config file or specifying the [server config file](#serverConfig) as the first argument. Note that the `server.config` file can be placed in the `<install location>/CSVSource/serverConfig/server.config` or `<install location>/CSVSource/server.config` locations.
 
 ## Logging
 To change the logging settings, edit the logging config file `<install location>/CSVSource/src/main/resources/log4j2.xml`,

--- a/CSVSource/src/main/java/io/vantiq/extsrc/CSVSource/CSVMain.java
+++ b/CSVSource/src/main/java/io/vantiq/extsrc/CSVSource/CSVMain.java
@@ -8,6 +8,7 @@
 
 package io.vantiq.extsrc.CSVSource;
 
+import io.vantiq.extjsdk.Utils;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -51,9 +52,9 @@ public class CSVMain {
     public static void main(String[] args) {
         Properties config;
         if (args != null && args.length > 0) {
-            config = obtainServerConfig(args[0]);
+            config = Utils.obtainServerConfig(args[0]);
         } else {
-            config = obtainServerConfig("server.config");
+            config = Utils.obtainServerConfig();
         }
         
         sources = createSources(config);
@@ -72,29 +73,6 @@ public class CSVMain {
             // Starting in threads so they can all connect at once
             new Thread( () -> {source.start(10);} ).start();;
         }
-    }
-
-    /**
-     * Turn the given configuration file into a {@link Map}. 
-     * 
-     * @param fileName  The name of the configuration file holding the server configuration.
-     * @return          The properties specified in the file.
-     */
-    static Properties obtainServerConfig(String fileName) {
-        File configFile = new File(fileName);
-        Properties properties = new Properties();
-        
-        try {
-            properties.load(new FileReader(fileName));
-        } catch (IOException e) {
-            throw new RuntimeException("Could not find valid server configuration file. Expected location: '" 
-                    + configFile.getAbsolutePath() + "'", e);
-        } catch (Exception e) {
-            throw new RuntimeException("Error occurred when trying to read the server configuration file. "
-                    + "Please ensure it is formatted properly.", e);
-        }
-
-        return properties;
     }
     
     /**

--- a/EasyModbusSource/README.md
+++ b/EasyModbusSource/README.md
@@ -43,7 +43,7 @@ Note: To use gradle builds in your IDE, you will need to define this variable ap
 3.  Navigate to `<repo location>/vantiq-extension-sources/easyModbusSource/build/distributions`. The zip and tar files both contain 
     the same files, so choose whichever you prefer.
 4.  Uncompress the file in the location that you would like to install the program.
-5.  Run `<install location>/easyModbusSource/bin/easyModbusSource` with a local server.config file or specifying the [server config file](#serverConfig) as the first argument.
+5.  Run `<install location>/easyModbusSource/bin/easyModbusSource` with a local server.config file or specifying the [server config file](#serverConfig) as the first argument. Note that the `server.config` file can be placed in the `<install location>/easyModbusSource/serverConfig/server.config` or `<install location>/easyModbusSource/server.config` locations.
 
 ## Logging
 To change the logging settings, edit the logging config file `<install location>/easyModbusSource/src/main/resources/log4j2.xml`,

--- a/EasyModbusSource/src/main/java/io/vantiq/extsrc/EasyModbusSource/EasyModbusMain.java
+++ b/EasyModbusSource/src/main/java/io/vantiq/extsrc/EasyModbusSource/EasyModbusMain.java
@@ -8,6 +8,7 @@
 
 package io.vantiq.extsrc.EasyModbusSource;
 
+import io.vantiq.extjsdk.Utils;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -55,9 +56,9 @@ public class EasyModbusMain {
     public static void main(String[] args) {
         Properties config;
         if (args != null && args.length > 0) {
-            config = obtainServerConfig(args[0]);
+            config = Utils.obtainServerConfig(args[0]);
         } else {
-            config = obtainServerConfig("server.config");
+            config = Utils.obtainServerConfig("server.config");
         }
 
         sources = createSources(config);
@@ -81,30 +82,6 @@ public class EasyModbusMain {
                 source.start(10);
             }).start();
         }
-    }
-
-    /**
-     * Turn the given configuration file into a {@link Map}.
-     * 
-     * @param fileName The name of the configuration file holding the server
-     *                 configuration.
-     * @return The properties specified in the file.
-     */
-    static Properties obtainServerConfig(String fileName) {
-        File configFile = new File(fileName);
-        Properties properties = new Properties();
-
-        try {
-            properties.load(new FileReader(fileName));
-        } catch (IOException e) {
-            throw new RuntimeException("Could not find valid server configuration file. Expected location: '"
-                    + configFile.getAbsolutePath() + "'", e);
-        } catch (Exception e) {
-            throw new RuntimeException("Error occurred when trying to read the server configuration file. "
-                    + "Please ensure it is formatted properly.", e);
-        }
-
-        return properties;
     }
 
     /**

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
@@ -21,16 +21,14 @@ public class Utils {
      * @return          The properties specified in the file.
      */
     public static Properties obtainServerConfig(String fileName) {
-        File configFile = new File(fileName);
+        File configFile = new File(SERVER_CONFIG_DIR, fileName);
         Properties properties = new Properties();
 
         try {
-            if (configFile.exists()) {
-                properties.load(new FileReader(configFile));
-            } else {
-                configFile = new File(SERVER_CONFIG_DIR, fileName);
-                properties.load(new FileReader(configFile));
+            if (!configFile.exists()) {
+                configFile = new File(fileName);
             }
+            properties.load(new FileReader(configFile));
         } catch (IOException e) {
             throw new RuntimeException("Could not find valid server configuration file. Expected location: '"
                     + configFile.getAbsolutePath() + "'", e);

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
@@ -1,0 +1,44 @@
+package io.vantiq.extjsdk;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Properties;
+
+public class Utils {
+    
+    public static String SERVER_CONFIG_DIR = "serverConfig";
+    public static String SERVER_CONFIG_FILENAME = "server.config";
+
+    public static Properties obtainServerConfig() {
+        return obtainServerConfig(SERVER_CONFIG_FILENAME);
+    }
+    
+    /**
+     * Turn the given configuration file into a {@link Properties} object.
+     *
+     * @param fileName  The name of the configuration file holding the server configuration.
+     * @return          The properties specified in the file.
+     */
+    public static Properties obtainServerConfig(String fileName) {
+        File configFile = new File(fileName);
+        Properties properties = new Properties();
+
+        try {
+            if (configFile.exists()) {
+                properties.load(new FileReader(configFile));
+            } else {
+                configFile = new File(SERVER_CONFIG_DIR, fileName);
+                properties.load(new FileReader(configFile));
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Could not find valid server configuration file. Expected location: '"
+                    + configFile.getAbsolutePath() + "'", e);
+        } catch (Exception e) {
+            throw new RuntimeException("Error occurred when trying to read the server configuration file. "
+                    + "Please ensure it is formatted properly.", e);
+        }
+
+        return properties;
+    }
+}

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestUtils.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestUtils.java
@@ -1,0 +1,117 @@
+package io.vantiq.extjsdk;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+
+
+public class TestUtils  {
+
+    private static final String FAKE_URL = "http://somewhere/else";
+    private static final String FAKE_TOKEN = "xxxx====";
+    private static final String FAKE_SOURCE = "someSource";
+    public static final String TARGET_SERVER_PROP = "targetServer";
+    public static final String AUTH_TOKEN_PROP = "authToken";
+    public static final String OTHER_PROP = "otherProperty";
+
+    @Test
+    public void testGetConfigAlone() throws Exception {
+        BufferedWriter bw = null;
+        File f = null;
+        try {
+            Path p = Files.createFile( Paths.get("server.config"));
+            f = new File(p.toString());
+            f.deleteOnExit();
+            
+            bw = fillProps(p);
+           
+            checkProps();
+        } finally {
+            if (bw != null) {
+                bw.close();
+            }
+            if (f != null) {
+                //noinspection ResultOfMethodCallIgnored
+                f.delete();
+            }
+        }
+    }
+
+    @Test
+    public void testGetConfigInDir() throws Exception {
+        BufferedWriter bw = null;
+        File f = null;
+        File dir = null;
+        try {
+            dir = new File("serverConfig");
+            //noinspection ResultOfMethodCallIgnored
+            dir.mkdir();
+            dir.deleteOnExit();
+            Path p = Files.createFile(Paths.get("serverConfig/server.config"));
+            f = new File(p.toString());
+            f.deleteOnExit();
+            bw = fillProps(p);
+            
+            checkProps();
+        } finally {
+            if (bw != null) {
+                bw.close();
+            }
+            if (f != null) {
+                //noinspection ResultOfMethodCallIgnored
+                f.delete();
+            }
+            if (dir != null) {
+                //noinspection ResultOfMethodCallIgnored
+                dir.delete();
+            }
+        }
+    }
+    
+    private BufferedWriter fillProps(Path p) throws IOException {
+        BufferedWriter bw = Files.newBufferedWriter(p);
+        bw.append(TARGET_SERVER_PROP + " = " + FAKE_URL + "\n");
+        bw.append(AUTH_TOKEN_PROP + " = " + FAKE_TOKEN + "\n");
+        bw.append(OTHER_PROP + " = " + FAKE_SOURCE + "\n");
+        bw.close();
+        return bw;
+    }
+    
+    private void checkProps() {
+        Properties props = Utils.obtainServerConfig();
+        assert props.getProperty(TARGET_SERVER_PROP) != null;
+        assert props.getProperty(TARGET_SERVER_PROP).contains(FAKE_URL);
+        assert props.getProperty(AUTH_TOKEN_PROP) != null;
+        assert props.getProperty(AUTH_TOKEN_PROP).contains(FAKE_TOKEN);
+        assert props.getProperty(OTHER_PROP) != null;
+        assert props.getProperty(OTHER_PROP).contains(FAKE_SOURCE);
+    }
+    
+    @Before
+    public void cleanupFiles() {
+        Path p = Paths.get("server.config");
+        File f = new File(p.toString());
+        if (f.exists()) {
+            //noinspection ResultOfMethodCallIgnored
+            f.delete();
+        }
+
+        File dir = new File("serverConfig");
+        f = new File("serverConfig/server.config");
+        if (f.exists()) {
+            //noinspection ResultOfMethodCallIgnored
+            f.delete();
+        }
+        if (dir.exists()) {
+            //noinspection ResultOfMethodCallIgnored
+            f.delete();
+        }
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Dec 09 14:41:33 PST 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/jdbcSource/README.md
+++ b/jdbcSource/README.md
@@ -47,7 +47,7 @@ Additionally, an example project named *jdbcExample.zip* can be found in the *sr
 4.  Navigate to `<repo location>/vantiq-extension-sources/jdbcSource/build/distributions`. The zip and tar files both contain 
     the same files, so choose whichever you prefer.
 5.  Uncompress the file in the location that you would like to install the program.
-6.  Run `<install location>/jdbcSource/bin/jdbcSource` with a local server.config file or specifying the [server config file](#serverConfig) as the first argument.
+6.  Run `<install location>/jdbcSource/bin/jdbcSource` with a local server.config file or specifying the [server config file](#serverConfig) as the first argument. Note that the `server.config` file can be placed in the `<install location>/jdbcSource/serverConfig/server.config` or `<install location>/jdbcSource/server.config` locations.
 
 ## Logging
 To change the logging settings, edit the logging config file `<install location>/jdbcSource/src/main/resources/log4j2.xml`,

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCMain.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCMain.java
@@ -8,6 +8,7 @@
 
 package io.vantiq.extsrc.jdbcSource;
 
+import io.vantiq.extjsdk.Utils;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -45,8 +46,6 @@ public class JDBCMain {
     static final int NO_SOURCE_EXIT = 2;
     static final int NO_SERVER_EXIT = 3;
     
-    
-    
     /**
      * Connects to the Vantiq source and starts polling for data. Exits when all sources are done running.
      * @param args  Should be either null or the first argument as a config file
@@ -54,9 +53,9 @@ public class JDBCMain {
     public static void main(String[] args) {
         Properties config;
         if (args != null && args.length > 0) {
-            config = obtainServerConfig(args[0]);
+            config = Utils.obtainServerConfig(args[0]);
         } else {
-            config = obtainServerConfig("server.config");
+            config = Utils.obtainServerConfig("server.config");
         }
         
         sources = createSources(config);
@@ -75,29 +74,6 @@ public class JDBCMain {
             // Starting in threads so they can all connect at once
             new Thread( () -> {source.start(10);} ).start();;
         }
-    }
-
-    /**
-     * Turn the given configuration file into a {@link Map}. 
-     * 
-     * @param fileName  The name of the configuration file holding the server configuration.
-     * @return          The properties specified in the file.
-     */
-    static Properties obtainServerConfig(String fileName) {
-        File configFile = new File(fileName);
-        Properties properties = new Properties();
-        
-        try {
-            properties.load(new FileReader(fileName));
-        } catch (IOException e) {
-            throw new RuntimeException("Could not find valid server configuration file. Expected location: '" 
-                    + configFile.getAbsolutePath() + "'", e);
-        } catch (Exception e) {
-            throw new RuntimeException("Error occurred when trying to read the server configuration file. "
-                    + "Please ensure it is formatted properly.", e);
-        }
-
-        return properties;
     }
     
     /**

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
+import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -776,7 +777,7 @@ public class TestJDBC extends TestJDBCBase {
         // Select from the type and make sure all of our results are there as expected
         response = vantiq.select(testTypeName, null, null, null);
         ArrayList responseBody = (ArrayList) response.getBody();
-        assert responseBody.size() == 500;
+        assertEquals (500, responseBody.size());
 
         // Delete the table for next test
         Map<String,Object> delete_params = new LinkedHashMap<String,Object>();

--- a/jmsSource/README.md
+++ b/jmsSource/README.md
@@ -48,7 +48,7 @@ and Topics.
 4.  Navigate to `<repo location>/vantiq-extension-sources/jmsSource/build/distributions`. The zip and tar files both contain 
     the same files, so choose whichever you prefer.
 5.  Uncompress the file in the location that you would like to install the program.
-6.  Run `<install location>/jmsSource/bin/jmsSource` with a local server.config file or specifying the [server config file](#serverConfig) as the first argument.
+6.  Run `<install location>/jmsSource/bin/jmsSource` with a local server.config file or specifying the [server config file](#serverConfig) as the first argument. Note that the `server.config` file can be placed in the `<install location>/jmsSource/serverConfig/server.config` or `<install location>/jmsSource/server.config` locations.
 
 ## Logging
 To change the logging settings, edit the logging config file `<install_location>/jmsSource/src/main/resources/log4j2.xml`,

--- a/jmsSource/src/main/java/io/vantiq/extsrc/jmsSource/JMSMain.java
+++ b/jmsSource/src/main/java/io/vantiq/extsrc/jmsSource/JMSMain.java
@@ -8,6 +8,7 @@
 
 package io.vantiq.extsrc.jmsSource;
 
+import io.vantiq.extjsdk.Utils;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -53,9 +54,9 @@ public class JMSMain {
     public static void main(String[] args) {
         Properties config = null;
         if (args == null || args.length < 1) {
-            config = obtainServerConfig("server.config");
+            config = Utils.obtainServerConfig();
         } else if (args != null && args.length == 1) {
-            config = obtainServerConfig(args[0]);
+            config = Utils.obtainServerConfig(args[0]);
         } else {
             log.error("Wrong number of arguments\n" + "Usage: <yourProgramInvocation> [localConfigFile]");
             exit(NO_CONFIG_EXIT);
@@ -77,29 +78,6 @@ public class JMSMain {
             // Starting in threads so they can all connect at once
             new Thread( () -> {source.start(10);} ).start();;
         }
-    }
-
-    /**
-     * Turn the given configuration file into a {@link Map}.
-     *
-     * @param fileName  The name of the configuration file holding the server configuration.
-     * @return          The properties specified in the file.
-     */
-    static Properties obtainServerConfig(String fileName) {
-        File configFile = new File(fileName);
-        Properties properties = new Properties();
-
-        try {
-            properties.load(new FileReader(fileName));
-        } catch (IOException e) {
-            throw new RuntimeException("Could not find valid server configuration file. Expected location: '"
-                    + configFile.getAbsolutePath() + "'", e);
-        } catch (Exception e) {
-            throw new RuntimeException("Error occurred when trying to read the server configuration file. "
-                    + "Please ensure it is formatted properly.", e);
-        }
-
-        return properties;
     }
 
     /**

--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -66,7 +66,7 @@ folder. Some features may depend on additional .dll/.so/.dylib files, such as FF
     files both contain the same files, so choose whichever you prefer.
 5.  Uncompress the file in the location that you would like to install the program.
 6.  Run `<install location>/objectRecognitionSource/bin/objectRecognitionSource` with a local server.config file or
-    specifying the [server config file](#serverConfig) as the first argument.
+specifying the [server config file](#serverConfig) as the first argument. Note that the `server.config` file can be placed in the `<install location>/objectRecognitionSource/serverConfig/server.config` or `<install location>/objectRecognitionSource/server.config` locations.
 
 ## Logging
 To change the logging settings, edit `<install location>/objectRecognitionSource/logConfig/log4j2.xml`. Here is

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionMain.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionMain.java
@@ -9,6 +9,7 @@
 
 package io.vantiq.extsrc.objectRecognition;
 
+import io.vantiq.extjsdk.Utils;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -50,9 +51,9 @@ public class ObjectRecognitionMain {
     public static void main(String[] args) {
         Properties config;
         if (args != null && args.length > 0) {
-            config = obtainServerConfig(args[0]);
+            config = Utils.obtainServerConfig(args[0]);
         } else {
-            config = obtainServerConfig("server.config");
+            config = Utils.obtainServerConfig("server.config");
         }
         
         sources = createSources(config);
@@ -71,29 +72,6 @@ public class ObjectRecognitionMain {
             // Starting in threads so they can all connect at once
             new Thread( () -> {source.start(10);} ).start();;
         }
-    }
-
-    /**
-     * Turn the given configuration file into a {@link Map}. 
-     * 
-     * @param fileName  The name of the configuration file holding the server configuration.
-     * @return          The properties specified in the file.
-     */
-    static Properties obtainServerConfig(String fileName) {
-        File configFile = new File(fileName);
-        Properties properties = new Properties();
-        
-        try {
-            properties.load(new FileReader(fileName));
-        } catch (IOException e) {
-            throw new RuntimeException("Could not find valid server configuration file. Expected location: '" 
-                    + configFile.getAbsolutePath() + "'", e);
-        } catch (Exception e) {
-            throw new RuntimeException("Error occurred when trying to read the server configuration file. "
-                    + "Please ensure it is formatted properly.", e);
-        }
-
-        return properties;
     }
     
     /**

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestFileRetriever.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestFileRetriever.java
@@ -9,6 +9,7 @@
 
 package io.vantiq.extsrc.objectRecognition.imageRetriever;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
@@ -64,7 +65,7 @@ public class TestFileRetriever extends ObjRecTestBase {
             results = fr.getImage();
             byte[] data = results.getImage();
             assert data != null;
-            assert data.length == 64585;
+            assert data.length >= 64000 && data.length < 66000;
         } catch (ImageAcquisitionException e) {
             fail("Exception occurred when obtaining image " + e.toString());
         }
@@ -84,7 +85,7 @@ public class TestFileRetriever extends ObjRecTestBase {
             results = fr.getImage();
             byte[] data = results.getImage();
             assert data != null;
-            assert data.length == 123383;
+            assert data.length >= 120000 && data.length <= 130000;
         } catch (ImageAcquisitionException e) {
             fail("Exception occurred when obtaining image " + e.toString());
         }
@@ -135,7 +136,7 @@ public class TestFileRetriever extends ObjRecTestBase {
                 results = fr.getImage();
                 byte[] data = results.getImage();
                 assert data != null;
-                assert data.length == 64585;
+                assert data.length >= 64000 && data.length < 66000;
             } catch (ImageAcquisitionException e) {
                 fail("Exception occurred when obtaining image after creating it " + e.toString());
             }
@@ -160,7 +161,7 @@ public class TestFileRetriever extends ObjRecTestBase {
             results = fr.getImage(message);
             byte[] data = results.getImage();
             assert data != null;
-            assert data.length == 64585;
+            assert data.length >= 64000 && data.length < 66000;
         } catch (ImageAcquisitionException e) {
             fail("Exception occurred when obtaining image " + e.toString());
         }
@@ -201,7 +202,7 @@ public class TestFileRetriever extends ObjRecTestBase {
             results = fr.getImage(message);
             byte[] data = results.getImage();
             assert data != null;
-            assert data.length == 64585;
+            assert data.length >= 64000 && data.length < 66000;
         } catch (ImageAcquisitionException e) {
             fail("Exception occurred when obtaining image: " + e.toString());
         }
@@ -222,7 +223,7 @@ public class TestFileRetriever extends ObjRecTestBase {
             results = fr.getImage();
             byte[] data = results.getImage();
             assert data != null;
-            assert data.length == 652762;
+            assert data.length >= 640000 && data.length <= 660000;
         } catch (ImageAcquisitionException e) {
             fail("Exception occurred when obtaining image: " + e.toString());
         }
@@ -259,7 +260,7 @@ public class TestFileRetriever extends ObjRecTestBase {
             results = fr.getImage(request);
             byte[] data = results.getImage();
             assert data != null;
-            assert data.length == 632148;
+            assert data.length >= 620000 && data.length <= 650000;
         } catch (ImageAcquisitionException e) {
             fail("Exception occurred when requesting frame 4 of video: " + e.toString());
         }

--- a/opcuaSource/README.md
+++ b/opcuaSource/README.md
@@ -256,14 +256,14 @@ where
 
 Alternatively,
 the connection information be provided in a *properties* file.
-Specifically, within the *storage directory*,
-create a file named `sourceconfig.properties`.
+Specifically, create a file named `server.config`.
+Note that the `server.config` file can be placed in the `<install location>/opcuaSource/serverConfig/server.config` or `<install location>/opcuaSource/server.config` locations.
 The information required is placed in that file as follows:
 
 ```
-vantiqUrl = ...
-token = ...
-sourceName = ...
+targetServer = ...
+authToken = ...
+source = ...
 ```
 
 Again, alternatively, but not recommended, you can provide `username` and `password` as
@@ -276,9 +276,9 @@ password = somePassword
 An example file might be
 
 ```
-vantiqUrl = https://dev.vantiq.com
-token = _cDWBfZLNO9FkXd-twjwKnVIBZSGwns35nF4nQFV_ps=
-sourceName = opcuaExample
+targetServer = https://dev.vantiq.com
+authToken = _cDWBfZLNO9FkXd-twjwKnVIBZSGwns35nF4nQFV_ps=
+source = opcuaExample
 ```
 
 > Note that this token will not work -- you will need to create your own

--- a/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/opcUaSource/OpcUaServer.java
+++ b/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/opcUaSource/OpcUaServer.java
@@ -111,6 +111,7 @@ public class OpcUaServer {
         String configFileName = locDir.getAbsolutePath() + File.separator + LOCAL_CONFIG_FILE_NAME;
         InputStream cfr = null;
         Properties props = null;
+        
         try {
             File configFile = new File(configFileName);
 
@@ -123,11 +124,27 @@ public class OpcUaServer {
                 props = Utils.obtainServerConfig();
             }
             
-            String url = props.getProperty(OpcConstants.VANTIQ_URL);
+            // In the effort to commonize the fetching of startup props,
+            // we try the common versions first.  When that fails, we walk
+            // back through old versions to maintain backward compatibility support.
+            
+            String url = props.getProperty(OpcConstants.TARGET_SERVER);
+            if (url == null) {
+                url = props.getProperty(OpcConstants.VANTIQ_URL);
+            }
             String username = props.getProperty(OpcConstants.VANTIQ_USERNAME);
             String password = props.getProperty(OpcConstants.VANTIQ_PASSWORD);
-            String token = props.getProperty(OpcConstants.VANTIQ_TOKEN);
-            String sourceName = props.getProperty(OpcConstants.VANTIQ_SOURCENAME);
+            String token = props.getProperty(OpcConstants.VANTIQ_AUTHTOKEN);
+            if (token == null) {
+                token = props.getProperty(OpcConstants.VANTIQ_TOKEN);
+            }
+            String sourceName = props.getProperty(OpcConstants.VANTIQ_SOURCE);
+            if (sourceName == null) {
+                sourceName = props.getProperty(OpcConstants.VANTIQ_SOURCES);
+                if (sourceName == null) {
+                    sourceName = props.getProperty(OpcConstants.VANTIQ_SOURCENAME);
+                }
+            }
 
             if (url != null) {
                 configMap.put(OpcConstants.VANTIQ_URL, url);

--- a/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/opcUaSource/OpcUaServer.java
+++ b/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/opcUaSource/OpcUaServer.java
@@ -35,7 +35,7 @@ public class OpcUaServer {
         Options options = new Options();
 
         Option input = new Option("d", "directory", true, "home directory for this source");
-        input.setRequired(true);
+        input.setRequired(false);
         options.addOption(input);
 
         Option urlOpt = new Option("v", "vantiq", true, "VANTIQ server URL");
@@ -71,6 +71,9 @@ public class OpcUaServer {
         }
 
         String homeDir = cmd.getOptionValue("directory");
+        if (homeDir == null) {
+            homeDir = "storage";
+        }
         String user = cmd.getOptionValue("username");
         String vantiqUrl = cmd.getOptionValue("vantiq");
         String pw = cmd.getOptionValue("password");

--- a/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/opcUaSource/OpcUaServer.java
+++ b/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/opcUaSource/OpcUaServer.java
@@ -8,6 +8,7 @@
 
 package io.vantiq.extsrc.opcua.opcUaSource;
 
+import io.vantiq.extjsdk.Utils;
 import io.vantiq.extsrc.opcua.uaOperations.OpcConstants;
 import io.vantiq.extsrc.opcua.uaOperations.OpcUaESClient;
 import org.apache.commons.cli.*;
@@ -25,6 +26,9 @@ import java.util.Properties;
 @Slf4j
 public class OpcUaServer {
 
+    // Note that this is deprecated in favor of using the extjsdk obtainServerConfig() methods
+    // to get things from a standard place.  We will continue support here for backward compatibility.
+    
     public static final String LOCAL_CONFIG_FILE_NAME = "sourceconfig.properties";
 
     public static void main(String[] argv) {
@@ -108,11 +112,17 @@ public class OpcUaServer {
         InputStream cfr = null;
         Properties props = null;
         try {
-            cfr = new FileInputStream(configFileName);
+            File configFile = new File(configFileName);
 
-            props = new Properties();
-            props.load(cfr);
+            if (configFile.exists()) {
+                cfr = new FileInputStream(configFileName);
 
+                props = new Properties();
+                props.load(cfr);
+            } else {
+                props = Utils.obtainServerConfig();
+            }
+            
             String url = props.getProperty(OpcConstants.VANTIQ_URL);
             String username = props.getProperty(OpcConstants.VANTIQ_USERNAME);
             String password = props.getProperty(OpcConstants.VANTIQ_PASSWORD);

--- a/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/uaOperations/OpcConstants.java
+++ b/opcuaSource/src/main/java/io/vantiq/extsrc/opcua/uaOperations/OpcConstants.java
@@ -33,9 +33,13 @@ public class OpcConstants {
     // Some config constants are used there for consistency.
 
     public static final String VANTIQ_URL = "vantiqUrl";
+    public static final String TARGET_SERVER = "targetServer";
     public static final String VANTIQ_USERNAME = "username";
     public static final String VANTIQ_PASSWORD = "password";
     public static final String VANTIQ_TOKEN = "token";
+    public static final String VANTIQ_AUTHTOKEN = "authToken";
+    public static final String VANTIQ_SOURCE = "source";
+    public static final String VANTIQ_SOURCES = "sources";
     public static final String VANTIQ_SOURCENAME = "sourceName";
     public static final String OPC_VALUE_IN_VANTIQ = "dataValue";
 

--- a/udpSource/README.md
+++ b/udpSource/README.md
@@ -16,8 +16,7 @@ Notification handlers.
 3.	Then navigate to `<repo location>/vantiq-extension-sources/udpSource/build/distributions`. The zip and tar files both
     contain the same files, so choose whichever you prefer.
 4. Uncompress the zip or tar in the location that you would like to install the program.
-5. Run `<install location>/udpSource/bin/udpSource` with a local config.json file or specifying the server config file
-    as the first argument.
+5. Run `<install location>/udpSource/bin/udpSource` with a local `server.config` file or specifying the server config file as the first argument.  Note that the `server.config` file can be placed in the `<install location>/udpSource/serverConfig/server.config` or `<install location>/udpSource/server.config` locations.
 
 ## Logging
 To change the logging settings, edit `<install location>/udpSource/logConfig/log4j2.xml`. Here is its
@@ -29,8 +28,8 @@ be included in future distributions produced through gradle.
 
 ## Server Config File<a name="serverConfig" id="serverConfig"></a>
 
-The server config file must be in JSON format. ConfigurableUDPSource runs using either the config file specified as the
-first argument or the file 'config.json' in the working directory.
+The server config file must be in properties file format. ConfigurableUDPSource runs using either the config file specified as the
+first argument or the file `server.config` in the `serverConfig` directory or in the working directory.
 
 ### Vantiq Options
 *	targetServer -- Optional. The Vantiq site that hosts the projects to which the sources will connect.

--- a/udpSource/src/main/java/io/vantiq/extsrc/udp/ConfigurableUDPSource.java
+++ b/udpSource/src/main/java/io/vantiq/extsrc/udp/ConfigurableUDPSource.java
@@ -602,17 +602,21 @@ public class ConfigurableUDPSource {
          * connect. For target, replace "ws" with "wss" to access the secure connection, and "localhost:8080" with
          * your Vantiq deployment's address, typically "dev.vantiq.com"
          */
-        if (!(config.get("sources") instanceof List)) {
+        List<String> sources;
+        if (config.get("sources") instanceof List) {
+            ((List<Object>) config.get("sources")).removeIf((obj) -> !(obj instanceof String));
+            sources = ((List<String>) config.get("sources"));
+        } else if (config.get("sources") instanceof String) {
+            sources = new ArrayList<>();
+            sources.add((String) config.get("sources"));
+        } else {
             throw new RuntimeException("No source names given in server config file.");
         }
-        ((List<Object>) config.get("sources")).removeIf((obj) -> !(obj instanceof String));
-        List<String> sources = ((List<String>) config.get("sources"));
         
         if (sources.isEmpty()) {
             throw new RuntimeException("No source names given.");
         }
-
-
+        
         /*
          * 1) Sets up the WebSocket connection through ExtensionWebSocketClient and sets up the UDP socket.
          *

--- a/udpSource/src/main/java/io/vantiq/extsrc/udp/ConfigurableUDPSource.java
+++ b/udpSource/src/main/java/io/vantiq/extsrc/udp/ConfigurableUDPSource.java
@@ -22,9 +22,11 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vantiq.extjsdk.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -472,11 +474,41 @@ public class ConfigurableUDPSource {
      * @return          A {@link Map} that holds the contents of the JSON file.
      */
     static Map<String, Object> obtainServerConfig(String fileName) {
+        Map <String, Object> config;
+        // First, try and fetch the properties from the "normal" place
+        try {
+            Properties props = Utils.obtainServerConfig();
+
+            // Properties is, eventually, a raw Map.  So we'll just convert the type...
+            //noinspection unchecked
+            config = (Map) props;
+            return config;
+        } catch (Exception e) {
+            // This probably means that this is an old-style file which is JSON.
+            // So we'll let the area below handle things.
+        }
+        
+        // If that fails, try with the named file, treating it as a properties file
+        
+        try {
+            Properties props = Utils.obtainServerConfig(fileName);
+
+            // Properties is, eventually, a raw Map.  So we'll just convert the type...
+            //noinspection unchecked
+            config = (Map) props;
+            return config;
+        } catch (Exception e) {
+            // This probably means that this is an old-style file which is JSON.
+            // So we'll let the area below handle things.
+        }
+        
+        // And if that fails, fall back the the json  file model...
+        
         File configFile = new File(fileName);
         log.debug("{}", configFile.getAbsolutePath());
-        Map<String, Object>  config = new LinkedHashMap();
         ObjectMapper mapper = new ObjectMapper();
         try {
+            //noinspection unchecked
             config = mapper.readValue(configFile, Map.class);
         } catch (IOException e) {
             throw new RuntimeException("Could not find valid server config file. Expected location: '" 
@@ -496,9 +528,8 @@ public class ConfigurableUDPSource {
      * @param config    The {@link Map} obtained from the config file
      */
     static void setupServer(Map config) {
-        MAX_UDP_DATA = config.get("maxPacketSize") instanceof Integer ? (int) config.get("maxPacketSize") : 1024;
-        LISTENING_PORT = config.get("defaultBindPort") instanceof Integer ? (int) config.get("defaultBindPort") :
-                3141;
+        MAX_UDP_DATA = fetchIntProp(config.get("maxPacketSize"), 1024);
+        LISTENING_PORT = fetchIntProp(config.get("defaultBindPort"), 3141);
         
         if (config.get("targetServer") instanceof String) {
             targetVantiqServer = (String) config.get("targetServer") ;
@@ -529,6 +560,22 @@ public class ConfigurableUDPSource {
             }
         }
     }
+    
+    private static int fetchIntProp(Object value, int defaultValue) throws RuntimeException {
+        if (value == null) {
+            return defaultValue;
+        } else if (value instanceof Integer) {
+            return (int) value;
+        } else if (value instanceof String) {
+            try {
+                return Integer.parseInt((String) value);
+            } catch (NumberFormatException nfe) {
+                throw new RuntimeException("Invalid integer value " + value, nfe);
+            }
+        } else {
+            throw new RuntimeException("Unexpected type " + value.getClass().getName() + " for value " + value);
+        }
+    }
 
     /**
      * The main function of the app. Here it: <br>
@@ -543,10 +590,10 @@ public class ConfigurableUDPSource {
      */
     public static void main(String[] args) {
         Map config;
+        
         if (args != null && args.length != 0) {
             config = obtainServerConfig(args[0]);
-        }
-        else {
+        } else {
             config = obtainServerConfig("config.json");
         }
         setupServer(config);


### PR DESCRIPTION
Fixes #214 

Add Util class to ExtJSdk to get config properties from $CWD/serverConfig/server.config.  Convert most, if not all, sources to use it.

Converted UPD source to pick up properties instead of JSON file.  Since it already converted the JSON file to a Map, I just took advantage of the fact that a Java Properties file IS a Map and used that.  Seems to work OK, at least in tests.

I may need to do more testing on these things. None of the connectors actually have tests that verify "real" configurations and none of them set up their source implementation types.  So it's a highly manual process right now.