### PR TITLE
Using gradle to build docker images

### DIFF
--- a/CSVSource/build.gradle
+++ b/CSVSource/build.gradle
@@ -78,31 +78,3 @@ tasks.withType(Test) {
         systemProperty 'EntFullFilePath', rootProject.findProperty('EntFullFilePath')?:"b.csv"
     }
 }
-
-// Using gradle-dcompose-plugin to build CSVSource docker image
-dcompose {
-    if (rootProject.hasProperty('dockerRegistry')) {
-        def registryName = rootProject.getProperty('dockerRegistry')
-        csvSource {
-            buildFiles = project.copySpec {
-                from "$projectDir/src/main/docker/"
-                from "$projectDir/build/distributions/CSVSource.tar"
-            }
-            if (rootProject.hasProperty('csvImageTag')) {
-                repository = registryName + '/csv-source' + rootProject.getProperty('csvImageTag')
-            } else {
-                repository = registryName + '/csv-source'
-            }
-            logBuildStatus = true
-            buildLogFile = file("$buildDir/csvDockerBuildLog.file")
-        }
-
-        // The credentials here should be stored in gradle.properties.
-        dockerClientConfig = {
-            withRegistryUsername dockerRegistryUser
-            withRegistryPassword dockerRegistryPassword
-        }
-    }
-}
-
-buildCsvSourceImage.dependsOn assemble

--- a/CSVSource/build.gradle
+++ b/CSVSource/build.gradle
@@ -78,3 +78,31 @@ tasks.withType(Test) {
         systemProperty 'EntFullFilePath', rootProject.findProperty('EntFullFilePath')?:"b.csv"
     }
 }
+
+// Using gradle-dcompose-plugin to build CSVSource docker image
+dcompose {
+    if (rootProject.hasProperty('dockerRegistry')) {
+        def registryName = rootProject.getProperty('dockerRegistry')
+        csvSource {
+            buildFiles = project.copySpec {
+                from "$projectDir/src/main/docker/"
+                from "$projectDir/build/distributions/CSVSource.tar"
+            }
+            if (rootProject.hasProperty('csvImageTag')) {
+                repository = registryName + '/csv-source' + rootProject.getProperty('csvImageTag')
+            } else {
+                repository = registryName + '/csv-source'
+            }
+            logBuildStatus = true
+            buildLogFile = file("$buildDir/csvDockerBuildLog.file")
+        }
+
+        // The credentials here should be stored in gradle.properties.
+        dockerClientConfig = {
+            withRegistryUsername dockerRegistryUser
+            withRegistryPassword dockerRegistryPassword
+        }
+    }
+}
+
+buildCsvSourceImage.dependsOn assemble

--- a/CSVSource/src/main/docker/Dockerfile
+++ b/CSVSource/src/main/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:11-jre-slim
+RUN mkdir /app
+ADD CSVSource.tar /app
+WORKDIR /app
+ENTRYPOINT ["./CSVSource/bin/CSVSource"]

--- a/EasyModbusSource/build.gradle
+++ b/EasyModbusSource/build.gradle
@@ -86,3 +86,31 @@ tasks.withType(Test) {
         systemProperty "EntBufferSize", rootProject.findProperty("EntBufferSize") ?: "20"
     }
 }
+
+// Using gradle-dcompose-plugin to build EasyModbusSource docker image
+dcompose {
+    if (rootProject.hasProperty('dockerRegistry')) {
+        def registryName = rootProject.getProperty('dockerRegistry')
+        easyModbusSource {
+            buildFiles = project.copySpec {
+                from "$projectDir/src/main/docker/"
+                from "$projectDir/build/distributions/EasyModbusSource.tar"
+            }
+            if (rootProject.hasProperty('easyModbusImageTag')) {
+                repository = registryName + '/easymodbus-source' + rootProject.getProperty('easyModbusImageTag')
+            } else {
+                repository = registryName + '/easymodbus-source'
+            }
+            logBuildStatus = true
+            buildLogFile = file("$buildDir/easyModbusDockerBuildLog.file")
+        }
+
+        // The credentials here should be stored in gradle.properties.
+        dockerClientConfig = {
+            withRegistryUsername dockerRegistryUser
+            withRegistryPassword dockerRegistryPassword
+        }
+    }
+}
+
+buildEasyModbusSourceImage.dependsOn assemble

--- a/EasyModbusSource/build.gradle
+++ b/EasyModbusSource/build.gradle
@@ -86,31 +86,3 @@ tasks.withType(Test) {
         systemProperty "EntBufferSize", rootProject.findProperty("EntBufferSize") ?: "20"
     }
 }
-
-// Using gradle-dcompose-plugin to build EasyModbusSource docker image
-dcompose {
-    if (rootProject.hasProperty('dockerRegistry')) {
-        def registryName = rootProject.getProperty('dockerRegistry')
-        easyModbusSource {
-            buildFiles = project.copySpec {
-                from "$projectDir/src/main/docker/"
-                from "$projectDir/build/distributions/EasyModbusSource.tar"
-            }
-            if (rootProject.hasProperty('easyModbusImageTag')) {
-                repository = registryName + '/easymodbus-source' + rootProject.getProperty('easyModbusImageTag')
-            } else {
-                repository = registryName + '/easymodbus-source'
-            }
-            logBuildStatus = true
-            buildLogFile = file("$buildDir/easyModbusDockerBuildLog.file")
-        }
-
-        // The credentials here should be stored in gradle.properties.
-        dockerClientConfig = {
-            withRegistryUsername dockerRegistryUser
-            withRegistryPassword dockerRegistryPassword
-        }
-    }
-}
-
-buildEasyModbusSourceImage.dependsOn assemble

