### PR TITLE
Add ability to pickup credentials from environment variable

### DIFF
--- a/extjsdk/build.gradle
+++ b/extjsdk/build.gradle
@@ -44,6 +44,7 @@ configurations {
 
 test {
     useJUnit()
+    environment "CONNECTOR_AUTH_TOKEN", "xxxx===="
 }
 
 tasks.withType(Test) {

--- a/extjsdk/build.gradle
+++ b/extjsdk/build.gradle
@@ -44,7 +44,9 @@ configurations {
 
 test {
     useJUnit()
-    environment "CONNECTOR_AUTH_TOKEN", "xxxx===="
+    if (System.getenv("CONNECTOR_AUTH_TOKEN") == null) {
+        environment "CONNECTOR_AUTH_TOKEN", "xxxx===="
+    }
 }
 
 tasks.withType(Test) {

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
@@ -9,6 +9,7 @@ public class Utils {
     
     public static String SERVER_CONFIG_DIR = "serverConfig";
     public static String SERVER_CONFIG_FILENAME = "server.config";
+    public static String SECRET_CREDENTIALS = "CONNECTOR_AUTH_TOKEN";
 
     public static Properties obtainServerConfig() {
         return obtainServerConfig(SERVER_CONFIG_FILENAME);
@@ -29,6 +30,12 @@ public class Utils {
                 configFile = new File(fileName);
             }
             properties.load(new FileReader(configFile));
+
+            // Next we check for the existence of an environment variable containing a secret reference to the authToken
+            String secretAuthToken = System.getenv(SECRET_CREDENTIALS);
+            if (secretAuthToken != null && !secretAuthToken.trim().isEmpty()) {
+                properties.setProperty("authToken", secretAuthToken);
+            }
         } catch (IOException e) {
             throw new RuntimeException("Could not find valid server configuration file. Expected location: '"
                     + configFile.getAbsolutePath() + "'", e);

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
@@ -32,8 +32,11 @@ public class Utils {
             properties.load(new FileReader(configFile));
 
             // Next we check for the existence of an environment variable containing a secret reference to the authToken
+            // We only set it if the value is not empty and if the authToken wasn't already specified in the
+            // server.config
             String secretAuthToken = System.getenv(SECRET_CREDENTIALS);
-            if (secretAuthToken != null && !secretAuthToken.trim().isEmpty()) {
+            if (secretAuthToken != null && !secretAuthToken.trim().isEmpty()
+                    && properties.getProperty("authToken") == null) {
                 properties.setProperty("authToken", secretAuthToken);
             }
         } catch (IOException e) {

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestUtils.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestUtils.java
@@ -13,7 +13,6 @@ import java.util.Properties;
 
 import static org.junit.Assume.assumeTrue;
 
-
 public class TestUtils  {
 
     private static final String FAKE_URL = "http://somewhere/else";
@@ -23,7 +22,6 @@ public class TestUtils  {
     public static final String AUTH_TOKEN_PROP = "authToken";
     public static final String OTHER_PROP = "otherProperty";
 
-    public static String FAKE_TOKEN2 = "xxxx====xxxx";
     public static String SECRET_CREDENTIALS = "CONNECTOR_AUTH_TOKEN";
     String envVarAuthToken;
 
@@ -43,7 +41,7 @@ public class TestUtils  {
             
             bw = fillProps(p, true);
            
-            checkProps(false);
+            checkProps();
         } finally {
             if (bw != null) {
                 bw.close();
@@ -70,7 +68,7 @@ public class TestUtils  {
             f.deleteOnExit();
             bw = fillProps(p, true);
             
-            checkProps(false);
+            checkProps();
         } finally {
             if (bw != null) {
                 bw.close();
@@ -93,13 +91,6 @@ public class TestUtils  {
         doEnvVarTests(false);
     }
 
-    @Test
-    public void testGetEnvVarOverwrite() throws Exception {
-        assumeTrue("\"CONNECTOR_AUTH_TOKEN\" environment variable must be set equal to \"xxxx====xxxx\"",
-                envVarAuthToken != null && envVarAuthToken.equals(FAKE_TOKEN2));
-        doEnvVarTests(true);
-    }
-
     private void doEnvVarTests(boolean includeAuthToken) throws Exception {
         BufferedWriter bw = null;
         File f = null;
@@ -114,7 +105,7 @@ public class TestUtils  {
             f.deleteOnExit();
             bw = fillProps(p, includeAuthToken);
 
-            checkProps(includeAuthToken);
+            checkProps();
         } finally {
             if (bw != null) {
                 bw.close();
@@ -141,16 +132,12 @@ public class TestUtils  {
         return bw;
     }
     
-    private void checkProps(boolean isOverwrite) {
+    private void checkProps() {
         Properties props = Utils.obtainServerConfig();
         assert props.getProperty(TARGET_SERVER_PROP) != null;
         assert props.getProperty(TARGET_SERVER_PROP).contains(FAKE_URL);
         assert props.getProperty(AUTH_TOKEN_PROP) != null;
-        if (isOverwrite) {
-            assert props.getProperty(AUTH_TOKEN_PROP).contains(FAKE_TOKEN2);
-        } else {
-            assert props.getProperty(AUTH_TOKEN_PROP).contains(FAKE_TOKEN);
-        }
+        assert props.getProperty(AUTH_TOKEN_PROP).contains(FAKE_TOKEN);
         assert props.getProperty(OTHER_PROP) != null;
         assert props.getProperty(OTHER_PROP).contains(FAKE_SOURCE);
     }


### PR DESCRIPTION
Fixes #219 

Enables the ExtSrc SDK to pickup the `authToken` property if specified in an environment variable named `CONNECTOR_AUTH_TOKEN`. If an authToken is included in the `server.config` file, that value will be given precedence over the environment variable.