### PR TITLE
Fixing reconnectHandler issue in connectors, and adding ability in SDK to queue up messages that failed to send while reconnecting, and resend later

### DIFF
--- a/CSVSource/src/main/java/io/vantiq/extsrc/CSVSource/CSVCore.java
+++ b/CSVSource/src/main/java/io/vantiq/extsrc/CSVSource/CSVCore.java
@@ -57,7 +57,9 @@ public class CSVCore {
             // Do connector-specific stuff here
             oConfigHandler.configComplete = false;
 
-            // Boiler-plate reconnect method, if reconnect fails then we call close()
+            // Boiler-plate reconnect method- if reconnect fails then we call close(). The code in this reconnect
+            // handler must finish executing before we can process another message from Vantiq, meaning the
+            // reconnectResult will not complete until after we have exited the handler.
             CompletableFuture<Boolean> reconnectResult = client.doCoreReconnect();
             reconnectResult.thenAccept(success -> {
                 if (!success) {

--- a/CSVSource/src/main/java/io/vantiq/extsrc/CSVSource/CSVCore.java
+++ b/CSVSource/src/main/java/io/vantiq/extsrc/CSVSource/CSVCore.java
@@ -55,24 +55,27 @@ public class CSVCore {
             }
             
             oConfigHandler.configComplete = false;
-                        
-            CompletableFuture<Boolean> success = client.connectToSource();
-            
-            try {
-                if ( !success.get(10, TimeUnit.SECONDS) ) {
-                    if (!client.isOpen()) {
-                        log.error("Failed to connect to server url '{}'.", targetVantiqServer);
-                    } else if (!client.isAuthed()) {
-                        log.error("Failed to authenticate within 10 seconds using the given authentication data.");
-                    } else {
-                        log.error("Failed to connect within 10 seconds");
+
+            // Spin off a thread to handle doing the reconnect and error/log handling, this way the handler doesn't
+            // block the onMessage() handler in the ExtensionWebSocketListener from processing future messages
+            new Thread( () -> {
+                CompletableFuture<Boolean> success = client.connectToSource();
+                try {
+                    if ( !success.get(10, TimeUnit.SECONDS) ) {
+                        if (!client.isOpen()) {
+                            log.error("Failed to connect to server url '" + targetVantiqServer + "'.");
+                        } else if (!client.isAuthed()) {
+                            log.error("Failed to authenticate within 10 seconds using the given authentication data.");
+                        } else {
+                            log.error("Failed to connect within 10 seconds");
+                        }
+                        close();
                     }
+                } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                    log.error("Could not reconnect to source within 10 seconds: ", e);
                     close();
                 }
-            } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                log.error("Could not reconnect to source within 10 seconds: ", e);
-                close();
-            }
+            }).start();
         }
     };
     

--- a/EasyModbusSource/src/main/java/io/vantiq/extsrc/EasyModbusSource/EasyModbusCore.java
+++ b/EasyModbusSource/src/main/java/io/vantiq/extsrc/EasyModbusSource/EasyModbusCore.java
@@ -73,28 +73,16 @@ public class EasyModbusCore {
                 pollTimer = null;
             }
 
+            // Do connector-specific stuff here
             easyModbusConfigHandler.configComplete = false;
 
-            // Spin off a thread to handle doing the reconnect and error/log handling, this way the handler doesn't
-            // block the onMessage() handler in the ExtensionWebSocketListener from processing future messages
-            new Thread( () -> {
-                CompletableFuture<Boolean> success = client.connectToSource();
-                try {
-                    if ( !success.get(10, TimeUnit.SECONDS) ) {
-                        if (!client.isOpen()) {
-                            log.error("Failed to connect to server url '" + targetVantiqServer + "'.");
-                        } else if (!client.isAuthed()) {
-                            log.error("Failed to authenticate within 10 seconds using the given authentication data.");
-                        } else {
-                            log.error("Failed to connect within 10 seconds");
-                        }
-                        close();
-                    }
-                } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                    log.error("Could not reconnect to source within 10 seconds: ", e);
+            // Boiler-plate reconnect method, if reconnect fails then we call close()
+            CompletableFuture<Boolean> reconnectResult = client.doCoreReconnect();
+            reconnectResult.thenAccept(success -> {
+                if (!success) {
                     close();
                 }
-            }).start();
+            });
         }
     };
 