--- a/EasyModbusSource/src/main/docker/Dockerfile
+++ b/EasyModbusSource/src/main/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:11-jre-slim
+RUN mkdir /app
+ADD EasyModbusSource.tar /app
+WORKDIR /app
+ENTRYPOINT ["./EasyModbusSource/bin/EasyModbusSource"]

--- a/README.md
+++ b/README.md
@@ -359,16 +359,17 @@ The connectors in this repository contain `gradle` tasks that can be used to bui
 push those images to the developer's Docker Registry. In order to use these tasks, the developer must include the 
 following configuration option in their `gradle.properties` file, along with some optional parameters:
 
-*   `dockerRegistry`: Required. The name of the registry to which the image should be pushed.
+*   `dockerRegistry`: Required. The name of the registry to which the image should be pushed (i.e. `docker.io`,
+`quay.io`, etc.).
+*   `pathToRepo`: Required. The path to the docker repository. This is typically the `namespace` portion of registry
+URIs that follow the `registry/namespace/repo:tag` structure, but each registry can very. This value should begin and
+end with "/" (i.e. `pathToRepo=/vantiq/`).
 *   `dockerRegistryUsername`: Optional. The username used for authenticating with the given docker registry.
 *   `dockerRegistryPassword`: Optional. The password used for authenticating with the given docker registry.
 *   `imageTag`: Optional. The tag used when pushing the image. If not specified, the tag will default to "latest".
 *   `repositoryName`: Optional. The name of the repository in the registry to which the image should be pushed. If not
 specified, the default repository will be the connector's name (i.e. "jdbc-source", "jms-source", 
 "objectrecognition-source", etc.).
-*   `useDockerHub`: Optional. A boolean flag that must be set to true if the docker registry is Docker Hub. This is 
-necessary in order to properly authenticate with Docker Hub. If the repository in question is public, then this can be 
-ignored.
 *   `connectorSpecificInclusions`: Optional. The path to a directory of files that need to be included in the image. 
 These can then be referenced and used by the Dockerfile.
 

--- a/README.md
+++ b/README.md
@@ -362,8 +362,7 @@ following configuration option in their `gradle.properties` file, along with som
 *   `dockerRegistry`: Required. The name of the registry to which the image should be pushed (i.e. `docker.io`,
 `quay.io`, etc.).
 *   `pathToRepo`: Required. The path to the docker repository. This is typically the `namespace` portion of registry
-URIs that follow the `registry/namespace/repo:tag` structure, but each registry can very. This value should begin and
-end with "/" (i.e. `pathToRepo=/vantiq/`).
+URIs that follow the `registry/namespace/repo:tag` structure, but each registry can vary, (i.e. `pathToRepo=/vantiq/`).
 *   `dockerRegistryUsername`: Optional. The username used for authenticating with the given docker registry.
 *   `dockerRegistryPassword`: Optional. The password used for authenticating with the given docker registry.
 *   `imageTag`: Optional. The tag used when pushing the image. If not specified, the tag will default to "latest".

--- a/README.md
+++ b/README.md
@@ -369,6 +369,8 @@ specified, the default repository will be the connector's name (i.e. "jdbc-sourc
 *   `notDockerHub`: Optional. A boolean flag that must be set to true if the docker registry is not Docker Hub. This is 
 necessary in order to properly authenticate with the given registry. If the repositories are public, then this can be 
 ignored.
+*   `connectorSpecificInclusions`: Optional. The path to a directory of files that need to be included in the image. 
+This data can then be referenced and used by the Dockerfile.
 
 With the required properties in place, the tasks can then be executed as follows:
 

--- a/README.md
+++ b/README.md
@@ -366,11 +366,11 @@ following configuration option in their `gradle.properties` file, along with som
 *   `repositoryName`: Optional. The name of the repository in the registry to which the image should be pushed. If not
 specified, the default repository will be the connector's name (i.e. "jdbc-source", "jms-source", 
 "objectrecognition-source", etc.).
-*   `notDockerHub`: Optional. A boolean flag that must be set to true if the docker registry is not Docker Hub. This is 
-necessary in order to properly authenticate with the given registry. If the repositories are public, then this can be 
+*   `useDockerHub`: Optional. A boolean flag that must be set to true if the docker registry is Docker Hub. This is 
+necessary in order to properly authenticate with Docker Hub. If the repositor in question is public, then this can be 
 ignored.
 *   `connectorSpecificInclusions`: Optional. The path to a directory of files that need to be included in the image. 
-This data can then be referenced and used by the Dockerfile.
+These can then be referenced and used by the Dockerfile.
 
 With the required properties in place, the tasks can then be executed as follows:
 
