### PR TITLE
Adds ability for Test Connector to read raw bytes from files

### DIFF
--- a/testConnector/README.md
+++ b/testConnector/README.md
@@ -98,6 +98,11 @@ include a `WITH` clause that contains a `filenames` and/or an `environmentVariab
 parameters must be provided. Both parameters are defined as lists of Strings, representing filenames or environment 
 variable names, respectively.
 
+Both Select and Publish statements can include an additional boolean parameter, `rawBytes`, that when true will tell the 
+Test Connector to read file data as raw bytes instead of a String. The raw bytes are then returned to Vantiq as a base64 
+encoded string. This parameter only applies to the data from files specified in the request, and does not apply to 
+environment variables or polling files specified in the Source Configuration.
+
 The following example uses a Vail Select Statement to retrieve data from files and environment variables:
 ```
 PROCEDURE queryTestConnector()
@@ -105,7 +110,8 @@ PROCEDURE queryTestConnector()
 try { 
     SELECT * FROM SOURCE TestConnector1 as results WITH
         filenames: ["testFile1.txt", "testFile2.txt"],
-        environmentVariables: ["MY_ENV_VAR1", "MY_ENV_VAR2"]
+        environmentVariables: ["MY_ENV_VAR1", "MY_ENV_VAR2"],
+        rawBytes: true
     
     var fileResponse = results.files
     var envVarResponse = results.environmentVariables

--- a/testConnector/src/test/java/io/vantiq/extsrc/testConnector/TestTestConnectorCore.java
+++ b/testConnector/src/test/java/io/vantiq/extsrc/testConnector/TestTestConnectorCore.java
@@ -12,7 +12,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
-import java.util.*;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.Base64;
 
 import org.junit.After;
 import org.junit.Before;
@@ -38,9 +42,9 @@ public class TestTestConnectorCore {
 
     @BeforeClass
     public static void checkFilesAndEnvVars() {
-        environmentVariable = System.getProperty("TestConnectorEnvVarName", null);
-        filename = System.getProperty("TestConnectorFilename", null);
-        fileContents = System.getProperty("TestConnectorFileContents", null);
+        environmentVariable = System.getProperty("TestConnectorEnvVarName");
+        filename = System.getProperty("TestConnectorFilename");
+        fileContents = System.getProperty("TestConnectorFileContents");
     }
 
     @Before

--- a/testConnector/src/test/java/io/vantiq/extsrc/testConnector/TestTestConnectorCore.java
+++ b/testConnector/src/test/java/io/vantiq/extsrc/testConnector/TestTestConnectorCore.java
@@ -150,7 +150,6 @@ public class TestTestConnectorCore {
         assert !fileString.isEmpty();
         assert !fileString.equals(fileContents);
         String decodedString = new String(Base64.getDecoder().decode(fileString.getBytes()));
-        decodedString = decodedString.replace(System.getProperty("line.separator"), ""); // Removing new lines
         assert decodedString.equals(fileContents);
     }
 

--- a/testConnector/src/test/java/io/vantiq/extsrc/testConnector/TestTestConnectorCore.java
+++ b/testConnector/src/test/java/io/vantiq/extsrc/testConnector/TestTestConnectorCore.java
@@ -12,10 +12,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.junit.After;
 import org.junit.Before;
@@ -35,6 +32,7 @@ public class TestTestConnectorCore {
 
     private static String environmentVariable;
     private static String filename;
+    private static String fileContents;
 
     private static final String NONEXISTENT_ENV_VAR = "anEnvironmentVariableThatIsUnlikelyToExist";
 
@@ -42,6 +40,7 @@ public class TestTestConnectorCore {
     public static void checkFilesAndEnvVars() {
         environmentVariable = System.getProperty("TestConnectorEnvVarName", null);
         filename = System.getProperty("TestConnectorFilename", null);
+        fileContents = System.getProperty("TestConnectorFileContents", null);
     }
 
     @Before
@@ -125,6 +124,30 @@ public class TestTestConnectorCore {
         assert result.get("environmentVariables") instanceof Map;
         resultEnvVars = (Map) result.get("environmentVariables");
         assert resultEnvVars.get(NONEXISTENT_ENV_VAR) == null;
+    }
+
+    @Test
+    public void testRawBytes() {
+        assumeTrue(filename != null && fileContents != null);
+
+        // Put data in the request and call the process method
+        Map<String, Object> request = new LinkedHashMap<>();
+        List<String> filenames = new ArrayList<>();
+        filenames.add(filename);
+        request.put("filenames", filenames);
+        request.put("rawBytes", true);
+        Map result = core.processRequest(request, null);
+
+        // Check that the data is base64 encoded version of what we expect
+        assert result.get("files") instanceof Map;
+        Map resultFiles = (Map) result.get("files");
+        assert resultFiles.get(filename) instanceof String;
+        String fileString = (String) resultFiles.get(filename);
+        assert !fileString.isEmpty();
+        assert !fileString.equals(fileContents);
+        String decodedString = new String(Base64.getDecoder().decode(fileString.getBytes()));
+        decodedString = decodedString.replace(System.getProperty("line.separator"), ""); // Removing new lines
+        assert decodedString.equals(fileContents);
     }
 
     @Test


### PR DESCRIPTION
Closes #258 

This enhancement adds an additional boolean parameter to Test Connector requests that, when specified as true, enables the  Test Connector to read data from files as raw bytes, and return them to Vantiq as a base64 encoded string.

This feature will be used for testing the K8s LCM tools in the Vantiq server code.