--- a/EasyModbusSource/src/main/java/io/vantiq/extsrc/EasyModbusSource/EasyModbusCore.java
+++ b/EasyModbusSource/src/main/java/io/vantiq/extsrc/EasyModbusSource/EasyModbusCore.java
@@ -76,7 +76,9 @@ public class EasyModbusCore {
             // Do connector-specific stuff here
             easyModbusConfigHandler.configComplete = false;
 
-            // Boiler-plate reconnect method, if reconnect fails then we call close()
+            // Boiler-plate reconnect method- if reconnect fails then we call close(). The code in this reconnect
+            // handler must finish executing before we can process another message from Vantiq, meaning the
+            // reconnectResult will not complete until after we have exited the handler.
             CompletableFuture<Boolean> reconnectResult = client.doCoreReconnect();
             reconnectResult.thenAccept(success -> {
                 if (!success) {

--- a/EasyModbusSource/src/main/java/io/vantiq/extsrc/EasyModbusSource/EasyModbusCore.java
+++ b/EasyModbusSource/src/main/java/io/vantiq/extsrc/EasyModbusSource/EasyModbusCore.java
@@ -75,23 +75,26 @@ public class EasyModbusCore {
 
             easyModbusConfigHandler.configComplete = false;
 
-            CompletableFuture<Boolean> success = client.connectToSource();
-
-            try {
-                if (!success.get(10, TimeUnit.SECONDS)) {
-                    if (!client.isOpen()) {
-                        log.error("Failed to connect to server url '" + targetVantiqServer + "'.");
-                    } else if (!client.isAuthed()) {
-                        log.error("Failed to authenticate within 10 seconds using the given authentication data.");
-                    } else {
-                        log.error("Failed to connect within 10 seconds");
+            // Spin off a thread to handle doing the reconnect and error/log handling, this way the handler doesn't
+            // block the onMessage() handler in the ExtensionWebSocketListener from processing future messages
+            new Thread( () -> {
+                CompletableFuture<Boolean> success = client.connectToSource();
+                try {
+                    if ( !success.get(10, TimeUnit.SECONDS) ) {
+                        if (!client.isOpen()) {
+                            log.error("Failed to connect to server url '" + targetVantiqServer + "'.");
+                        } else if (!client.isAuthed()) {
+                            log.error("Failed to authenticate within 10 seconds using the given authentication data.");
+                        } else {
+                            log.error("Failed to connect within 10 seconds");
+                        }
+                        close();
                     }
+                } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                    log.error("Could not reconnect to source within 10 seconds: ", e);
                     close();
                 }
-            } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                log.error("Could not reconnect to source within 10 seconds: ", e);
-                close();
-            }
+            }).start();
         }
     };
 

--- a/extjsdk/LICENSE/apache-2.txt
+++ b/extjsdk/LICENSE/apache-2.txt
@@ -1,0 +1,203 @@
+
+
+                                     Apache License
+                               Version 2.0, January 2004
+                            http://www.apache.org/licenses/
+     
+       TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+     
+       1. Definitions.
+     
+          "License" shall mean the terms and conditions for use, reproduction,
+          and distribution as defined by Sections 1 through 9 of this document.
+     
+          "Licensor" shall mean the copyright owner or entity authorized by
+          the copyright owner that is granting the License.
+     
+          "Legal Entity" shall mean the union of the acting entity and all
+          other entities that control, are controlled by, or are under common
+          control with that entity. For the purposes of this definition,
+          "control" means (i) the power, direct or indirect, to cause the
+          direction or management of such entity, whether by contract or
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the
+          outstanding shares, or (iii) beneficial ownership of such entity.
+     
+          "You" (or "Your") shall mean an individual or Legal Entity
+          exercising permissions granted by this License.
+     
+          "Source" form shall mean the preferred form for making modifications,
+          including but not limited to software source code, documentation
+          source, and configuration files.
+     
+          "Object" form shall mean any form resulting from mechanical
+          transformation or translation of a Source form, including but
+          not limited to compiled object code, generated documentation,
+          and conversions to other media types.
+     
+          "Work" shall mean the work of authorship, whether in Source or
+          Object form, made available under the License, as indicated by a
+          copyright notice that is included in or attached to the work
+          (an example is provided in the Appendix below).
+     
+          "Derivative Works" shall mean any work, whether in Source or Object
+          form, that is based on (or derived from) the Work and for which the
+          editorial revisions, annotations, elaborations, or other modifications
+          represent, as a whole, an original work of authorship. For the purposes
+          of this License, Derivative Works shall not include works that remain
+          separable from, or merely link (or bind by name) to the interfaces of,
+          the Work and Derivative Works thereof.
+     
+          "Contribution" shall mean any work of authorship, including
+          the original version of the Work and any modifications or additions
+          to that Work or Derivative Works thereof, that is intentionally
+          submitted to Licensor for inclusion in the Work by the copyright owner
+          or by an individual or Legal Entity authorized to submit on behalf of
+          the copyright owner. For the purposes of this definition, "submitted"
+          means any form of electronic, verbal, or written communication sent
+          to the Licensor or its representatives, including but not limited to
+          communication on electronic mailing lists, source code control systems,
+          and issue tracking systems that are managed by, or on behalf of, the
+          Licensor for the purpose of discussing and improving the Work, but
+          excluding communication that is conspicuously marked or otherwise
+          designated in writing by the copyright owner as "Not a Contribution."
+     
+          "Contributor" shall mean Licensor and any individual or Legal Entity
+          on behalf of whom a Contribution has been received by Licensor and
+          subsequently incorporated within the Work.
+     
+       2. Grant of Copyright License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          copyright license to reproduce, prepare Derivative Works of,
+          publicly display, publicly perform, sublicense, and distribute the
+          Work and such Derivative Works in Source or Object form.
+     
+       3. Grant of Patent License. Subject to the terms and conditions of
+          this License, each Contributor hereby grants to You a perpetual,
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+          (except as stated in this section) patent license to make, have made,
+          use, offer to sell, sell, import, and otherwise transfer the Work,
+          where such license applies only to those patent claims licensable
+          by such Contributor that are necessarily infringed by their
+          Contribution(s) alone or by combination of their Contribution(s)
+          with the Work to which such Contribution(s) was submitted. If You
+          institute patent litigation against any entity (including a
+          cross-claim or counterclaim in a lawsuit) alleging that the Work
+          or a Contribution incorporated within the Work constitutes direct
+          or contributory patent infringement, then any patent licenses
+          granted to You under this License for that Work shall terminate
+          as of the date such litigation is filed.
+     
+       4. Redistribution. You may reproduce and distribute copies of the
+          Work or Derivative Works thereof in any medium, with or without
+          modifications, and in Source or Object form, provided that You
+          meet the following conditions:
+     
+          (a) You must give any other recipients of the Work or
+              Derivative Works a copy of this License; and
+     
+          (b) You must cause any modified files to carry prominent notices
+              stating that You changed the files; and
+     
+          (c) You must retain, in the Source form of any Derivative Works
+              that You distribute, all copyright, patent, trademark, and
+              attribution notices from the Source form of the Work,
+              excluding those notices that do not pertain to any part of
+              the Derivative Works; and
+     
+          (d) If the Work includes a "NOTICE" text file as part of its
+              distribution, then any Derivative Works that You distribute must
+              include a readable copy of the attribution notices contained
+              within such NOTICE file, excluding those notices that do not
+              pertain to any part of the Derivative Works, in at least one
+              of the following places: within a NOTICE text file distributed
+              as part of the Derivative Works; within the Source form or
+              documentation, if provided along with the Derivative Works; or,
+              within a display generated by the Derivative Works, if and
+              wherever such third-party notices normally appear. The contents
+              of the NOTICE file are for informational purposes only and
+              do not modify the License. You may add Your own attribution
+              notices within Derivative Works that You distribute, alongside
+              or as an addendum to the NOTICE text from the Work, provided
+              that such additional attribution notices cannot be construed
+              as modifying the License.
+     
+          You may add Your own copyright statement to Your modifications and
+          may provide additional or different license terms and conditions
+          for use, reproduction, or distribution of Your modifications, or
+          for any such Derivative Works as a whole, provided Your use,
+          reproduction, and distribution of the Work otherwise complies with
+          the conditions stated in this License.
+     
+       5. Submission of Contributions. Unless You explicitly state otherwise,
+          any Contribution intentionally submitted for inclusion in the Work
+          by You to the Licensor shall be under the terms and conditions of
+          this License, without any additional terms or conditions.
+          Notwithstanding the above, nothing herein shall supersede or modify
+          the terms of any separate license agreement you may have executed
+          with Licensor regarding such Contributions.
+     
+       6. Trademarks. This License does not grant permission to use the trade
+          names, trademarks, service marks, or product names of the Licensor,
+          except as required for reasonable and customary use in describing the
+          origin of the Work and reproducing the content of the NOTICE file.
+     
+       7. Disclaimer of Warranty. Unless required by applicable law or
+          agreed to in writing, Licensor provides the Work (and each
+          Contributor provides its Contributions) on an "AS IS" BASIS,
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+          implied, including, without limitation, any warranties or conditions
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+          PARTICULAR PURPOSE. You are solely responsible for determining the
+          appropriateness of using or redistributing the Work and assume any
+          risks associated with Your exercise of permissions under this License.
+     
+       8. Limitation of Liability. In no event and under no legal theory,
+          whether in tort (including negligence), contract, or otherwise,
+          unless required by applicable law (such as deliberate and grossly
+          negligent acts) or agreed to in writing, shall any Contributor be
+          liable to You for damages, including any direct, indirect, special,
+          incidental, or consequential damages of any character arising as a
+          result of this License or out of the use or inability to use the
+          Work (including but not limited to damages for loss of goodwill,
+          work stoppage, computer failure or malfunction, or any and all
+          other commercial damages or losses), even if such Contributor
+          has been advised of the possibility of such damages.
+     
+       9. Accepting Warranty or Additional Liability. While redistributing
+          the Work or Derivative Works thereof, You may choose to offer,
+          and charge a fee for, acceptance of support, warranty, indemnity,
+          or other liability obligations and/or rights consistent with this
+          License. However, in accepting such obligations, You may act only
+          on Your own behalf and on Your sole responsibility, not on behalf
+          of any other Contributor, and only if You agree to indemnify,
+          defend, and hold each Contributor harmless for any liability
+          incurred by, or claims asserted against, such Contributor by reason
+          of your accepting any such warranty or additional liability.
+     
+       END OF TERMS AND CONDITIONS
+     
+       APPENDIX: How to apply the Apache License to your work.
+     
+          To apply the Apache License to your work, attach the following
+          boilerplate notice, with the fields enclosed by brackets "[]"
+          replaced with your own identifying information. (Don't include
+          the brackets!)  The text should be enclosed in the appropriate
+          comment syntax for the file format. We also recommend that a
+          file or class name and description of purpose be included on the
+          same "printed page" as the copyright notice for easier
+          identification within third-party archives.
+     
+       Copyright [yyyy] [name of copyright owner]
+     
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+     
+           http://www.apache.org/licenses/LICENSE-2.0
+     
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.

--- a/extjsdk/README.md
+++ b/extjsdk/README.md
@@ -154,6 +154,14 @@ Query errors are sent when a Query cannot be completed successfully. To send a Q
 *	The parameters are an Object array of that will be translated into strings and inserted into the message template
     based anywhere that `{<array index>}` is located.
 
+#### Sending Messages when Vantiq connection drops
+Over the lifetime of a connector, it is possible for the connection between itself and the Vantiq server to drop or get 
+restarted at any point. This can be the result of normal network connectivity issues, or can be initiated by the Vantiq 
+server (if, for example, the connector's source configuration is modified, which would trigger a reconnect). In these 
+circumstances, the SDK will queue up any messages that would have failed to send while waiting for the connection to get
+reestablished. Once the connection is back up and running, the queue of messages will be flushed and sent to Vantiq. The
+queue will only hold onto 25 such messages to avoid filling up memory if the connection is down for an extended period.
+
 
 ### <a name="handler" id="handler"></a>Receiving Messages
 All messages received from the Vantiq server are dealt with using handlers attached to the ExtensionWebSocketListener,

--- a/extjsdk/README.md
+++ b/extjsdk/README.md
@@ -156,11 +156,12 @@ Query errors are sent when a Query cannot be completed successfully. To send a Q
 
 #### Sending Messages when Vantiq connection drops
 Over the lifetime of a connector, it is possible for the connection between itself and the Vantiq server to drop or get 
-restarted at any point. This can be the result of normal network connectivity issues, or can be initiated by the Vantiq 
-server (if, for example, the connector's source configuration is modified, which would trigger a reconnect). In these 
-circumstances, the SDK will queue up any messages that would have failed to send while waiting for the connection to get
-reestablished. Once the connection is back up and running, the queue of messages will be flushed and sent to Vantiq. The
-queue will only hold onto 25 such messages to avoid filling up memory if the connection is down for an extended period.
+restarted at any point because of normal network connectivity issues. In addition, the Vantiq server may request a 
+reconnection from the connector using the same websocket session, as is the case when the connector's source 
+configuration is modified. In these circumstances, the SDK will queue up any messages that would have failed to send 
+while waiting for the connection to get reestablished. Once the connection is back up and running, the queue of messages 
+will be flushed and sent to Vantiq. The queue will only hold onto 25 such messages to avoid filling up memory if the 
+connection is down for an extended period.
 
 
 ### <a name="handler" id="handler"></a>Receiving Messages

--- a/extjsdk/build.gradle
+++ b/extjsdk/build.gradle
@@ -81,6 +81,9 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     // Used for uploading documents (images) to VANTIQ with VANTIQ SDK
     testCompile 'io.vantiq:vantiq-sdk:1.0.24'
+
+    // Used to create EvictingQueue for failed messages queue
+    implementation 'com.google.guava:guava:23.0'
 }
 
 // Create a jar with all dependencies included

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -552,6 +552,10 @@ public class ExtensionWebSocketClient {
         return sourceFuture;
     }
 
+    /**
+     * Method called by reconnectHandlers that actually does the reconnect work.
+     * @return  Returns boolean completable indicating if the reconnect was successful, used by the caller
+     */
     public CompletableFuture<Boolean> doCoreReconnect() {
         return CompletableFuture.supplyAsync(() -> {
             CompletableFuture<Boolean> success = connectToSource();

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -260,7 +260,6 @@ public class ExtensionWebSocketClient {
         if (data != null && (data.getClass().isArray() || data instanceof List)) {
             throw new IllegalArgumentException("Notifications cannot be lists or arrays.");
         }
-//        if (isConnected()) {
         Map<String,Object> m = new LinkedHashMap<>();
         m.put("op", ExtensionServiceMessage.OP_NOTIFICATION);
         m.put("resourceId", sourceName);
@@ -282,7 +281,6 @@ public class ExtensionWebSocketClient {
         } else {
             failedMessageQueue.add(msg);
         }
-//        }
     }
 
     /**

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
@@ -392,6 +392,10 @@ public class ExtensionWebSocketListener implements WebSocketListener{
 
                     client.sourceFuture.complete(true);
                     log.info("Successful connection to {}", msg.get("resourceId").toString());
+
+                    // Since we've connected successfully, we'll flush the queue if there was anything left behind after
+                    // a dropped connection
+                    client.flushQueue();
                 }
                 if (this.configHandler != null) {
                     try {

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
@@ -159,8 +159,10 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase{
         Map<String, Object> queryData = new LinkedHashMap<>();
         queryData.put("msg", "val");
         queryData.put("val", "msg");
-        
-        client.webSocketFuture = CompletableFuture.completedFuture(true);
+
+        markWsConnected(true);
+        markAuthSuccess(true);
+        markSourceConnected(true);
         client.sendQueryResponse(200, queryAddress, queryData);
         
         assert socket.compareData("body", queryData);
@@ -177,8 +179,10 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase{
         queryData[1] = new LinkedHashMap<>();
         queryData[1].put("message", "value");
         queryData[1].put("value", "message");
-        
+
         markWsConnected(true);
+        markAuthSuccess(true);
+        markSourceConnected(true);
         client.sendQueryResponse(200, queryAddress, queryData);
         
         // The ArrayList creation is necessary since JSON interprets arrays as ArrayList
@@ -194,6 +198,8 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase{
         String errorCode = "io.vantiq.extjsdk.ExampleErrorName";
         
         markWsConnected(true);
+        markAuthSuccess(true);
+        markSourceConnected(true);
         client.sendQueryError(queryAddress, errorCode, errorMessage, params);
         
         assert socket.compareData("headers." + ExtensionServiceMessage.RESPONSE_ADDRESS_HEADER, queryAddress);

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
@@ -326,7 +326,73 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase{
             // Expected
         } // Other invalid exceptions will escape & cause failure.
     }
-    
+
+    @Test
+    public void testFailedMessageQueue() {
+        // Setup a client and listener and mark things "connected"
+        FalseClient newClient = new FalseClient(srcName);
+        TestListener testListener = new TestListener(newClient);
+        newClient.listener = testListener;
+
+        newClient.initiateWebsocketConnection("unused");
+        newClient.authenticate("");
+        newClient.connectToSource();
+
+        markSourceConnected(true);
+        Map<String,Object> m = new LinkedHashMap<>();
+        m.put("msg", "str");
+
+        // Now break the connection, and while it's down lets try to send a notification
+        newClient.close();
+        assert !newClient.isOpen();
+        assert !newClient.isAuthed();
+        assert !newClient.isConnected();
+
+        // We should see it get put in the queue
+        newClient.sendNotification(m);
+        assert newClient.failedMessageQueue.size() == 1;
+
+        // Upon a "reconnection" (here we're just forcing the issue by sending a connectExtension message), we should
+        // see that the queue was flushed
+        newClient.webSocketFuture = CompletableFuture.completedFuture(true);
+        newClient.authFuture = CompletableFuture.completedFuture(true);
+        newClient.sourceFuture = CompletableFuture.completedFuture(false);
+        newClient.listener.onMessage(testListener.createConfigResponse(new LinkedHashMap<>(), srcName));
+        assert newClient.failedMessageQueue.size() == 0;
+
+        // Now lets do the same thing with a query
+        newClient.close();
+        assert !newClient.isOpen();
+        assert !newClient.isAuthed();
+        assert !newClient.isConnected();
+
+        Map<String, Object> queryData = new LinkedHashMap<>();
+        queryData.put("msg", "val");
+        queryData.put("val", "msg");
+        newClient.sendQueryResponse(200, queryAddress, queryData);
+        assert newClient.failedMessageQueue.size() == 1;
+
+        newClient.webSocketFuture = CompletableFuture.completedFuture(true);
+        newClient.authFuture = CompletableFuture.completedFuture(true);
+        newClient.sourceFuture = CompletableFuture.completedFuture(false);
+        newClient.listener.onMessage(testListener.createConfigResponse(new LinkedHashMap<>(), srcName));
+        assert newClient.failedMessageQueue.size() == 0;
+    }
+
+    @Test
+    public void testReconnect() {
+        client.webSocketFuture = CompletableFuture.completedFuture(true);
+        client.authFuture = CompletableFuture.completedFuture(true);
+
+        client.doCoreReconnect();
+        // Wait up to 5 seconds for asynchronous action to complete
+        waitUntilTrue(5 * 1000, () -> socket.receivedMessage());
+
+        assert socket.compareData("op", ExtensionServiceMessage.OP_CONNECT_EXTENSION);
+        assert socket.compareData("resourceName", ExtensionServiceMessage.RESOURCE_NAME_SOURCES);
+        assert socket.compareData("resourceId", srcName);
+    }
+
 // ============================== Helper functions ==============================
     private void markWsConnected(boolean success) {
         client.webSocketFuture = CompletableFuture.completedFuture(success);

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
@@ -74,7 +74,9 @@ public class JDBCCore {
             // Do connector-specific stuff here
             jdbcConfigHandler.configComplete = false;
 
-            // Boiler-plate reconnect method, if reconnect fails then we call close()
+            // Boiler-plate reconnect method- if reconnect fails then we call close(). The code in this reconnect
+            // handler must finish executing before we can process another message from Vantiq, meaning the
+            // reconnectResult will not complete until after we have exited the handler.
             CompletableFuture<Boolean> reconnectResult = client.doCoreReconnect();
             reconnectResult.thenAccept(success -> {
                 if (!success) {

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
@@ -70,29 +70,17 @@ public class JDBCCore {
                 pollTimer.cancel();
                 pollTimer = null;
             }
-            
+
+            // Do connector-specific stuff here
             jdbcConfigHandler.configComplete = false;
 
-            // Spin off a thread to handle doing the reconnect and error/log handling, this way the handler doesn't
-            // block the onMessage() handler in the ExtensionWebSocketListener from processing future messages
-            new Thread( () -> {
-                CompletableFuture<Boolean> success = client.connectToSource();
-                try {
-                    if ( !success.get(10, TimeUnit.SECONDS) ) {
-                        if (!client.isOpen()) {
-                            log.error("Failed to connect to server url '" + targetVantiqServer + "'.");
-                        } else if (!client.isAuthed()) {
-                            log.error("Failed to authenticate within 10 seconds using the given authentication data.");
-                        } else {
-                            log.error("Failed to connect within 10 seconds");
-                        }
-                        close();
-                    }
-                } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                    log.error("Could not reconnect to source within 10 seconds: ", e);
+            // Boiler-plate reconnect method, if reconnect fails then we call close()
+            CompletableFuture<Boolean> reconnectResult = client.doCoreReconnect();
+            reconnectResult.thenAccept(success -> {
+                if (!success) {
                     close();
                 }
-            }).start();
+            });
         }
     };
     

--- a/jmsSource/src/main/java/io/vantiq/extsrc/jmsSource/JMSCore.java
+++ b/jmsSource/src/main/java/io/vantiq/extsrc/jmsSource/JMSCore.java
@@ -64,28 +64,16 @@ public class JMSCore {
         public void handleMessage(ExtensionServiceMessage message) {
             log.trace("Reconnect message received. Reinitializing configuration");
 
+            // Do connector-specific stuff here
             jmsConfigHandler.configComplete = false;
 
-            // Spin off a thread to handle doing the reconnect and error/log handling, this way the handler doesn't
-            // block the onMessage() handler in the ExtensionWebSocketListener from processing future messages
-            new Thread( () -> {
-                CompletableFuture<Boolean> success = client.connectToSource();
-                try {
-                    if ( !success.get(10, TimeUnit.SECONDS) ) {
-                        if (!client.isOpen()) {
-                            log.error("Failed to connect to server url '" + targetVantiqServer + "'.");
-                        } else if (!client.isAuthed()) {
-                            log.error("Failed to authenticate within 10 seconds using the given authentication data.");
-                        } else {
-                            log.error("Failed to connect within 10 seconds");
-                        }
-                        close();
-                    }
-                } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                    log.error("Could not reconnect to source within 10 seconds: ", e);
+            // Boiler-plate reconnect method, if reconnect fails then we call close()
+            CompletableFuture<Boolean> reconnectResult = client.doCoreReconnect();
+            reconnectResult.thenAccept(success -> {
+                if (!success) {
                     close();
                 }
-            }).start();
+            });
         }
     };
 

--- a/jmsSource/src/main/java/io/vantiq/extsrc/jmsSource/JMSCore.java
+++ b/jmsSource/src/main/java/io/vantiq/extsrc/jmsSource/JMSCore.java
@@ -67,7 +67,9 @@ public class JMSCore {
             // Do connector-specific stuff here
             jmsConfigHandler.configComplete = false;
 
-            // Boiler-plate reconnect method, if reconnect fails then we call close()
+            // Boiler-plate reconnect method- if reconnect fails then we call close(). The code in this reconnect
+            // handler must finish executing before we can process another message from Vantiq, meaning the
+            // reconnectResult will not complete until after we have exited the handler.
             CompletableFuture<Boolean> reconnectResult = client.doCoreReconnect();
             reconnectResult.thenAccept(success -> {
                 if (!success) {

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -102,7 +102,9 @@ public class ObjectRecognitionCore {
             // Do connector-specific stuff here
             objRecConfigHandler.configComplete = false;
 
-            // Boiler-plate reconnect method, if reconnect fails then we call close()
+            // Boiler-plate reconnect method- if reconnect fails then we call close(). The code in this reconnect
+            // handler must finish executing before we can process another message from Vantiq, meaning the
+            // reconnectResult will not complete until after we have exited the handler.
             CompletableFuture<Boolean> reconnectResult = client.doCoreReconnect();
             reconnectResult.thenAccept(success -> {
                 if (!success) {

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -100,20 +100,27 @@ public class ObjectRecognitionCore {
             }
             
             objRecConfigHandler.configComplete = false;
-            
-            client.setQueryHandler(defaultQueryHandler);
-            
-            CompletableFuture<Boolean> success = client.connectToSource();
-            
-            try {
-                if ( !success.get(10, TimeUnit.SECONDS) ) {
-                    log.error("Source reconnection failed");
+
+            // Spin off a thread to handle doing the reconnect and error/log handling, this way the handler doesn't
+            // block the onMessage() handler in the ExtensionWebSocketListener from processing future messages
+            new Thread( () -> {
+                CompletableFuture<Boolean> success = client.connectToSource();
+                try {
+                    if ( !success.get(10, TimeUnit.SECONDS) ) {
+                        if (!client.isOpen()) {
+                            log.error("Failed to connect to server url '" + targetVantiqServer + "'.");
+                        } else if (!client.isAuthed()) {
+                            log.error("Failed to authenticate within 10 seconds using the given authentication data.");
+                        } else {
+                            log.error("Failed to connect within 10 seconds");
+                        }
+                        close();
+                    }
+                } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                    log.error("Could not reconnect to source within 10 seconds: ", e);
                     close();
                 }
-            } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                log.error("Could not reconnect to source within 10 seconds");
-                close();
-            }
+            }).start();
         }
     };
 

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -98,29 +98,17 @@ public class ObjectRecognitionCore {
                 pollTimer.cancel();
                 pollTimer = null;
             }
-            
+
+            // Do connector-specific stuff here
             objRecConfigHandler.configComplete = false;
 
-            // Spin off a thread to handle doing the reconnect and error/log handling, this way the handler doesn't
-            // block the onMessage() handler in the ExtensionWebSocketListener from processing future messages
-            new Thread( () -> {
-                CompletableFuture<Boolean> success = client.connectToSource();
-                try {
-                    if ( !success.get(10, TimeUnit.SECONDS) ) {
-                        if (!client.isOpen()) {
-                            log.error("Failed to connect to server url '" + targetVantiqServer + "'.");
-                        } else if (!client.isAuthed()) {
-                            log.error("Failed to authenticate within 10 seconds using the given authentication data.");
-                        } else {
-                            log.error("Failed to connect within 10 seconds");
-                        }
-                        close();
-                    }
-                } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                    log.error("Could not reconnect to source within 10 seconds: ", e);
+            // Boiler-plate reconnect method, if reconnect fails then we call close()
+            CompletableFuture<Boolean> reconnectResult = client.doCoreReconnect();
+            reconnectResult.thenAccept(success -> {
+                if (!success) {
                     close();
                 }
-            }).start();
+            });
         }
     };
 

--- a/udpSource/src/main/java/io/vantiq/extsrc/udp/ConfigurableUDPSource.java
+++ b/udpSource/src/main/java/io/vantiq/extsrc/udp/ConfigurableUDPSource.java
@@ -151,7 +151,9 @@ public class ConfigurableUDPSource {
             
             ExtensionWebSocketClient client = clients.get(message.getSourceName());
 
-            // Boiler-plate reconnect method, if reconnect fails then we call close()
+            // Boiler-plate reconnect method- if reconnect fails then we call close(). The code in this reconnect
+            // handler must finish executing before we can process another message from Vantiq, meaning the
+            // reconnectResult will not complete until after we have exited the handler.
             client.doCoreReconnect();
         }
         

--- a/udpSource/src/main/java/io/vantiq/extsrc/udp/ConfigurableUDPSource.java
+++ b/udpSource/src/main/java/io/vantiq/extsrc/udp/ConfigurableUDPSource.java
@@ -151,24 +151,8 @@ public class ConfigurableUDPSource {
             
             ExtensionWebSocketClient client = clients.get(message.getSourceName());
 
-            // Spin off a thread to handle doing the reconnect and error/log handling, this way the handler doesn't
-            // block the onMessage() handler in the ExtensionWebSocketListener from processing future messages
-            new Thread( () -> {
-                CompletableFuture<Boolean> success = client.connectToSource();
-                try {
-                    if ( !success.get(10, TimeUnit.SECONDS) ) {
-                        if (!client.isOpen()) {
-                            log.error("Failed to connect to server url '" + targetVantiqServer + "'.");
-                        } else if (!client.isAuthed()) {
-                            log.error("Failed to authenticate within 10 seconds using the given authentication data.");
-                        } else {
-                            log.error("Failed to connect within 10 seconds");
-                        }
-                    }
-                } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                    log.error("Could not reconnect to source within 10 seconds: ", e);
-                }
-            }).start();
+            // Boiler-plate reconnect method, if reconnect fails then we call close()
+            client.doCoreReconnect();
         }
         
     };


### PR DESCRIPTION
Closes #222 

Fixes a bug in many of the connector's reconnectHandlers that threw an unnecessary TimeoutException. Also adds an enhancement that allows the SDK to queue up messages that would have failed to send while the connection between connector<--->Vantiq is down. The SDK now queues up these messages (up to the 25 most recent), and then sends them after a successful reconnection. 