### PR TITLE
Checks that semaphore is non-null before releasing

### DIFF
--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -275,15 +275,16 @@ public class ExtensionWebSocketClient {
         ExtensionServiceMessage msg = new ExtensionServiceMessage("");
         msg.fromMap(m);
         if (isConnected()) {
+            Semaphore localOutstandingNotifications = outstandingNotifications;
             try {
-                outstandingNotifications.acquire();
+                localOutstandingNotifications.acquire();
                 this.send(msg);
             } catch (InterruptedException ie) {
                 log.warn("Obtaining space to sent notifications was interrupted.", ie);
             } catch (Exception e) {
                 // If we get an exception during the send, we're unlikely to get a response so release now.
-                if (outstandingNotifications != null) {
-                    outstandingNotifications.release();
+                if (localOutstandingNotifications != null) {
+                    localOutstandingNotifications.release();
                 }
                 throw e;
             }
@@ -300,8 +301,9 @@ public class ExtensionWebSocketClient {
      * receipt of a response message.
      */
     void acknowledgeNotification() {
-        if (outstandingNotifications != null) {
-            outstandingNotifications.release();
+        Semaphore localOutstandingNotifications = outstandingNotifications;
+        if (localOutstandingNotifications != null) {
+            localOutstandingNotifications.release();
         }
     }
 

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -282,7 +282,9 @@ public class ExtensionWebSocketClient {
                 log.warn("Obtaining space to sent notifications was interrupted.", ie);
             } catch (Exception e) {
                 // If we get an exception during the send, we're unlikely to get a response so release now.
-                outstandingNotifications.release();
+                if (outstandingNotifications != null) {
+                    outstandingNotifications.release();
+                }
                 throw e;
             }
         } else {
@@ -298,7 +300,9 @@ public class ExtensionWebSocketClient {
      * receipt of a response message.
      */
     void acknowledgeNotification() {
-        outstandingNotifications.release();
+        if (outstandingNotifications != null) {
+            outstandingNotifications.release();
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #242 

Adds checks to make sure the semaphore is non-null before trying to release. This was causing some issues for reconnect/close handlers, particularly when the `ExtensionWebSocketListener` called `client.acknowledgeNotification()`.