### PR TITLE
Changing all Vantiq SDK Java uses to have the (newest) same version

### DIFF
--- a/CSVSource/build.gradle
+++ b/CSVSource/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.0"
 
     // Used in tests
-    testCompile 'io.vantiq:vantiq-sdk:1.0.28'
+    testCompile "io.vantiq:vantiq-sdk:${vantiqSDKVersion}"
     
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'

--- a/CSVSource/build.gradle
+++ b/CSVSource/build.gradle
@@ -9,11 +9,6 @@ sourceCompatibility = 1.8
 repositories {
     mavenCentral()
     jcenter()
-    
-    // Used for checking VANTIQ date format behavior with VANTIQ SDK
-    maven {
-    	url "https://dl.bintray.com/vantiq/maven"
-    }
 }
 
 mainClassName = 'io.vantiq.extsrc.CSVSource.CSVMain'

--- a/CSVSource/build.gradle
+++ b/CSVSource/build.gradle
@@ -42,10 +42,9 @@ dependencies {
     
     compile "org.slf4j:slf4j-api:1.7.25"
     compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.0"
-    
-      
-    // Used for checking VANTIQ date format behavior with VANTIQ SDK
-    compile 'io.vantiq:vantiq-sdk:1.0.27'
+
+    // Used in tests
+    testCompile 'io.vantiq:vantiq-sdk:1.0.28'
     
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'

--- a/EasyModbusSource/build.gradle
+++ b/EasyModbusSource/build.gradle
@@ -49,9 +49,9 @@ dependencies {
     compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.0"
     
     compile files("${System.env.EASY_MODBUS_LOC}/EasyModbusJava.jar")
-        
-    // Used for checking VANTIQ date format behavior with VANTIQ SDK
-    compile 'io.vantiq:vantiq-sdk:1.0.27'
+
+    // Used in tests
+    testCompile 'io.vantiq:vantiq-sdk:1.0.28'
     
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'

--- a/EasyModbusSource/build.gradle
+++ b/EasyModbusSource/build.gradle
@@ -10,11 +10,6 @@ sourceCompatibility = 1.8
 repositories {
     mavenCentral()
     jcenter()
-    
-    // Used for checking VANTIQ date format behavior with VANTIQ SDK
-    maven {
-    	url "https://dl.bintray.com/vantiq/maven"
-    }
 }
 
 mainClassName = 'io.vantiq.extsrc.EasyModbusSource.EasyModbusMain'

--- a/EasyModbusSource/build.gradle
+++ b/EasyModbusSource/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compile files("${System.env.EASY_MODBUS_LOC}/EasyModbusJava.jar")
 
     // Used in tests
-    testCompile 'io.vantiq:vantiq-sdk:1.0.28'
+    testCompile "io.vantiq:vantiq-sdk:${vantiqSDKVersion}"
     
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ group 'io.vantiq'
 ext {
     slf4jApiVersion = '1.7.25'
     eclipseMiloVersion = '0.2.1'
+    vantiqSDKVersion = "1.0.28"
 }
 
 

--- a/extjsdk/build.gradle
+++ b/extjsdk/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
 
     // Used in tests
-    testCompile 'io.vantiq:vantiq-sdk:1.0.28'
+    testCompile "io.vantiq:vantiq-sdk:${vantiqSDKVersion}"
 
     // Used to create EvictingQueue for failed messages queue
     implementation 'com.google.guava:guava:23.0'

--- a/extjsdk/build.gradle
+++ b/extjsdk/build.gradle
@@ -33,9 +33,7 @@ jar.from(".") {
 }
 
 repositories {
-    maven {
-        url "https://dl.bintray.com/vantiq/maven"
-    }
+    mavenCentral()
 }
 
 configurations {

--- a/extjsdk/build.gradle
+++ b/extjsdk/build.gradle
@@ -79,8 +79,9 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
-    // Used for uploading documents (images) to VANTIQ with VANTIQ SDK
-    testCompile 'io.vantiq:vantiq-sdk:1.0.24'
+
+    // Used in tests
+    testCompile 'io.vantiq:vantiq-sdk:1.0.28'
 
     // Used to create EvictingQueue for failed messages queue
     implementation 'com.google.guava:guava:23.0'

--- a/jdbcSource/build.gradle
+++ b/jdbcSource/build.gradle
@@ -9,11 +9,6 @@ sourceCompatibility = 1.8
 repositories {
     mavenCentral()
     jcenter()
-    
-    // Used for checking VANTIQ date format behavior with VANTIQ SDK
-    maven {
-    	url "https://dl.bintray.com/vantiq/maven"
-    }
 }
 
 mainClassName = 'io.vantiq.extsrc.jdbcSource.JDBCMain'

--- a/jdbcSource/build.gradle
+++ b/jdbcSource/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     runtime files("${System.env.JDBC_DRIVER_LOC}")
     
     // Used in tests that check VANTIQ date format behavior
-    testCompile 'io.vantiq:vantiq-sdk:1.0.28'
+    testCompile "io.vantiq:vantiq-sdk:${vantiqSDKVersion}"
     
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'

--- a/jdbcSource/build.gradle
+++ b/jdbcSource/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     //  Compiling relevant JDBC Driver .jar file
     runtime files("${System.env.JDBC_DRIVER_LOC}")
     
-    // Used for test that checks VANTIQ date format behavior with VANTIQ SDK
+    // Used in tests that check VANTIQ date format behavior
     testCompile 'io.vantiq:vantiq-sdk:1.0.28'
     
     // Use JUnit test framework

--- a/jdbcSource/build.gradle
+++ b/jdbcSource/build.gradle
@@ -74,8 +74,8 @@ dependencies {
     //  Compiling relevant JDBC Driver .jar file
     runtime files("${System.env.JDBC_DRIVER_LOC}")
     
-    // Used for checking VANTIQ date format behavior with VANTIQ SDK
-    compile 'io.vantiq:vantiq-sdk:1.0.17'
+    // Used for test that checks VANTIQ date format behavior with VANTIQ SDK
+    testCompile 'io.vantiq:vantiq-sdk:1.0.28'
     
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'

--- a/jmsSource/build.gradle
+++ b/jmsSource/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     compile files("${System.env.JMS_DRIVER_LOC}")
 
     // Used for testing extension source in VANTIQ
-    testCompile 'io.vantiq:vantiq-sdk:1.0.17'
+    testCompile 'io.vantiq:vantiq-sdk:1.0.28'
 
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'

--- a/jmsSource/build.gradle
+++ b/jmsSource/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     compile files("${System.env.JMS_DRIVER_LOC}")
 
     // Used for testing extension source in VANTIQ
-    testCompile 'io.vantiq:vantiq-sdk:1.0.28'
+    testCompile "io.vantiq:vantiq-sdk:${vantiqSDKVersion}"
 
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'

--- a/jmsSource/build.gradle
+++ b/jmsSource/build.gradle
@@ -9,11 +9,6 @@ sourceCompatibility = 1.8
 repositories {
     mavenCentral()
     jcenter()
-
-    // Used for testing extension source in VANTIQ
-    maven {
-        url "https://dl.bintray.com/vantiq/maven"
-    }
 }
 
 mainClassName = 'io.vantiq.extsrc.jmsSource.JMSMain'

--- a/objectRecognitionSource/build.gradle
+++ b/objectRecognitionSource/build.gradle
@@ -254,7 +254,7 @@ dependencies {
     }
     
     // Used for uploading documents (images) to VANTIQ with VANTIQ SDK
-    compile 'io.vantiq:vantiq-sdk:1.0.28'
+    compile "io.vantiq:vantiq-sdk:${vantiqSDKVersion}"
 
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'

--- a/objectRecognitionSource/build.gradle
+++ b/objectRecognitionSource/build.gradle
@@ -254,7 +254,7 @@ dependencies {
     }
     
     // Used for uploading documents (images) to VANTIQ with VANTIQ SDK
-    compile 'io.vantiq:vantiq-sdk:1.0.24'
+    compile 'io.vantiq:vantiq-sdk:1.0.28'
 
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'

--- a/objectRecognitionSource/build.gradle
+++ b/objectRecognitionSource/build.gradle
@@ -12,11 +12,6 @@ sourceCompatibility = 1.8
 repositories {
     mavenCentral()
     jcenter()
-    
-    // Used for uploading documents (images) to VANTIQ with VANTIQ SDK
-    maven {
-    	url "https://dl.bintray.com/vantiq/maven"
-    }
 
     maven {
         url "http://vantiqmaven.s3.amazonaws.com/"


### PR DESCRIPTION
Closes #255 
Closes #257 

Updating all of the Vantiq SDK Java dependencies to be version 1.0.28. We still need to sort out the Bintray migration, but this can be left as a placeholder in the meantime.

Also changed some of the dependencies to be testCompiles where applicable, (everyone but the Obj Rec connector).

