### PR TITLE
Removing model-copying from the Object Recognition Connector's Dockerfile

### DIFF
--- a/objectRecognitionSource/src/main/docker/Dockerfile
+++ b/objectRecognitionSource/src/main/docker/Dockerfile
@@ -1,9 +1,5 @@
 FROM openjdk:11-jre-slim
 RUN mkdir /app
-RUN mkdir /app/models
 ADD objectRecognitionSource.tar /app
-ADD *.meta /app/models/
-ADD *.pb /app/models/
-ADD *.names /app/models/
 WORKDIR /app
 ENTRYPOINT ["./objectRecognitionSource/bin/objectRecognitionSource"]


### PR DESCRIPTION
Closes #247 

Removing Dockerfile commands originally intended to copy .meta/.pb/.labels files downloaded by the `copyModels` task. Since the `buildConnectorImage` task isn't currently configured to depend on the `copyModels` task, we get an error when building the objectRec image.

In any case, it makes more sense to not include any model files by default and encourage the developer to use the `connectorSpecificInclusions` gradle property instead.