### PR TITLE
README updates for Utils.obtainServerConfig()

### DIFF
--- a/CSVSource/README.md
+++ b/CSVSource/README.md
@@ -45,6 +45,8 @@ name for each class is the class's fully qualified class name, *e.g.* "io.vantiq
 
 ## Server Config File
 
+(Please read to the [SDK's server config documentation](../README.md#serverConfig) first.)
+
 The server config file is written as `property=value`, with each property on its
 own line. 
 The following is an example of a valid server.config file:

--- a/CSVSource/README.md
+++ b/CSVSource/README.md
@@ -45,7 +45,7 @@ name for each class is the class's fully qualified class name, *e.g.* "io.vantiq
 
 ## Server Config File
 
-(Please read to the [SDK's server config documentation](../README.md#serverConfig) first.)
+(Please read to the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
 
 The server config file is written as `property=value`, with each property on its
 own line. 

--- a/CSVSource/README.md
+++ b/CSVSource/README.md
@@ -44,18 +44,7 @@ which is an [Apache Log4j configuration file.](https://logging.apache.org/log4j/
 name for each class is the class's fully qualified class name, *e.g.* "io.vantiq.extjsdk.ExtensionWebSocketClient".  
 
 ## Server Config File
-
 (Please read to the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
-
-The server config file is written as `property=value`, with each property on its
-own line. 
-The following is an example of a valid server.config file:
-
-```
-authToken=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-sources=CSV1
-targetServer=https://dev.vantiq.com/
-```
 
 ### Vantiq Options
 

--- a/EasyModbusSource/README.md
+++ b/EasyModbusSource/README.md
@@ -52,6 +52,8 @@ name for each class is the class's fully qualified class name, *e.g.* "io.vantiq
 
 ## Server Config File
 
+(Please read to the [SDK's server config documentation](../README.md#serverConfig) first.)
+
 The server config file is written as `property=value`, with each property on its
 own line. The following is an example of a valid server.config file:
 ```

--- a/EasyModbusSource/README.md
+++ b/EasyModbusSource/README.md
@@ -51,16 +51,7 @@ which is an [Apache Log4j configuration file.](https://logging.apache.org/log4j/
 name for each class is the class's fully qualified class name, *e.g.* "io.vantiq.extjsdk.ExtensionWebSocketClient".  
 
 ## Server Config File
-
 (Please read to the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
-
-The server config file is written as `property=value`, with each property on its
-own line. The following is an example of a valid server.config file:
-```
-authToken=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-sources=EasyModbus1
-targetServer=https://dev.vantiq.com/
-```
 
 ### Vantiq Options
 *   **authToken**: Required. The authentication token to connect with. These can be obtained from the namespace admin.

--- a/EasyModbusSource/README.md
+++ b/EasyModbusSource/README.md
@@ -52,7 +52,7 @@ name for each class is the class's fully qualified class name, *e.g.* "io.vantiq
 
 ## Server Config File
 
-(Please read to the [SDK's server config documentation](../README.md#serverConfig) first.)
+(Please read to the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
 
 The server config file is written as `property=value`, with each property on its
 own line. The following is an example of a valid server.config file:

--- a/extjsdk/README.md
+++ b/extjsdk/README.md
@@ -43,15 +43,24 @@ Generally, connectors need a minimum of three configuration properties at startu
     
 The SDK includes a utility method to retrieve the startup configuration document and parse its contents into a 
 `Properties` object: `Utils.obtainServerConfig()`. By default, this method will look for those values in a file named 
-`server.config`. That file is expected to be included in the running connector directory as follows: 
-`<connectorRunningDirector>/serverConfig/server.config`. The SDK will also look for the file in the running connector 
-directory if it is not found in the `serverConfig` subdirectory (i.e. `<connectorRunningDirector>/server.config`).
+`server.config`. That file is expected to be included in the connector's working directory as follows: 
+`<connectorWorkingDirector>/serverConfig/server.config`. The SDK will also look for the file in the working connector 
+directory if it is not found in the `serverConfig` subdirectory (i.e. `<connectorWorkingDirector>/server.config`).
 
 For users who may not want to write the `authToken` property to a file because of its sensitive nature, the 
 `Utils.obtainServerConfig()` method will also search for this value in an environment variable named 
-`CONNECTOR_AUTH_TOKEN`. If the `authToken` is specified in the `server.config` document, that value will take precedent.
+`CONNECTOR_AUTH_TOKEN`. If the `authToken` is specified in the `server.config` document, that value will take precedence.
 Otherwise, if the `authToken` is not set in the configuration file, the utility method will retrieve whatever value is 
 provided in the environment variable.
+
+The server config file is written as `property=value`, with each property on its own line. The following is an example 
+of a valid `server.config` file (including the `authToken`, but that can be omitted and specified as an environment 
+variable instead):
+```
+authToken=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+sources=MySourceName
+targetServer=https://dev.vantiq.com/
+```
 
 ## Program Flow
 1.	A new ExtensionWebSocketClient is created.

--- a/extjsdk/README.md
+++ b/extjsdk/README.md
@@ -34,6 +34,25 @@ dependencies on mvnrepository.com are included.
 The SDK uses the Slf4j logging interface with no implementation provided. The names of the loggers are the fully
 qualified class name, appended by a '#' and the name of the source they are associated with.
 
+## <a name="serverConfig" id="serverConfig"></a>Connector Startup Configuration
+Generally, connectors need a minimum of three configuration properties at startup:
+*   `targetServer`: The URL of the Vantiq server to which the connector should connect.
+*   `authToken`: The access token that the connector will use to authenticate to the desired namespace.
+*   `source(s)`: The name of the source in the namespace (or in some cases a list of comma-separated source names) 
+    that the connector will connect to
+    
+The SDK includes a utility method to retrieve the startup configuration document and parse its contents into a 
+`Properties` object: `Utils.obtainServerConfig()`. By default, this method will look for those values in a file named 
+`server.config`. That file is expected to be included in the running connector directory as follows: 
+`<connectorRunningDirector>/serverConfig/server.config`. The SDK will also look for the file in the running connector 
+directory if it is not found in the `serverConfig` subdirectory (i.e. `<connectorRunningDirector>/server.config`).
+
+For users who may not want to write the `authToken` property to a file because of its sensitive nature, the 
+`Utils.obtainServerConfig()` method will also search for this value in an environment variable named 
+`CONNECTOR_AUTH_TOKEN`. If the `authToken` is specified in the `server.config` document, that value will take precedent.
+Otherwise, if the `authToken` is not set in the configuration file, the utility method will retrieve whatever value is 
+provided in the environment variable.
+
 ## Program Flow
 1.	A new ExtensionWebSocketClient is created.
 2.	Setup and add any handlers through `client.set<type>Handler()`. See the [Receiving Messages](#handler) section for

--- a/jdbcSource/README.md
+++ b/jdbcSource/README.md
@@ -56,6 +56,8 @@ name for each class is the class's fully qualified class name, *e.g.* "io.vantiq
 
 ## Server Config File
 
+(Please read to the [SDK's server config documentation](../README.md#serverConfig) first.)
+
 The server config file is written as `property=value`, with each property on its
 own line. The following is an example of a valid server.config file:
 ```

--- a/jdbcSource/README.md
+++ b/jdbcSource/README.md
@@ -55,16 +55,7 @@ which is an [Apache Log4j configuration file.](https://logging.apache.org/log4j/
 name for each class is the class's fully qualified class name, *e.g.* "io.vantiq.extjsdk.ExtensionWebSocketClient".  
 
 ## Server Config File
-
 (Please read to the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
-
-The server config file is written as `property=value`, with each property on its
-own line. The following is an example of a valid server.config file:
-```
-authToken=vadfEarscQadfagdfjrKt7Fj1xjfjzBxliahO9adliiH-Dj--gNM=
-sources=JDBC1
-targetServer=https://dev.vantiq.com/
-```
 
 ### Vantiq Options
 *   **authToken**: Required. The authentication token to connect with. These can be obtained from the namespace admin.

--- a/jdbcSource/README.md
+++ b/jdbcSource/README.md
@@ -56,7 +56,7 @@ name for each class is the class's fully qualified class name, *e.g.* "io.vantiq
 
 ## Server Config File
 
-(Please read to the [SDK's server config documentation](../README.md#serverConfig) first.)
+(Please read to the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
 
 The server config file is written as `property=value`, with each property on its
 own line. The following is an example of a valid server.config file:

--- a/jmsSource/README.md
+++ b/jmsSource/README.md
@@ -60,7 +60,7 @@ named "output.log".
 
 ## Server Config File
 
-(Please read to the [SDK's server config documentation](../README.md#serverConfig) first.)
+(Please read to the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
 
 The server config file is written as `property=value`, with each property on its
 own line. The following is an example of a valid server.config file:

--- a/jmsSource/README.md
+++ b/jmsSource/README.md
@@ -60,6 +60,8 @@ named "output.log".
 
 ## Server Config File
 
+(Please read to the [SDK's server config documentation](../README.md#serverConfig) first.)
+
 The server config file is written as `property=value`, with each property on its
 own line. The following is an example of a valid server.config file:
 ```

--- a/jmsSource/README.md
+++ b/jmsSource/README.md
@@ -59,16 +59,7 @@ name for each class is the class's fully qualified class name, *e.g.* "io.vantiq
 named "output.log".
 
 ## Server Config File
-
 (Please read to the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
-
-The server config file is written as `property=value`, with each property on its
-own line. The following is an example of a valid server.config file:
-```
-authToken=vadfEarscQadfagdfjrKt7Fj1xjfjzBxliahO9adliiH-Dj--gNM=
-sources=JMS1
-targetServer=https://dev.vantiq.com/
-```
 
 ### Vantiq Options
 *   **authToken**: Required. The authentication token to connect with. These can be obtained from the namespace admin.

--- a/opcuaSource/README.md
+++ b/opcuaSource/README.md
@@ -256,7 +256,7 @@ where
 
 Alternatively,
 the connection information be provided in a *properties* file. 
-(Please read to the [SDK's server config documentation](../README.md#serverConfig) first.)
+(Please read to the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
 Specifically, create a file named `server.config`.
 Note that the `server.config` file can be placed in the `<install location>/opcuaSource/serverConfig/server.config` or `<install location>/opcuaSource/server.config` locations.
 The information required is placed in that file as follows:

--- a/opcuaSource/README.md
+++ b/opcuaSource/README.md
@@ -255,7 +255,8 @@ where
  - *<storageDirectory>* is the place on the file system to store information.
 
 Alternatively,
-the connection information be provided in a *properties* file.
+the connection information be provided in a *properties* file. 
+(Please read to the [SDK's server config documentation](../README.md#serverConfig) first.)
 Specifically, create a file named `server.config`.
 Note that the `server.config` file can be placed in the `<install location>/opcuaSource/serverConfig/server.config` or `<install location>/opcuaSource/server.config` locations.
 The information required is placed in that file as follows:

--- a/udpSource/README.md
+++ b/udpSource/README.md
@@ -28,7 +28,7 @@ be included in future distributions produced through gradle.
 
 ## Server Config File<a name="serverConfig" id="serverConfig"></a>
 
-(Please read to the [SDK's server config documentation](../README.md#serverConfig) first.)
+(Please read to the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
 
 The server config file must be in properties file format. ConfigurableUDPSource runs using either the config file specified as the
 first argument or the file `server.config` in the `serverConfig` directory or in the working directory.

--- a/udpSource/README.md
+++ b/udpSource/README.md
@@ -28,6 +28,8 @@ be included in future distributions produced through gradle.
 
 ## Server Config File<a name="serverConfig" id="serverConfig"></a>
 
+(Please read to the [SDK's server config documentation](../README.md#serverConfig) first.)
+
 The server config file must be in properties file format. ConfigurableUDPSource runs using either the config file specified as the
 first argument or the file `server.config` in the `serverConfig` directory or in the working directory.
 


### PR DESCRIPTION
Closes #221 

Added documentation for the `Utils.obtainServerConfig()` method in the extjsdk/README. As part of that documentation, added a description of the new enhancement to retrieve the `authToken` from an environment variable.

Each connector's README now references this documentation and encourages reading the SDK Server Config documentation first before reading the connector specific one.