### PR TITLE
Adds handling for K8s Readiness/Liveness TCP Probe

### DIFF
--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -16,7 +16,6 @@ package io.vantiq.extjsdk;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 // WebSocket imports
-import groovy.json.internal.IO;
 import okhttp3.*;
 import okhttp3.ws.WebSocket;
 import okhttp3.ws.WebSocketCall;
@@ -205,7 +204,7 @@ public class ExtensionWebSocketClient {
      * readiness/liveness probe.
      */
     @SuppressWarnings("InfiniteLoopStatement")
-    synchronized public void declareHealthy() {
+    public synchronized void declareHealthy() {
         // Only reinitialize things if we have to, otherwise we just leave things running
         if (probeFuture != null && livenessSocket != null && !livenessSocket.isClosed()) {
             return;

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -20,6 +20,8 @@ import okhttp3.*;
 import okhttp3.ws.WebSocket;
 import okhttp3.ws.WebSocketCall;
 
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -41,73 +43,109 @@ public class ExtensionWebSocketClient {
     /**
      * The code for a query response where more data will be sent.
      */
-    public static final int QUERY_CHUNK_CODE    = 100;
+    public static final int QUERY_CHUNK_CODE = 100;
+
     /**
      * The code for a query response where data is sent and no more is coming.
      */
-    public static final int QUERY_DATA_CODE     = 200;
+    public static final int QUERY_DATA_CODE = 200;
+
     /**
      * The code for a query response where no data is sent and no more is coming.
      */
-    public static final int QUERY_NODATA_CODE   = 204;
+    public static final int QUERY_NODATA_CODE = 204;
+
+    /**
+     * The default port value to run the TCP Probe Server Socket.
+     */
+    public static final int DEFAULT_TCP_PROBE_PORT = 8000;
+
     /**
      * The default max queue size of the failedMessageQueue
      */
     private static final int DEFAULT_FAILED_MESSAGE_QUEUE_SIZE = 25;
+
     /**
      * The env var used to overwrite default queue size
      */
     private static final String FAILED_MESAGE_QUEUE_SIZE = "FAILED_MESSAGE_QUEUE_SIZE";
+
     /**
      * An {@link ObjectMapper} used to transform objects into JSON before sending
      */
     private ObjectMapper mapper = new ObjectMapper();
+
     /**
      * The WebSocket used to talk to the Vantiq deployment. null when no connection is established
      */
     WebSocket webSocket = null;
-    
+
+    /**
+     * The semaphore used to manage sending source notifications back to Vantiq.
+     */
     Semaphore outstandingNotifications = null;
+
     /**
      * The name of the source this client is connected to.
      */
     private String sourceName;
+
     /**
      * An Slf4j logger
      */
     private final Logger log;
+
     /**
      * The listener that receives and interprets responses from the Vantiq deployment for this client's connection.
      */
     ExtensionWebSocketListener listener;
+
     /**
      * A {@link CompletableFuture} that will return true when connected over a websocket, and false when the connection
      * is closed or has failed
      */
     CompletableFuture<Boolean> webSocketFuture;
+
     /**
      * A {@link CompletableFuture} that will return true when authenticated with Vantiq, and false when the WebSocket
      * connection is closed or has failed
      */
     CompletableFuture<Boolean> authFuture;
+
     /**
      * A {@link CompletableFuture} that will return true when connected to source {@code sourceName}, and false when the
      * WebSocket connection is closed or has failed
      */
     CompletableFuture<Boolean> sourceFuture;
+
+    /**
+     * A {@link CompletableFuture} that actively listens for incoming TCP messages on the specified port. This functions
+     * as the readiness/liveness checks configured through K8s.
+     */
+    CompletableFuture<Void> probeFuture;
+
+    /**
+     * The Server Socket used to connect to the specified port and listen for inbound TCP messages sent by K8s. These
+     * messages function as readiness/liveness checks.
+     */
+    ServerSocket serverSocket = null;
+
     /**
      * Whether it should automatically send a connection message after receiving a reconnect message
      */
     boolean autoReconnect = false;
+
     /**
      * The data to be used for authentication. This will be either a {@link String} containing an authentication token or
      * a {@link Map} containing the username and password.
      */
     Object authData;
+
     /**
      * An {@link Handler} that is called when the websocket connection is closed
      */
     Handler<ExtensionWebSocketClient> closeHandler;
+
     /**
      * A {@link Queue} that is used as an internal queue to store messages that failed to send to Vantiq because
      * of a dropped connection. Once a reconnect is successful, the queued messages will be resent.
@@ -159,6 +197,54 @@ public class ExtensionWebSocketClient {
         } else {
             failedMessageQueue = EvictingQueue.create(failedMessageQueueSize);
         }
+    }
+
+    /**
+     * Initializes the Server Socket and probeFuture to actively listen for incoming TCP messages from the K8s
+     * readiness/liveness probe.
+     */
+    @SuppressWarnings("InfiniteLoopStatement")
+    public void initializeTCPProbeListener() throws Exception {
+        Integer port = Utils.obtainTCPProbePort();
+        if (port == null) {
+            port = DEFAULT_TCP_PROBE_PORT;
+        }
+
+        if (probeFuture == null && serverSocket == null) {
+            serverSocket = new ServerSocket(port);
+            probeFuture = CompletableFuture.runAsync(() -> {
+                while (true) {
+                    try {
+                        serverSocket.accept();
+                    } catch (IOException e){
+                        log.error("An error occurred while attempting to listen for TCP Probe messages.", e);
+                    }
+                }
+            });
+        } else {
+            throw new RuntimeException("Error occurred when trying to initialize the TCP Probe Listener. A listener" +
+                    " already exists, that one must be cancelled before a new one can be initialized.");
+        }
+    }
+
+    /**
+     * Cancels the probeFuture, and sets it to null. This kills the ServerSocket, which will indicate to K8s that the
+     * connector is not ready/healthy.
+     */
+    public void cancelTCPProbeListener() {
+        // First we cancel the probeFuture and nullify it
+        probeFuture.cancel(true);
+        probeFuture = null;
+
+        // Then we close the ServerSocket and nullify it
+        if (!serverSocket.isClosed()) {
+            try {
+                serverSocket.close();
+            } catch (IOException e) {
+                log.error("An error occurred when trying to close the Server Socket.", e);
+            }
+        }
+        serverSocket = null;
     }
 
     /**

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -248,6 +248,13 @@ public class ExtensionWebSocketClient {
     }
 
     /**
+     * Returns the probeFuture
+     */
+    public CompletableFuture getTCPProbeListenerFuture() {
+        return probeFuture;
+    }
+
+    /**
      * Attempts to connect to the source using the given target url and authentication token. If the connection fails, 
      * {@link #isOpen}, {@link #isAuthed}, and {@link #isConnected} can be used to identify if the connection failed
      * or succeeded at the WebSocket, authentication attempt, and source, respectively. This function may be called

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -122,7 +122,7 @@ public class ExtensionWebSocketClient {
      * A {@link CompletableFuture} that actively listens for incoming TCP messages on the specified port. This functions
      * as the readiness/liveness checks configured through K8s.
      */
-    CompletableFuture<Void> probeFuture;
+    private CompletableFuture<Void> probeFuture;
 
     /**
      * The Server Socket used to connect to the specified port and listen for inbound TCP messages sent by K8s. These
@@ -258,7 +258,9 @@ public class ExtensionWebSocketClient {
      * Returns the probeFuture
      */
     public boolean isMarkedHealthy() {
-        return probeFuture != null && livenessSocket != null && !livenessSocket.isClosed();
+        CompletableFuture<Void> localProbeFuture = probeFuture;
+        ServerSocket localLivenessSocket = livenessSocket;
+        return localProbeFuture != null && localLivenessSocket != null && !localLivenessSocket.isClosed();
     }
 
     /**

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -216,7 +216,7 @@ public class ExtensionWebSocketClient {
                 while (true) {
                     try {
                         serverSocket.accept();
-                    } catch (IOException e){
+                    } catch (IOException e) {
                         log.error("An error occurred while attempting to listen for TCP Probe messages.", e);
                     }
                 }

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
@@ -49,4 +49,27 @@ public class Utils {
 
         return properties;
     }
+
+    /**
+     * Helper method used to
+     * @return An Integer for the port value provided in the server.config file, or null if non was specified.
+     * @throws Exception
+     */
+    public static Integer obtainTCPProbePort() throws Exception {
+        File configFile = new File(SERVER_CONFIG_DIR, SERVER_CONFIG_FILENAME);
+        Properties properties = new Properties();
+        if (!configFile.exists()) {
+            configFile = new File(SERVER_CONFIG_FILENAME);
+            if (!configFile.exists()) {
+                return null;
+            }
+        }
+        properties.load(new FileReader(configFile));
+        String portString = properties.getProperty("tcpProbePort");
+        if (portString != null) {
+            return new Integer(portString);
+        } else {
+            return null;
+        }
+    }
 }

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
@@ -6,7 +6,8 @@ import java.io.IOException;
 import java.util.Properties;
 
 public class Utils {
-    
+
+    public static String PORT_PROPERTY_NAME = "tcpProbePort";
     public static String SERVER_CONFIG_DIR = "serverConfig";
     public static String SERVER_CONFIG_FILENAME = "server.config";
     public static String SECRET_CREDENTIALS = "CONNECTOR_AUTH_TOKEN";
@@ -65,9 +66,9 @@ public class Utils {
             }
         }
         properties.load(new FileReader(configFile));
-        String portString = properties.getProperty("tcpProbePort");
+        String portString = properties.getProperty(PORT_PROPERTY_NAME);
         if (portString != null) {
-            return new Integer(portString);
+            return Integer.valueOf(portString);
         } else {
             return null;
         }

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
@@ -10,10 +10,10 @@ import java.util.Properties;
 
 public class Utils {
 
-    public static String PORT_PROPERTY_NAME = "tcpProbePort";
-    public static String SERVER_CONFIG_DIR = "serverConfig";
-    public static String SERVER_CONFIG_FILENAME = "server.config";
-    public static String SECRET_CREDENTIALS = "CONNECTOR_AUTH_TOKEN";
+    public static final String PORT_PROPERTY_NAME = "tcpProbePort";
+    public static final String SERVER_CONFIG_DIR = "serverConfig";
+    public static final String SERVER_CONFIG_FILENAME = "server.config";
+    public static final String SECRET_CREDENTIALS = "CONNECTOR_AUTH_TOKEN";
 
     private static final Logger log = LoggerFactory.getLogger(Utils.class);
 

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
@@ -393,6 +393,54 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase{
         assert socket.compareData("resourceId", srcName);
     }
 
+    @Test
+    public void testTCPProbeListener() {
+        // Setup a client and listener and mark things "connected"
+        FalseClient newClient = new FalseClient(srcName);
+        TestListener testListener = new TestListener(newClient);
+        newClient.listener = testListener;
+
+        newClient.initiateWebsocketConnection("unused");
+        newClient.authenticate("");
+        newClient.connectToSource();
+        newClient.webSocketFuture = CompletableFuture.completedFuture(true);
+        newClient.authFuture = CompletableFuture.completedFuture(true);
+        newClient.sourceFuture = CompletableFuture.completedFuture(true);
+
+
+        // Now lets try initialize the TCP Probe Listener, and make sure things still look alright
+        try {
+            newClient.initializeTCPProbeListener();
+        } catch (Exception e) {
+            fail("Initializing TCP Probe should not throw exception.");
+        }
+        assert newClient.isOpen();
+        assert newClient.isAuthed();
+        assert newClient.isConnected();
+
+        // Now we'll cancel the listener, and again check that we didn't mess up anything else
+        newClient.cancelTCPProbeListener();
+        assert newClient.isOpen();
+        assert newClient.isAuthed();
+        assert newClient.isConnected();
+
+        // Finally, lets initialize a new one
+        try {
+            newClient.initializeTCPProbeListener();
+        } catch (Exception e) {
+            fail("Initializing TCP Probe should not throw exception.");
+        }
+        assert newClient.isOpen();
+        assert newClient.isAuthed();
+        assert newClient.isConnected();
+
+        // And cancel it to be complete
+        newClient.cancelTCPProbeListener();
+        assert newClient.isOpen();
+        assert newClient.isAuthed();
+        assert newClient.isConnected();
+    }
+
 // ============================== Helper functions ==============================
     private void markWsConnected(boolean success) {
         client.webSocketFuture = CompletableFuture.completedFuture(success);

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
@@ -410,7 +410,7 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase{
 
         // Now lets try initialize the TCP Probe Listener, and make sure things still look alright
         try {
-            newClient.initializeTCPProbeListener();
+            newClient.declareHealthy();
         } catch (Exception e) {
             fail("Initializing TCP Probe should not throw exception.");
         }
@@ -419,14 +419,14 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase{
         assert newClient.isConnected();
 
         // Now we'll cancel the listener, and again check that we didn't mess up anything else
-        newClient.cancelTCPProbeListener();
+        newClient.declareUnhealthy();
         assert newClient.isOpen();
         assert newClient.isAuthed();
         assert newClient.isConnected();
 
         // Finally, lets initialize a new one
         try {
-            newClient.initializeTCPProbeListener();
+            newClient.declareHealthy();
         } catch (Exception e) {
             fail("Initializing TCP Probe should not throw exception.");
         }
@@ -435,10 +435,22 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase{
         assert newClient.isConnected();
 
         // And cancel it to be complete
-        newClient.cancelTCPProbeListener();
+        newClient.declareUnhealthy();
         assert newClient.isOpen();
         assert newClient.isAuthed();
         assert newClient.isConnected();
+
+        // One last test to prove that we don't throw exceptions when declaring healthy/unhealthy multiple times
+        try {
+            newClient.declareHealthy();
+            newClient.declareHealthy();
+            newClient.declareHealthy();
+            newClient.declareUnhealthy();
+            newClient.declareUnhealthy();
+            newClient.declareUnhealthy();
+        } catch (Exception e) {
+            fail("No exceptions should be thrown regardless of when or how the healthy/unhealthy methods are called.");
+        }
     }
 
 // ============================== Helper functions ==============================

--- a/testConnector/src/main/java/io/vantiq/extsrc/testConnector/TestConnectorCore.java
+++ b/testConnector/src/main/java/io/vantiq/extsrc/testConnector/TestConnectorCore.java
@@ -34,9 +34,9 @@ public class TestConnectorCore {
     final Logger log;
     final static int RECONNECT_INTERVAL = 5000;
 
-    static final String ENVIRONMENT_VARIABLES = "environmentVariables";
-    static final String FILENAMES = "filenames";
-    static final String UNHEALTHY = "unhealthy";
+    public static final String ENVIRONMENT_VARIABLES = "environmentVariables";
+    public static final String FILENAMES = "filenames";
+    public static final String UNHEALTHY = "unhealthy";
 
     // Timer used if source is configured to poll from files
     Timer pollingTimer;

--- a/testConnector/src/main/java/io/vantiq/extsrc/testConnector/TestConnectorCore.java
+++ b/testConnector/src/main/java/io/vantiq/extsrc/testConnector/TestConnectorCore.java
@@ -138,11 +138,7 @@ public class TestConnectorCore {
         doFullClientConnection(timeout);
 
         // Setup the TCP Probe Listener
-        try {
-            client.initializeTCPProbeListener();
-        } catch (Exception e) {
-            log.error("An exception occurred while trying to setup the TCP Probe Listener");
-        }
+        client.declareHealthy();
     }
 
     /**
@@ -280,21 +276,10 @@ public class TestConnectorCore {
             Boolean unhealthyState = (Boolean) request.get(UNHEALTHY);
             // If true, set to unhealthy
             if (unhealthyState) {
-                client.cancelTCPProbeListener();
+                client.declareUnhealthy();
             } else {
                 // Otherwise, reinitialize the listener (i.e. we're back to a healthy state)
-                try {
-                    client.initializeTCPProbeListener();
-                } catch (Exception e) {
-                    log.error("An error occurred while trying to initialize the TCP Listener, this could be because it" +
-                            " was already initialized.");
-                    if (replyAddress != null) {
-                        client.sendQueryError(replyAddress, Exception.class.getCanonicalName(),
-                                "An error occurred while trying to initialize the TCP Listener, this " +
-                                        "could be because it was already initialized.", null);
-                    }
-                    return  null;
-                }
+                client.declareHealthy();
             }
 
             if (replyAddress != null) {

--- a/testConnector/src/main/java/io/vantiq/extsrc/testConnector/TestConnectorCore.java
+++ b/testConnector/src/main/java/io/vantiq/extsrc/testConnector/TestConnectorCore.java
@@ -268,7 +268,7 @@ public class TestConnectorCore {
             if (replyAddress != null) {
                 client.sendQueryError(replyAddress, Exception.class.getCanonicalName(),
                         "The request cannot be processed because it does not contain a valid list of " +
-                                "filenames or environmentVariables, nor does it contain an '" + UNHEALTHY+ "' flag. " +
+                                "filenames or environmentVariables, nor does it contain an '" + UNHEALTHY + "' flag. " +
                                 "At least one parameter must be provided.", null);
             }
             return null;

--- a/testConnector/src/test/java/io/vantiq/extsrc/testConnector/NoSendTestConnectorCore.java
+++ b/testConnector/src/test/java/io/vantiq/extsrc/testConnector/NoSendTestConnectorCore.java
@@ -40,6 +40,12 @@ public class NoSendTestConnectorCore extends TestConnectorCore {
         fClient.completeSourceConnection(true);
 
         exitIfConnectionFails(timeout);
+
+        try {
+            client.initializeTCPProbeListener();
+        } catch (Exception e) {
+            log.error("An exception occurred while trying to setup the TCP Probe Listener");
+        }
     }
 
     @Override

--- a/testConnector/src/test/java/io/vantiq/extsrc/testConnector/NoSendTestConnectorCore.java
+++ b/testConnector/src/test/java/io/vantiq/extsrc/testConnector/NoSendTestConnectorCore.java
@@ -40,22 +40,19 @@ public class NoSendTestConnectorCore extends TestConnectorCore {
         fClient.completeSourceConnection(true);
 
         exitIfConnectionFails(timeout);
-
-        try {
-            client.initializeTCPProbeListener();
-        } catch (Exception e) {
-            log.error("An exception occurred while trying to setup the TCP Probe Listener");
-        }
+        client.declareHealthy();
     }
 
     @Override
     public void close() {
+        client.declareUnhealthy();
         super.close();
         closed = true;
     }
 
     @Override
     public void stop() {
+        client.declareUnhealthy();
         super.stop();
         closed = true;
     }

--- a/testConnector/src/test/java/io/vantiq/extsrc/testConnector/TestTestConnectorCore.java
+++ b/testConnector/src/test/java/io/vantiq/extsrc/testConnector/TestTestConnectorCore.java
@@ -133,14 +133,14 @@ public class TestTestConnectorCore {
         request.put("unhealthy", true);
         Map result = core.processRequest(request, null);
         assert result == null;
-        assert core.client.getTCPProbeListenerFuture() == null;
+        assert !core.client.isMarkedHealthy();
 
         request.clear();
         request = new LinkedHashMap<>();
         request.put("unhealthy", false);
         result = core.processRequest(request, null);
         assert result == null;
-        assert core.client.getTCPProbeListenerFuture() != null;
+        assert core.client.isMarkedHealthy();
     }
 
     @Test
@@ -186,7 +186,7 @@ public class TestTestConnectorCore {
         request.put("unhealthy", 100);
         result = core.processRequest(request, null);
         assert result == null;
-        assert core.client.getTCPProbeListenerFuture() != null;
+        assert core.client.isMarkedHealthy();
 
         // Now lets provide nothing in the request and make sure that fails.
         request.clear();
@@ -196,10 +196,8 @@ public class TestTestConnectorCore {
 
     @Test
     public void testExitIfConnectionFails() {
-        core.start(3);
         assertTrue("Should have succeeded", core.exitIfConnectionFails(3));
         assertFalse("Success means it shouldn't be closed", core.isClosed());
-
 
         core.close();
         core = new NoSendTestConnectorCore(sourceName, authToken, targetVantiqServer);

--- a/testConnector/src/test/java/io/vantiq/extsrc/testConnector/TestTestConnectorCore.java
+++ b/testConnector/src/test/java/io/vantiq/extsrc/testConnector/TestTestConnectorCore.java
@@ -128,6 +128,22 @@ public class TestTestConnectorCore {
     }
 
     @Test
+    public void testUnhealthyRequest() {
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("unhealthy", true);
+        Map result = core.processRequest(request, null);
+        assert result == null;
+        assert core.client.getTCPProbeListenerFuture() == null;
+
+        request.clear();
+        request = new LinkedHashMap<>();
+        request.put("unhealthy", false);
+        result = core.processRequest(request, null);
+        assert result == null;
+        assert core.client.getTCPProbeListenerFuture() != null;
+    }
+
+    @Test
     public void testProcessInvalidRequest() {
         // Put invalid arguments into request to make sure it returns null (if this is a query, we would have sent a
         // query error)
@@ -164,6 +180,13 @@ public class TestTestConnectorCore {
         request.put("environmentVariables", environmentVariables);
         result = core.processRequest(request, null);
         assert result == null;
+
+        // One test to make sure the "unhealthy" flag must be a boolean
+        request.clear();
+        request.put("unhealthy", 100);
+        result = core.processRequest(request, null);
+        assert result == null;
+        assert core.client.getTCPProbeListenerFuture() != null;
 
         // Now lets provide nothing in the request and make sure that fails.
         request.clear();


### PR DESCRIPTION
Closes #215 

Adds enhancements to the SDK to support K8s Readiness/Liveness TCP Probes. The TCP socket listener will listen on port 8000 by default, but this can be overridden by specifying the `tcpProbePort` in the `server.config` file.

The TestConnector was also enhanced to be able to set/unset its "health state" via publish/query requests. Not sure if we want to add this for all of the connectors, but that can be done in a separate issue/PR.

Need to add documentation for the new SDK features. Manually tested with my local minikube, and readiness/liveness checks all worked as expected.