### PR TITLE
Skip buildConnectorImage dependency when the task has not been created.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,9 @@ subprojects {
             }
         }
     }
-    buildConnectorImage.dependsOn assemble
+    if (project.tasks.findByName('buildConnectorImage')) {
+        buildConnectorImage.dependsOn assemble
+    }
 
     // only run with code-coverage metrics if property is explicitly specified
     if (rootProject.hasProperty('jacocoReport')) {


### PR DESCRIPTION
Fixes #234

This happens if the properties `dockerRegistry` and  `pathToRepo` are
missing.  This may often be the case when you are not intending to
or currently publishing.