### PR TITLE
Adding reference to our K8s docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,3 +414,10 @@ Or, you can just run the following task:
 ./gradlew jdbcSource:pushImages
 ```
 *   **NOTE:** Same note as the one above.
+
+### Deploying the connector images in the Vantiq IDE
+
+Once you have built and published the docker image for a given connector (as described above), you can then deploy it 
+into a Kubernetes Cluster directly from the Vantiq IDE. This process is described in its entirety 
+[here](https://dev.vantiq.com/docs/system/extlifecycle/index.html), including both the prerequisite Kubernetes Cluster 
+setup, and an example that deploys the JDBC Connector.


### PR DESCRIPTION
Closes #250 

After describing the docker image build/publish process, we include a short blurb to point users to the documentation that explains how to deploy the connectors from the Vantiq IDE.

Will wait to merge this until after (or just before) 1.31 is released on dev.