@@ -379,11 +379,6 @@ With the required properties in place, the tasks can then be executed as follows
 From the root directory of this repo, run the following command (this example builds the JDBC Connector)
 ```
 ./gradlew jdbcSource:buildConnectorImage
-```
-
-You can also use the camel-cased version:
-```
-./gradlew jdbcSource:bCI
 ```
 
 Or, you can just run the following task:
@@ -399,11 +394,6 @@ than one image, this command will build them all.
 From the root directory of this repo, run the following command (this example pushes the JDBC Connector image)
 ```
 ./gradlew jdbcSource:pushConnectorImage
-```
-
-You can also use the camel-cased version:
-```
-./gradlew jdbcSource:pCI
 ```
 
 Or, you can just run the following task:

--- a/README.md
+++ b/README.md
@@ -352,3 +352,60 @@ we have parameterized the top-level `settings.gradle` file.
 The `settings.gradle` file determines the scope of the build.
 Connectors requiring a driver are included in the overall build *only if* the associated driver location environment variable is present.
 Otherwise, the connector is ignored for the build.
+
+## Building Docker Images
+
+The connectors in this repository contain `gradle` tasks that can be used to build Docker Images for each connector and 
+push those images to the developer's Docker Registry. In order to use these tasks, the developer must include the 
+following configuration option in their `gradle.properties` file, along with some optional parameters:
+
+*   `dockerRegistry`: Required. The name of the registry to which the image should be pushed.
+*   `dockerRegistryUsername`: Optional. The username used for authenticating with the given docker registry.
+*   `dockerRegistryPassword`: Optional. The password used for authenticating with the given docker registry.
+*   `imageTag`: Optional. The tag used when pushing the image. If not specified, the tag will default to "latest".
+*   `repositoryName`: Optional. The name of the repository in the registry to which the image should be pushed. If not
+specified, the default repository will be the connector's name (i.e. "jdbc-source", "jms-source", 
+"objectrecognition-source", etc.).
+*   `notDockerHub`: Optional. A boolean flag that must be set to true if the docker registry is not Docker Hub. This is 
+necessary in order to properly authenticate with the given registry. If the repositories are public, then this can be 
+ignored.
+
+With the required properties in place, the tasks can then be executed as follows:
+
+### Build Image
+
+From the root directory of this repo, run the following command (this example builds the JDBC Connector)
+```
+./gradlew jdbcSource:buildConnectorImage
+```
+
+You can also use the camel-cased version:
+```
+./gradlew jdbcSource:bCI
+```
+
+Or, you can just run the following task:
+```
+./gradlew jdbcSource:buildImages
+```
+*   **NOTE:** This last option will build all images configured for a given subproject. Currently, each subproject 
+(connector) is only configured to build one image. If the developer modifies any of the `build.gradle` to configure more
+than one image, this command will build them all.
+
+### Push Image
+
+From the root directory of this repo, run the following command (this example pushes the JDBC Connector image)
+```
+./gradlew jdbcSource:pushConnectorImage
+```
+
+You can also use the camel-cased version:
+```
+./gradlew jdbcSource:pCI
+```
+
+Or, you can just run the following task:
+```
+./gradlew jdbcSource:pushImages
+```
+*   **NOTE:** Same note as the one above.

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ following configuration option in their `gradle.properties` file, along with som
 specified, the default repository will be the connector's name (i.e. "jdbc-source", "jms-source", 
 "objectrecognition-source", etc.).
 *   `useDockerHub`: Optional. A boolean flag that must be set to true if the docker registry is Docker Hub. This is 
-necessary in order to properly authenticate with Docker Hub. If the repositor in question is public, then this can be 
+necessary in order to properly authenticate with Docker Hub. If the repository in question is public, then this can be 
 ignored.
 *   `connectorSpecificInclusions`: Optional. The path to a directory of files that need to be included in the image. 
 These can then be referenced and used by the Dockerfile.

