### PR TITLE
Handling missing or extra slashes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,17 +78,11 @@ subprojects {
     dcompose {
         if (rootProject.hasProperty('dockerRegistry') && rootProject.hasProperty('pathToRepo')) {
             def registryName = rootProject.getProperty('dockerRegistry')
-            registryName = registryName.endsWith('/') ? registryName - '/': registryName
-
             def pathToRepo = rootProject.getProperty('pathToRepo')
-            pathToRepo = pathToRepo.startsWith('/') ? pathToRepo : '/' + pathToRepo
-            pathToRepo = pathToRepo.endsWith('/') ? pathToRepo : pathToRepo + '/'
-
             def repositoryName = "${project.name - 'Source' + '-source'}".toLowerCase()
             if (rootProject.hasProperty('repositoryName')) {
                 repositoryName = rootProject.getProperty('repositoryName')
             }
-            repositoryName = repositoryName.startsWith('/') ? repositoryName - '/' : repositoryName
 
             connector {
                 buildFiles = project.copySpec {
@@ -100,7 +94,8 @@ subprojects {
                     }
                 }
 
-                def repositoryBase = registryName + pathToRepo + repositoryName
+                def repositoryBase = registryName + '/' + pathToRepo + '/' + repositoryName
+                repositoryBase = repositoryBase.replace('//', '/')
                 repository = rootProject.hasProperty('imageTag') ? repositoryBase + ":${rootProject.getProperty('imageTag')}" : repositoryBase
                 logBuildStatus = true
                 buildLogFile = file("$buildDir/dockerBuildLog.txt")

--- a/build.gradle
+++ b/build.gradle
@@ -78,12 +78,17 @@ subprojects {
     dcompose {
         if (rootProject.hasProperty('dockerRegistry') && rootProject.hasProperty('pathToRepo')) {
             def registryName = rootProject.getProperty('dockerRegistry')
+            registryName = registryName.endsWith('/') ? registryName - '/': registryName
+
             def pathToRepo = rootProject.getProperty('pathToRepo')
+            pathToRepo = pathToRepo.startsWith('/') ? pathToRepo : '/' + pathToRepo
+            pathToRepo = pathToRepo.endsWith('/') ? pathToRepo : pathToRepo + '/'
 
             def repositoryName = "${project.name - 'Source' + '-source'}".toLowerCase()
             if (rootProject.hasProperty('repositoryName')) {
                 repositoryName = rootProject.getProperty('repositoryName')
             }
+            repositoryName = repositoryName.startsWith('/') ? repositoryName - '/' : repositoryName
 
             connector {
                 buildFiles = project.copySpec {
@@ -95,10 +100,8 @@ subprojects {
                     }
                 }
 
-                repository = registryName + pathToRepo + repositoryName
-                if (rootProject.hasProperty('imageTag')) {
-                    repository += rootProject.getProperty('imageTag')
-                }
+                def repositoryBase = registryName + pathToRepo + repositoryName
+                repository = rootProject.hasProperty('imageTag') ? repositoryBase + ":${rootProject.getProperty('imageTag')}" : repositoryBase
                 logBuildStatus = true
                 buildLogFile = file("$buildDir/dockerBuildLog.txt")
             }


### PR DESCRIPTION
Closes #231 

Add some protection to make sure that the full `registry/namespace/repository:tag` structure is built correctly. Makes sure that there are slashes in the appropriate spots.

Also tweaked the tag mechanism to make sure it actually works, the old way wasn't really working.