### PR TITLE
Fixing SDK server config documentation typos

### DIFF
--- a/CSVSource/README.md
+++ b/CSVSource/README.md
@@ -44,7 +44,7 @@ which is an [Apache Log4j configuration file.](https://logging.apache.org/log4j/
 name for each class is the class's fully qualified class name, *e.g.* "io.vantiq.extjsdk.ExtensionWebSocketClient".  
 
 ## Server Config File
-(Please read to the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
+(Please read the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
 
 ### Vantiq Options
 

--- a/EasyModbusSource/README.md
+++ b/EasyModbusSource/README.md
@@ -51,7 +51,7 @@ which is an [Apache Log4j configuration file.](https://logging.apache.org/log4j/
 name for each class is the class's fully qualified class name, *e.g.* "io.vantiq.extjsdk.ExtensionWebSocketClient".  
 
 ## Server Config File
-(Please read to the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
+(Please read the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
 
 ### Vantiq Options
 *   **authToken**: Required. The authentication token to connect with. These can be obtained from the namespace admin.

--- a/jdbcSource/README.md
+++ b/jdbcSource/README.md
@@ -55,7 +55,7 @@ which is an [Apache Log4j configuration file.](https://logging.apache.org/log4j/
 name for each class is the class's fully qualified class name, *e.g.* "io.vantiq.extjsdk.ExtensionWebSocketClient".  
 
 ## Server Config File
-(Please read to the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
+(Please read the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
 
 ### Vantiq Options
 *   **authToken**: Required. The authentication token to connect with. These can be obtained from the namespace admin.

--- a/jmsSource/README.md
+++ b/jmsSource/README.md
@@ -59,7 +59,7 @@ name for each class is the class's fully qualified class name, *e.g.* "io.vantiq
 named "output.log".
 
 ## Server Config File
-(Please read to the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
+(Please read the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
 
 ### Vantiq Options
 *   **authToken**: Required. The authentication token to connect with. These can be obtained from the namespace admin.

--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -77,16 +77,7 @@ To edit the logging for an IDE, change `<repo location>/objectRecognitionSource/
 to this will be included in future distributions produced through gradle.
 
 ## Server Config File<a name="serverConfig" id="serverConfig"></a>
-
-The server config file is written as `property=value`, with each property on its
-own line. The following is an example of a valid server.config file:
-
-```
-authToken=vadfEarscQadfagdfjrKt7Fj1xjfjzBxliahO9adliiH-Dj--gNM=
-sources=Camera1
-targetServer=https://dev.vantiq.com/
-modelDirectory=<path_to_your_pb_file>
-```
+(Please read the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
 
 ### Vantiq Options
 *   authToken: Required. The authentication token to connect with. These can be obtained from the namespace admin.

--- a/opcuaSource/README.md
+++ b/opcuaSource/README.md
@@ -256,7 +256,7 @@ where
 
 Alternatively,
 the connection information be provided in a *properties* file. 
-(Please read to the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
+(Please read the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
 Specifically, create a file named `server.config`.
 Note that the `server.config` file can be placed in the `<install location>/opcuaSource/serverConfig/server.config` or `<install location>/opcuaSource/server.config` locations.
 The information required is placed in that file as follows:

--- a/udpSource/README.md
+++ b/udpSource/README.md
@@ -28,7 +28,7 @@ be included in future distributions produced through gradle.
 
 ## Server Config File<a name="serverConfig" id="serverConfig"></a>
 
-(Please read to the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
+(Please read the [SDK's server config documentation](../extjsdk/README.md#serverConfig) first.)
 
 The server config file must be in properties file format. ConfigurableUDPSource runs using either the config file specified as the
 first argument or the file `server.config` in the `serverConfig` directory or in the working directory.


### PR DESCRIPTION
Closes #224 

Cleaning up leftover typos, and missing change to object rec connector.