--- a/build.gradle
+++ b/build.gradle
@@ -91,8 +91,6 @@ subprojects {
                     if (rootProject.hasProperty('connectorSpecificInclusions')) {
                         def inclusionsDir = rootProject.getProperty('connectorSpecificInclusions')
                         from "$inclusionsDir"
-                    } else {
-                        from "$projectDir/build/models"
                     }
                 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ subprojects {
     dcompose {
         if (rootProject.hasProperty('dockerRegistry')) {
             def registryName = rootProject.getProperty('dockerRegistry')
+            def isDockerHub = rootProject.hasProperty('useDockerHub') ? rootProject.getProperty('useDockerHub') : false
 
             def repositoryName = "${project.name - 'Source' + '-source'}".toLowerCase()
             if (rootProject.hasProperty('repositoryName')) {
@@ -103,15 +104,15 @@ subprojects {
             }
 
             // The credentials here should be stored in gradle.properties.
-            if (rootProject.hasProperty('notDockerHub') && rootProject.getProperty('notDockerHub') as boolean) {
-                registry(registryName) {
-                    withUsername dockerRegistryUser
-                    withPassword dockerRegistryPassword
-                }
-            } else {
+            if (isDockerHub) {
                 dockerClientConfig = {
                     withRegistryUsername dockerRegistryUser
                     withRegistryPassword dockerRegistryPassword
+                }
+            } else {
+                registry(registryName) {
+                    withUsername dockerRegistryUser
+                    withPassword dockerRegistryPassword
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,52 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'com.chrisgahlert.gradle-dcompose-plugin'
 
+    // Using gradle-dcompose-plugin to build/push docker images
+    dcompose {
+        if (rootProject.hasProperty('dockerRegistry')) {
+            def registryName = rootProject.getProperty('dockerRegistry')
+
+            def repositoryName = "${project.name - 'Source' + '-source'}".toLowerCase()
+            if (rootProject.hasProperty('repositoryName')) {
+                repositoryName = rootProject.getProperty('repositoryName')
+            }
+
+            connector {
+                buildFiles = project.copySpec {
+                    from "$projectDir/src/main/docker/"
+                    from "$projectDir/build/distributions/${project.name}.tar"
+                    if (rootProject.hasProperty('connectorSpecificInclusions')) {
+                        def inclusionsDir = rootProject.getProperty('connectorSpecificInclusions')
+                        from "$inclusionsDir"
+                    } else {
+                        from "$projectDir/build/models"
+                    }
+                }
+
+                repository = registryName + repositoryName
+                if (rootProject.hasProperty('imageTag')) {
+                    repository = registryName + repositoryName + rootProject.getProperty('imageTag')
+                }
+                logBuildStatus = true
+                buildLogFile = file("$buildDir/dockerBuildLog.txt")
+            }
+
+            // The credentials here should be stored in gradle.properties.
+            if (rootProject.hasProperty('notDockerHub') && rootProject.getProperty('notDockerHub') as boolean) {
+                registry(registryName) {
+                    withUsername dockerRegistryUser
+                    withPassword dockerRegistryPassword
+                }
+            } else {
+                dockerClientConfig = {
+                    withRegistryUsername dockerRegistryUser
+                    withRegistryPassword dockerRegistryPassword
+                }
+            }
+        }
+    }
+    buildConnectorImage.dependsOn assemble
+
     // only run with code-coverage metrics if property is explicitly specified
     if (rootProject.hasProperty('jacocoReport')) {
         apply plugin: "jacoco"
@@ -153,13 +199,10 @@ subprojects {
             }
         }
     }
-
 }
+
 apply plugin: 'java'
-//dependencies {
-//    compile 'org.codehaus.groovy:groovy-all:2.4.11'
-//    compile "org.slf4j:slf4j-api:1.7.5"
-//}
+
 repositories {
     mavenCentral()
     jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -76,9 +76,9 @@ subprojects {
 
     // Using gradle-dcompose-plugin to build/push docker images
     dcompose {
-        if (rootProject.hasProperty('dockerRegistry')) {
+        if (rootProject.hasProperty('dockerRegistry') && rootProject.hasProperty('pathToRepo')) {
             def registryName = rootProject.getProperty('dockerRegistry')
-            def isDockerHub = rootProject.hasProperty('useDockerHub') ? rootProject.getProperty('useDockerHub') : false
+            def pathToRepo = rootProject.getProperty('pathToRepo')
 
             def repositoryName = "${project.name - 'Source' + '-source'}".toLowerCase()
             if (rootProject.hasProperty('repositoryName')) {
@@ -95,25 +95,18 @@ subprojects {
                     }
                 }
 
-                repository = registryName + repositoryName
+                repository = registryName + pathToRepo + repositoryName
                 if (rootProject.hasProperty('imageTag')) {
-                    repository = registryName + repositoryName + rootProject.getProperty('imageTag')
+                    repository += rootProject.getProperty('imageTag')
                 }
                 logBuildStatus = true
                 buildLogFile = file("$buildDir/dockerBuildLog.txt")
             }
 
             // The credentials here should be stored in gradle.properties.
-            if (isDockerHub) {
-                dockerClientConfig = {
-                    withRegistryUsername dockerRegistryUser
-                    withRegistryPassword dockerRegistryPassword
-                }
-            } else {
-                registry(registryName) {
-                    withUsername dockerRegistryUser
-                    withPassword dockerRegistryPassword
-                }
+            registry(registryName) {
+                withUsername dockerRegistryUser
+                withPassword dockerRegistryPassword
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ plugins {
     id 'io.franzbecker.gradle-lombok' version '1.14' apply false
     id 'pl.allegro.tech.build.axion-release' version '1.6.0'
     id 'jacoco'
+    id 'com.chrisgahlert.gradle-dcompose-plugin' version '0.17.1' apply false
 }
 
 wrapper {
@@ -71,6 +72,7 @@ subprojects {
     apply plugin: 'idea'
     apply plugin: 'eclipse'
     apply plugin: 'java'
+    apply plugin: 'com.chrisgahlert.gradle-dcompose-plugin'
 
     // only run with code-coverage metrics if property is explicitly specified
     if (rootProject.hasProperty('jacocoReport')) {

--- a/jdbcSource/build.gradle
+++ b/jdbcSource/build.gradle
@@ -88,18 +88,31 @@ dependencies {
 
 // Using gradle-dcompose-plugin to build jdbcSource docker image
 dcompose {
-    jdbcSource {
-        buildFiles = project.copySpec {
-            from "$projectDir/src/main/docker/"
-            from "$projectDir/build/distributions/jdbcSource.tar"
+    if (rootProject.hasProperty('dockerRegistry')) {
+        def registryName = rootProject.getProperty('dockerRegistry')
+        jdbcSource {
+            buildFiles = project.copySpec {
+                from "$projectDir/src/main/docker/"
+                from "$projectDir/build/distributions/jdbcSource.tar"
+            }
+            if (rootProject.hasProperty('jdbcImageTag')) {
+                repository = registryName + '/jdbc-source' + rootProject.getProperty('jdbcImageTag')
+            } else {
+                repository = registryName + '/jdbc-source'
+            }
+            logBuildStatus = true
+            buildLogFile = file("$buildDir/jdbcDockerBuildLog.file")
         }
-        if (rootProject.hasProperty('dockerRegistry')) {
-            repository = rootProject.getProperty('dockerRegistry') + '/jdbcsource'
-        } else {
-            repository = 'jdbcsource'
+
+        // The credentials here should be stored in gradle.properties.
+        dockerClientConfig = {
+            withRegistryUsername dockerRegistryUser
+            withRegistryPassword dockerRegistryPassword
         }
-        logBuildStatus = true
-        buildLogFile = file("$buildDir/jdbcDockerBuildLog.file")
+//        registry(registryName as String) {
+//            withUsername rootProject.getProperty('dockerRegistryUser')
+//            withPassword rootProject.getProperty('dockerRegistryPassword')
+//        }
     }
 }
 

--- a/jdbcSource/build.gradle
+++ b/jdbcSource/build.gradle
@@ -94,9 +94,9 @@ dcompose {
             from "$projectDir/build/distributions/jdbcSource.tar"
         }
         if (rootProject.hasProperty('dockerRegistry')) {
-            repository = rootProject.getProperty('dockerRegistry') + '/jdbcSource'
+            repository = rootProject.getProperty('dockerRegistry') + '/jdbcsource'
         } else {
-            repository = 'jdbcSource'
+            repository = 'jdbcsource'
         }
         logBuildStatus = true
         buildLogFile = file("$buildDir/jdbcDockerBuildLog.file")

--- a/jdbcSource/build.gradle
+++ b/jdbcSource/build.gradle
@@ -85,3 +85,17 @@ dependencies {
     compile group: 'com.zaxxer', name: 'HikariCP', version: '3.3.1'
 
 }
+
+// Using gradle-dcompose-plugin to build jdbcSource docker image
+dcompose {
+    jdbcSource {
+        buildFiles = project.copySpec {
+            from "$projectDir/src/main/docker/"
+            from "$projectDir/build/distributions/jdbcSource.tar"
+        }
+        repository = 'namirfa/namir-testing:jdbc'
+        logBuildStatus = true
+        buildLogFile = file("$buildDir/jdbcDockerBuildLog.file")
+
+    }
+}

--- a/jdbcSource/build.gradle
+++ b/jdbcSource/build.gradle
@@ -93,9 +93,14 @@ dcompose {
             from "$projectDir/src/main/docker/"
             from "$projectDir/build/distributions/jdbcSource.tar"
         }
-        repository = 'namirfa/namir-testing:jdbc'
+        if (rootProject.hasProperty('dockerRegistry')) {
+            repository = rootProject.getProperty('dockerRegistry') + '/jdbcSource'
+        } else {
+            repository = 'jdbcSource'
+        }
         logBuildStatus = true
         buildLogFile = file("$buildDir/jdbcDockerBuildLog.file")
-
     }
 }
+
+buildJdbcSourceImage.dependsOn assemble

--- a/jdbcSource/build.gradle
+++ b/jdbcSource/build.gradle
@@ -83,37 +83,4 @@ dependencies {
 
     // Used to create a connection pool if asynchronous processing has been specified for publish/query handlers
     compile group: 'com.zaxxer', name: 'HikariCP', version: '3.3.1'
-
 }
-
-// Using gradle-dcompose-plugin to build jdbcSource docker image
-dcompose {
-    if (rootProject.hasProperty('dockerRegistry')) {
-        def registryName = rootProject.getProperty('dockerRegistry')
-        jdbcSource {
-            buildFiles = project.copySpec {
-                from "$projectDir/src/main/docker/"
-                from "$projectDir/build/distributions/jdbcSource.tar"
-            }
-            if (rootProject.hasProperty('jdbcImageTag')) {
-                repository = registryName + '/jdbc-source' + rootProject.getProperty('jdbcImageTag')
-            } else {
-                repository = registryName + '/jdbc-source'
-            }
-            logBuildStatus = true
-            buildLogFile = file("$buildDir/jdbcDockerBuildLog.file")
-        }
-
-        // The credentials here should be stored in gradle.properties.
-        dockerClientConfig = {
-            withRegistryUsername dockerRegistryUser
-            withRegistryPassword dockerRegistryPassword
-        }
-//        registry(registryName as String) {
-//            withUsername rootProject.getProperty('dockerRegistryUser')
-//            withPassword rootProject.getProperty('dockerRegistryPassword')
-//        }
-    }
-}
-
-buildJdbcSourceImage.dependsOn assemble

--- a/jdbcSource/src/main/docker/Dockerfile
+++ b/jdbcSource/src/main/docker/Dockerfile
@@ -2,5 +2,4 @@ FROM openjdk:11-jre-slim
 RUN mkdir /app
 ADD jdbcSource.tar /app
 WORKDIR /app
-#ENTRYPOINT ["tail", "-f", "/dev/null"]
-ENTRYPOINT ["./jdbcsource/bin/jdbcSource"]
+ENTRYPOINT ["./jdbcSource/bin/jdbcSource"]

--- a/jdbcSource/src/main/docker/Dockerfile
+++ b/jdbcSource/src/main/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM openjdk:11-jre-slim
+RUN mkdir /app
+ADD jdbcSource.tar /app
+WORKDIR /app
+#ENTRYPOINT ["tail", "-f", "/dev/null"]
+ENTRYPOINT ["./jdbcsource/bin/jdbcSource"]

--- a/jmsSource/build.gradle
+++ b/jmsSource/build.gradle
@@ -71,31 +71,3 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile project(path:":extjsdk", configuration:"testArtifacts")
 }
-
-// Using gradle-dcompose-plugin to build jmsSource docker image
-dcompose {
-    if (rootProject.hasProperty('dockerRegistry')) {
-        def registryName = rootProject.getProperty('dockerRegistry')
-        jmsSource {
-            buildFiles = project.copySpec {
-                from "$projectDir/src/main/docker/"
-                from "$projectDir/build/distributions/jmsSource.tar"
-            }
-            if (rootProject.hasProperty('jmsImageTag')) {
-                repository = registryName + '/jms-source' + rootProject.getProperty('jmsImageTag')
-            } else {
-                repository = registryName + '/jms-source'
-            }
-            logBuildStatus = true
-            buildLogFile = file("$buildDir/jmsDockerBuildLog.file")
-        }
-
-        // The credentials here should be stored in gradle.properties.
-        dockerClientConfig = {
-            withRegistryUsername dockerRegistryUser
-            withRegistryPassword dockerRegistryPassword
-        }
-    }
-}
-
-buildJmsSourceImage.dependsOn assemble

--- a/jmsSource/build.gradle
+++ b/jmsSource/build.gradle
@@ -71,3 +71,31 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile project(path:":extjsdk", configuration:"testArtifacts")
 }
+
+// Using gradle-dcompose-plugin to build jmsSource docker image
+dcompose {
+    if (rootProject.hasProperty('dockerRegistry')) {
+        def registryName = rootProject.getProperty('dockerRegistry')
+        jmsSource {
+            buildFiles = project.copySpec {
+                from "$projectDir/src/main/docker/"
+                from "$projectDir/build/distributions/jmsSource.tar"
+            }
+            if (rootProject.hasProperty('jmsImageTag')) {
+                repository = registryName + '/jms-source' + rootProject.getProperty('jmsImageTag')
+            } else {
+                repository = registryName + '/jms-source'
+            }
+            logBuildStatus = true
+            buildLogFile = file("$buildDir/jmsDockerBuildLog.file")
+        }
+
+        // The credentials here should be stored in gradle.properties.
+        dockerClientConfig = {
+            withRegistryUsername dockerRegistryUser
+            withRegistryPassword dockerRegistryPassword
+        }
+    }
+}
+
+buildJmsSourceImage.dependsOn assemble

--- a/jmsSource/src/main/docker/Dockerfile
+++ b/jmsSource/src/main/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:11-jre-slim
+RUN mkdir /app
+ADD jmsSource.tar /app
+WORKDIR /app
+ENTRYPOINT ["./jmsSource/bin/jmsSource"]

--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -88,6 +88,10 @@ to this will be included in future distributions produced through gradle.
 ### Local Options
 *   modelDirectory: Optional. The directory in which the files for your neural networks will be. Defaults to the current
     working directory.
+    
+**NOTE:** If using gradle to build a docker image for this connector, the modelDirectory must be specified as the value
+for `connectorSpecificInclusions` in the `gradle.properties` file. The default Dockerfile for this connector will place
+the modelDirectory files in the `/app/models` directory within the docker image.
 
 ## Running Inside Your Own Code<a name="core" id="core"></a>
 

--- a/objectRecognitionSource/build.gradle
+++ b/objectRecognitionSource/build.gradle
@@ -305,3 +305,38 @@ task copyTestResources(type: Copy, dependsOn: [configurations.testRuntime, confi
 }
 
 test.dependsOn copyModels, copyTestResources
+
+// Using gradle-dcompose-plugin to build objectRecognitionSource docker image
+dcompose {
+    if (rootProject.hasProperty('dockerRegistry')) {
+        def registryName = rootProject.getProperty('dockerRegistry')
+        objectRecognitionSource {
+            buildFiles = project.copySpec {
+                from "$projectDir/src/main/docker/"
+                from "$projectDir/build/distributions/objectRecognitionSource.tar"
+                if (rootProject.hasProperty('objectRecognitionModelFiles')) {
+                    def modelLocation = rootProject.getProperty('objectRecognitionModelFiles')
+                    from "$modelLocation"
+                } else {
+                    from "$projectDir/build/models"
+                }
+            }
+            if (rootProject.hasProperty('objectRecognitionImageTag')) {
+                repository = registryName + '/object-recognition-source' + rootProject.getProperty('objectRecognitionImageTag')
+            } else {
+                repository = registryName + '/object-recognition-source'
+            }
+            logBuildStatus = true
+            buildLogFile = file("$buildDir/objectRecognitionDockerBuildLog.file")
+        }
+
+        // The credentials here should be stored in gradle.properties.
+        dockerClientConfig = {
+            withRegistryUsername dockerRegistryUser
+            withRegistryPassword dockerRegistryPassword
+        }
+    }
+}
+
+buildObjectRecognitionSourceImage.dependsOn assemble
+buildObjectRecognitionSourceImage.dependsOn copyModels

--- a/objectRecognitionSource/build.gradle
+++ b/objectRecognitionSource/build.gradle
@@ -305,38 +305,3 @@ task copyTestResources(type: Copy, dependsOn: [configurations.testRuntime, confi
 }
 
 test.dependsOn copyModels, copyTestResources
-
-// Using gradle-dcompose-plugin to build objectRecognitionSource docker image
-dcompose {
-    if (rootProject.hasProperty('dockerRegistry')) {
-        def registryName = rootProject.getProperty('dockerRegistry')
-        objectRecognitionSource {
-            buildFiles = project.copySpec {
-                from "$projectDir/src/main/docker/"
-                from "$projectDir/build/distributions/objectRecognitionSource.tar"
-                if (rootProject.hasProperty('objectRecognitionModelFiles')) {
-                    def modelLocation = rootProject.getProperty('objectRecognitionModelFiles')
-                    from "$modelLocation"
-                } else {
-                    from "$projectDir/build/models"
-                }
-            }
-            if (rootProject.hasProperty('objectRecognitionImageTag')) {
-                repository = registryName + '/object-recognition-source' + rootProject.getProperty('objectRecognitionImageTag')
-            } else {
-                repository = registryName + '/object-recognition-source'
-            }
-            logBuildStatus = true
-            buildLogFile = file("$buildDir/objectRecognitionDockerBuildLog.file")
-        }
-
-        // The credentials here should be stored in gradle.properties.
-        dockerClientConfig = {
-            withRegistryUsername dockerRegistryUser
-            withRegistryPassword dockerRegistryPassword
-        }
-    }
-}
-
-buildObjectRecognitionSourceImage.dependsOn assemble
-buildObjectRecognitionSourceImage.dependsOn copyModels

--- a/objectRecognitionSource/src/main/docker/Dockerfile
+++ b/objectRecognitionSource/src/main/docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:11-jre-slim
+RUN mkdir /app
+RUN mkdir /app/models
+ADD objectRecognitionSource.tar /app
+ADD *.meta /app/models/
+ADD *.pb /app/models/
+ADD *.names /app/models/
+WORKDIR /app
+ENTRYPOINT ["./objectRecognitionSource/bin/objectRecognitionSource"]

--- a/opcuaSource/build.gradle
+++ b/opcuaSource/build.gradle
@@ -98,31 +98,3 @@ task runExampleServer(type: JavaExec) {
     main = "io.vantiq.extsrc.opcua.io.vantiq.extsrc.opcua.sampleServer.RunExampleServer"
     classpath = sourceSets.test.runtimeClasspath
 }
-
-// Using gradle-dcompose-plugin to build opcuaSource docker image
-dcompose {
-    if (rootProject.hasProperty('dockerRegistry')) {
-        def registryName = rootProject.getProperty('dockerRegistry')
-        opcuaSource {
-            buildFiles = project.copySpec {
-                from "$projectDir/src/main/docker/"
-                from "$projectDir/build/distributions/opcuaSource.tar"
-            }
-            if (rootProject.hasProperty('opcuaImageTag')) {
-                repository = registryName + '/opcua-source' + rootProject.getProperty('opcuaImageTag')
-            } else {
-                repository = registryName + '/opcua-source'
-            }
-            logBuildStatus = true
-            buildLogFile = file("$buildDir/opcuaDockerBuildLog.file")
-        }
-
-        // The credentials here should be stored in gradle.properties.
-        dockerClientConfig = {
-            withRegistryUsername dockerRegistryUser
-            withRegistryPassword dockerRegistryPassword
-        }
-    }
-}
-
-buildOpcuaSourceImage.dependsOn assemble

--- a/opcuaSource/build.gradle
+++ b/opcuaSource/build.gradle
@@ -98,3 +98,31 @@ task runExampleServer(type: JavaExec) {
     main = "io.vantiq.extsrc.opcua.io.vantiq.extsrc.opcua.sampleServer.RunExampleServer"
     classpath = sourceSets.test.runtimeClasspath
 }
+
+// Using gradle-dcompose-plugin to build opcuaSource docker image
+dcompose {
+    if (rootProject.hasProperty('dockerRegistry')) {
+        def registryName = rootProject.getProperty('dockerRegistry')
+        opcuaSource {
+            buildFiles = project.copySpec {
+                from "$projectDir/src/main/docker/"
+                from "$projectDir/build/distributions/opcuaSource.tar"
+            }
+            if (rootProject.hasProperty('opcuaImageTag')) {
+                repository = registryName + '/opcua-source' + rootProject.getProperty('opcuaImageTag')
+            } else {
+                repository = registryName + '/opcua-source'
+            }
+            logBuildStatus = true
+            buildLogFile = file("$buildDir/opcuaDockerBuildLog.file")
+        }
+
+        // The credentials here should be stored in gradle.properties.
+        dockerClientConfig = {
+            withRegistryUsername dockerRegistryUser
+            withRegistryPassword dockerRegistryPassword
+        }
+    }
+}
+
+buildOpcuaSourceImage.dependsOn assemble

--- a/opcuaSource/src/main/docker/Dockerfile
+++ b/opcuaSource/src/main/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:11-jre-slim
+RUN mkdir /app
+ADD opcuaSource.tar /app
+WORKDIR /app
+ENTRYPOINT ["./opcuaSource/bin/opcuaSource"]

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,10 +2,10 @@ rootProject.name = 'vantiq-extension-source'
 include 'opcuaSource'
 include 'extjsdk'
 include 'udpSource'
+include 'CSVSource'
 if (System.env.EASY_MODBUS_LOC) {
     include 'EasyModbusSource' 
 }
-include 'CSVSource'
 if (System.env.OPENCV_LOC) {
     include 'objectRecognitionSource'
 }

--- a/udpSource/build.gradle
+++ b/udpSource/build.gradle
@@ -72,3 +72,30 @@ dependencies {
     testCompile project(path:":extjsdk", configuration:"testArtifacts")
 }
 
+// Using gradle-dcompose-plugin to build udpSource docker image
+dcompose {
+    if (rootProject.hasProperty('dockerRegistry')) {
+        def registryName = rootProject.getProperty('dockerRegistry')
+        udpSource {
+            buildFiles = project.copySpec {
+                from "$projectDir/src/main/docker/"
+                from "$projectDir/build/distributions/udpSource.tar"
+            }
+            if (rootProject.hasProperty('udpImageTag')) {
+                repository = registryName + '/udp-source' + rootProject.getProperty('udpImageTag')
+            } else {
+                repository = registryName + '/udp-source'
+            }
+            logBuildStatus = true
+            buildLogFile = file("$buildDir/udpDockerBuildLog.file")
+        }
+
+        // The credentials here should be stored in gradle.properties.
+        dockerClientConfig = {
+            withRegistryUsername dockerRegistryUser
+            withRegistryPassword dockerRegistryPassword
+        }
+    }
+}
+
+buildUdpSourceImage.dependsOn assemble

--- a/udpSource/build.gradle
+++ b/udpSource/build.gradle
@@ -71,31 +71,3 @@ dependencies {
     testCompile 'junit:junit:4.12'
     testCompile project(path:":extjsdk", configuration:"testArtifacts")
 }
-
-// Using gradle-dcompose-plugin to build udpSource docker image
-dcompose {
-    if (rootProject.hasProperty('dockerRegistry')) {
-        def registryName = rootProject.getProperty('dockerRegistry')
-        udpSource {
-            buildFiles = project.copySpec {
-                from "$projectDir/src/main/docker/"
-                from "$projectDir/build/distributions/udpSource.tar"
-            }
-            if (rootProject.hasProperty('udpImageTag')) {
-                repository = registryName + '/udp-source' + rootProject.getProperty('udpImageTag')
-            } else {
-                repository = registryName + '/udp-source'
-            }
-            logBuildStatus = true
-            buildLogFile = file("$buildDir/udpDockerBuildLog.file")
-        }
-
-        // The credentials here should be stored in gradle.properties.
-        dockerClientConfig = {
-            withRegistryUsername dockerRegistryUser
-            withRegistryPassword dockerRegistryPassword
-        }
-    }
-}
-
-buildUdpSourceImage.dependsOn assemble

--- a/udpSource/src/main/docker/Dockerfile
+++ b/udpSource/src/main/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:11-jre-slim
+RUN mkdir /app
+ADD udpSource.tar /app
+WORKDIR /app
+ENTRYPOINT ["./udpSource/bin/udpSource"]


### PR DESCRIPTION
Uses the `dcompose` plugin to build docker images for the connectors.

The developer will need to configure a `Dockerfile` for their connector, and add the proper `dcompose` task to their connector's `build.gradle` file.

This is not fully completed, it just shows an example of this working for the JDBC Connector. We will need to add similar code for each of the other connectors, which I can do next.

There are two things that still need to be completed:
1. Checking for the existence of Docker Hub credentials in the gradle.properties file, along with a Docker Hub registry to which we should push the image. Currently the `repository` portion of the `dcompose` task is just creating the image with that name in my local Docker Hub registry.
2. Forcing the `dcompose` task to depend on the default `assemble` task. This was not working when I tried it, though of course there must be a way to get this done.

After building the image with this tool, I manually pushed it to my public Docker Hub repository. I then ran the Connector test in `K8sClusterTests` using the debugger and was able to pulish/query the connector running in my local K8s cluster. Of course there was no DB running in the container so all the requests failed, but the connector received them all and attempted to send them along to the nonexistent DB.