### PR TITLE
Fix skippable tests for simple unit testing

### DIFF
--- a/CSVSource/src/test/java/io/vantiq/extsrc/CSVSource/TestCSVReaderFixedLength.java
+++ b/CSVSource/src/test/java/io/vantiq/extsrc/CSVSource/TestCSVReaderFixedLength.java
@@ -28,11 +28,10 @@ public class TestCSVReaderFixedLength extends TestCSVConfigFixedLength {
 
     @Before
     public void setup() {
-        config = new HashMap<String, Object>();
+        super.setup();
 
-        TestCSVConfigFixedLength o = new TestCSVConfigFixedLength();
-        config = o.minimalConfig();
-        options = o.createMinimalOptions();
+        config = minimalConfig();
+        options = createMinimalOptions();
         CSVReader.segmentList.clear();
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -204,6 +204,14 @@ subprojects {
                 }
             }
         }
+
+        def jenkinsHome = System.env.JENKINS_HOME
+
+        if (jenkinsHome != null && jenkinsHome.length() > 0) {
+            // continue the build on test failures, so that all tests get run & we get one total...
+            // AND in jenkins, the build is continued with later reports collected...
+            ignoreFailures = true
+        }
     }
 }
 

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestWithServer.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestWithServer.java
@@ -16,12 +16,15 @@ public class TestWithServer extends RoundTripTestBase {
     
     @AfterClass
     public static void cleanup() {
-        deleteType();
-        deleteRule();
-        deleteSource();
-        deleteSourceImpl();
+        // If we started up, shut down nicely.  Otherwise, pass w/o issue
+        if (vantiq != null && vantiq.isAuthenticated()) {
+            deleteType();
+            deleteRule();
+            deleteSource();
+            deleteSourceImpl();
+        }
     }
-    
+
     @Test
     public void testNotificationEnMasse() throws Exception {
 

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -32,6 +32,7 @@ import io.vantiq.client.Vantiq;
 import io.vantiq.client.VantiqResponse;
 import io.vantiq.extsrc.jdbcSource.exception.VantiqSQLException;
 
+@SuppressWarnings("PMD.ExcessiveClassLength")
 public class TestJDBC extends TestJDBCBase {
     
     // Queries to be tested

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -149,7 +149,8 @@ public class TestJDBC extends TestJDBCBase {
     }
     
     */
-    
+
+    @SuppressWarnings("PMD.JUnit4TestShouldUseAfterAnnotation")
     @AfterClass
     public static void tearDown() throws VantiqSQLException {
         if (testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null) {

--- a/jmsSource/src/test/java/io/vantiq/extsrc/jmsSource/TestJMS.java
+++ b/jmsSource/src/test/java/io/vantiq/extsrc/jmsSource/TestJMS.java
@@ -67,7 +67,8 @@ public class TestJMS extends TestJMSBase {
     public void unsubscribe() {
         vantiq.unsubscribeAll();
     }
-        
+
+    @SuppressWarnings("PMD.JUnit4TestShouldUseAfterAnnotation")
     @AfterClass
     public static void tearDown() {
         // Delete source from VANTIQ

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecConfig.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecConfig.java
@@ -275,7 +275,7 @@ public class TestObjRecConfig {
 
     @Test
     public void testEmptyPostProcessor() {
-        postProcessor = new HashMap<String, Object>();
+        postProcessor = new HashMap<>();
         Map conf = minimalConfig();
         sendConfig(conf);
         assertFalse("Should not fail with empty postProcessor", configIsFailed());
@@ -283,7 +283,7 @@ public class TestObjRecConfig {
 
     @Test
     public void testEmptyPPMapper() {
-        postProcessor = new HashMap<String, Object>();
+        postProcessor = new HashMap<>();
         postProcessor.put(ObjectRecognitionConfigHandler.LOCATION_MAPPER, new HashMap<String, Object>());
         Map conf = minimalConfig();
         sendConfig(conf);
@@ -292,8 +292,8 @@ public class TestObjRecConfig {
 
     @Test
     public void testBadCoords() {
-        postProcessor = new HashMap<String, Object>();
-        Map<String, Object> mapper = new HashMap<String,Object>();
+        postProcessor = new HashMap<>();
+        Map<String, Object> mapper = new HashMap<>();
         List<Map> imgCoords = new ArrayList<>();
         mapper.put(ObjectRecognitionConfigHandler.IMAGE_COORDINATES, imgCoords);
         postProcessor.put(ObjectRecognitionConfigHandler.LOCATION_MAPPER, mapper);
@@ -374,8 +374,8 @@ public class TestObjRecConfig {
 
     @Test
     public void testInvalidResultSpec() {
-        postProcessor = new HashMap<String, Object>();
-        Map<String, Object> mapper = new HashMap<String,Object>();
+        postProcessor = new HashMap<>();
+        Map<String, Object> mapper = new HashMap<>();
         List<Map> imgCoords = new ArrayList<>();
         List<Map> mappedCoords = new ArrayList<>();
 
@@ -411,7 +411,7 @@ public class TestObjRecConfig {
 
     @Test
     public void testValidPostProcessor() {
-        postProcessor = new HashMap<String, Object>();
+        postProcessor = new HashMap<>();
         Map<String, Object> mapper = new HashMap<String,Object>();
         List<Map> imgCoords = new ArrayList<>();
         List<Map> mappedCoords = new ArrayList<>();

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
@@ -78,7 +78,6 @@ public class TestNoProcessor extends NeuralNetTestBase {
                     public void onError(List<VantiqError> errors, Response response) {
                         super.onError(errors, response);
                     }
-
                 });
             }
             // Deleting files saved as images

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
@@ -55,47 +55,50 @@ public class TestNoProcessor extends NeuralNetTestBase {
         Map<String, Object> config = new LinkedHashMap<>();
         noProcessor.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
 
-        vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
-        vantiq.setAccessToken(testAuthToken);
+        if (testAuthToken != null && testVantiqServer != null) {
+            vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
+            vantiq.setAccessToken(testAuthToken);
+        }
     }
 
     @AfterClass
     public static void deleteFromVantiq() throws InterruptedException {
-        // Deleting files saved as documents
-        for (int i = 0; i < vantiqSavedFiles.size(); i++) {
-            Thread.sleep(1000);
-            vantiq.deleteOne(VANTIQ_DOCUMENTS, vantiqSavedFiles.get(i), new BaseResponseHandler() {
+        if (vantiq != null && vantiq.isAuthenticated()) {
+            // Deleting files saved as documents
+            for (int i = 0; i < vantiqSavedFiles.size(); i++) {
+                Thread.sleep(1000);
+                vantiq.deleteOne(VANTIQ_DOCUMENTS, vantiqSavedFiles.get(i), new BaseResponseHandler() {
 
-                @Override
-                public void onSuccess(Object body, Response response) {
-                    super.onSuccess(body, response);
-                }
+                    @Override
+                    public void onSuccess(Object body, Response response) {
+                        super.onSuccess(body, response);
+                    }
 
-                @Override
-                public void onError(List<VantiqError> errors, Response response) {
-                    super.onError(errors, response);
-                }
+                    @Override
+                    public void onError(List<VantiqError> errors, Response response) {
+                        super.onError(errors, response);
+                    }
 
-            });
+                });
+            }
+            // Deleting files saved as images
+            for (int i = 0; i < vantiqSavedImageFiles.size(); i++) {
+                Thread.sleep(1000);
+                vantiq.deleteOne(VANTIQ_IMAGES, vantiqSavedImageFiles.get(i), new BaseResponseHandler() {
+
+                    @Override
+                    public void onSuccess(Object body, Response response) {
+                        super.onSuccess(body, response);
+                    }
+
+                    @Override
+                    public void onError(List<VantiqError> errors, Response response) {
+                        super.onError(errors, response);
+                    }
+
+                });
+            }
         }
-        // Deleting files saved as images
-        for (int i = 0; i < vantiqSavedImageFiles.size(); i++) {
-            Thread.sleep(1000);
-            vantiq.deleteOne(VANTIQ_IMAGES, vantiqSavedImageFiles.get(i), new BaseResponseHandler() {
-
-                @Override
-                public void onSuccess(Object body, Response response) {
-                    super.onSuccess(body, response);
-                }
-
-                @Override
-                public void onError(List<VantiqError> errors, Response response) {
-                    super.onError(errors, response);
-                }
-
-            });
-        }
-
     }
 
     @AfterClass

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
@@ -65,9 +65,9 @@ public class TestNoProcessor extends NeuralNetTestBase {
     public static void deleteFromVantiq() throws InterruptedException {
         if (vantiq != null && vantiq.isAuthenticated()) {
             // Deleting files saved as documents
-            for (int i = 0; i < vantiqSavedFiles.size(); i++) {
+            for (String vantiqSavedFile : vantiqSavedFiles) {
                 Thread.sleep(1000);
-                vantiq.deleteOne(VANTIQ_DOCUMENTS, vantiqSavedFiles.get(i), new BaseResponseHandler() {
+                vantiq.deleteOne(VANTIQ_DOCUMENTS, vantiqSavedFile, new BaseResponseHandler() {
 
                     @Override
                     public void onSuccess(Object body, Response response) {
@@ -82,9 +82,9 @@ public class TestNoProcessor extends NeuralNetTestBase {
                 });
             }
             // Deleting files saved as images
-            for (int i = 0; i < vantiqSavedImageFiles.size(); i++) {
+            for (String vantiqSavedImageFile : vantiqSavedImageFiles) {
                 Thread.sleep(1000);
-                vantiq.deleteOne(VANTIQ_IMAGES, vantiqSavedImageFiles.get(i), new BaseResponseHandler() {
+                vantiq.deleteOne(VANTIQ_IMAGES, vantiqSavedImageFile, new BaseResponseHandler() {
 
                     @Override
                     public void onSuccess(Object body, Response response) {
@@ -95,7 +95,6 @@ public class TestNoProcessor extends NeuralNetTestBase {
                     public void onError(List<VantiqError> errors, Response response) {
                         super.onError(errors, response);
                     }
-
                 });
             }
         }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
@@ -51,8 +51,8 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         if (vantiq != null && vantiq.isAuthenticated()) {
             deleteSource();
 
-            for (int i = 0; i < vantiqUploadFiles.size(); i++) {
-                deleteFileFromVantiq(vantiqUploadFiles.get(i));
+            for (String vantiqUploadFile : vantiqUploadFiles) {
+                deleteFileFromVantiq(vantiqUploadFile);
             }
         }
         deleteDirectory(OUTPUT_DIR);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
@@ -1,6 +1,5 @@
 package io.vantiq.extsrc.objectRecognition.neuralNet;
 
-import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
@@ -14,7 +13,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import io.vantiq.client.Vantiq;
-import io.vantiq.client.VantiqError;
 import io.vantiq.client.VantiqResponse;
 import io.vantiq.extsrc.objectRecognition.ObjectRecognitionCore;
 
@@ -36,10 +34,12 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
     
     @BeforeClass
     public static void setup() {
-        vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
-        vantiq.setAccessToken(testAuthToken);
-        
-        setupSource(createSourceDef());
+        if (testVantiqServer != null && testAuthToken != null) {
+            vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
+            vantiq.setAccessToken(testAuthToken);
+
+            setupSource(createSourceDef());
+        }
     }
     
     @AfterClass
@@ -48,12 +48,15 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
             core.stop();
             core = null;
         }
-        deleteSource();
-        deleteDirectory(OUTPUT_DIR);
-        
-        for (int i = 0; i < vantiqUploadFiles.size(); i++) {
-            deleteFileFromVantiq(vantiqUploadFiles.get(i));
+        if (vantiq != null && vantiq.isAuthenticated()) {
+            deleteSource();
+
+            for (int i = 0; i < vantiqUploadFiles.size(); i++) {
+                deleteFileFromVantiq(vantiqUploadFiles.get(i));
+            }
         }
+        deleteDirectory(OUTPUT_DIR);
+
     }
     
     @Test

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
@@ -41,7 +41,8 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
             setupSource(createSourceDef());
         }
     }
-    
+
+    @SuppressWarnings("PMD.JUnit4TestShouldUseAfterAnnotation")
     @AfterClass
     public static void tearDown() {
         if (core != null) {

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
@@ -25,16 +25,20 @@ public class TestParallelProcessing extends NeuralNetTestBase {
 
     @BeforeClass
     public static void classSetup() {
-        vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
-        vantiq.setAccessToken(testAuthToken);
+        if (testVantiqServer != null && testAuthToken != null) {
+            vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
+            vantiq.setAccessToken(testAuthToken);
+        }
     }
 
     @AfterClass
     public static void tearDown() {
         // Double check that everything was deleted from VANTIQ
-        deleteSource(vantiq);
-        deleteType(vantiq);
-        deleteRule(vantiq);
+        if (vantiq != null && vantiq.isAuthenticated()) {
+            deleteSource(vantiq);
+            deleteType(vantiq);
+            deleteRule(vantiq);
+        }
     }
 
     @Test

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
@@ -31,6 +31,7 @@ public class TestParallelProcessing extends NeuralNetTestBase {
         }
     }
 
+    @SuppressWarnings("PMD.JUnit4TestShouldUseAfterAnnotation")
     @AfterClass
     public static void tearDown() {
         // Double check that everything was deleted from VANTIQ

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
@@ -144,9 +144,9 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     @After
     public void deleteFromVantiq() throws InterruptedException {
         if (vantiq != null && vantiq.isAuthenticated()) {
-            for (int i = 0; i < vantiqUploadFiles.size(); i++) {
+            for (String vantiqUploadFile : vantiqUploadFiles) {
                 Thread.sleep(1000);
-                vantiq.deleteOne(VANTIQ_DOCUMENTS, vantiqUploadFiles.get(i), new BaseResponseHandler() {
+                vantiq.deleteOne(VANTIQ_DOCUMENTS, vantiqUploadFile, new BaseResponseHandler() {
 
                     @Override
                     public void onSuccess(Object body, Response response) {

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
@@ -86,21 +86,24 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     
     @BeforeClass
     public static void setup() {
+
         core = new NoSendORCore(SOURCE_NAME, testAuthToken, testVantiqServer, MODEL_DIRECTORY);
         core.start(10);
         core.outputDir = OUTPUT_DIR;
-        
-        vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
-        vantiq.setAccessToken(testAuthToken);
-        
-        // Add files to be deleted from VANTIQ later
-        vantiqUploadFiles.add(IMAGE_1.get("filename"));
-        vantiqUploadFiles.add(IMAGE_2.get("filename"));
-        vantiqUploadFiles.add(IMAGE_3.get("filename"));
-        vantiqUploadFiles.add(IMAGE_4.get("filename"));
-        vantiqUploadFiles.add(IMAGE_5.get("filename"));
-        vantiqUploadFiles.add(IMAGE_6.get("filename"));
-        vantiqUploadFiles.add(IMAGE_7.get("filename"));
+
+        if (testAuthToken != null && testVantiqServer != null) {
+            vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
+            vantiq.setAccessToken(testAuthToken);
+
+            // Add files to be deleted from VANTIQ later
+            vantiqUploadFiles.add(IMAGE_1.get("filename"));
+            vantiqUploadFiles.add(IMAGE_2.get("filename"));
+            vantiqUploadFiles.add(IMAGE_3.get("filename"));
+            vantiqUploadFiles.add(IMAGE_4.get("filename"));
+            vantiqUploadFiles.add(IMAGE_5.get("filename"));
+            vantiqUploadFiles.add(IMAGE_6.get("filename"));
+            vantiqUploadFiles.add(IMAGE_7.get("filename"));
+        }
     }
     
     @Before
@@ -140,21 +143,23 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     
     @After
     public void deleteFromVantiq() throws InterruptedException {
-        for (int i = 0; i < vantiqUploadFiles.size(); i++) {
-            Thread.sleep(1000);
-            vantiq.deleteOne(VANTIQ_DOCUMENTS, vantiqUploadFiles.get(i), new BaseResponseHandler() {
+        if (vantiq != null && vantiq.isAuthenticated()) {
+            for (int i = 0; i < vantiqUploadFiles.size(); i++) {
+                Thread.sleep(1000);
+                vantiq.deleteOne(VANTIQ_DOCUMENTS, vantiqUploadFiles.get(i), new BaseResponseHandler() {
 
-                @Override
-                public void onSuccess(Object body, Response response) {
-                    super.onSuccess(body, response);
-                }
+                    @Override
+                    public void onSuccess(Object body, Response response) {
+                        super.onSuccess(body, response);
+                    }
 
-                @Override
-                public void onError(List<VantiqError> errors, Response response) {
-                    super.onError(errors, response);
-                }
+                    @Override
+                    public void onError(List<VantiqError> errors, Response response) {
+                        super.onError(errors, response);
+                    }
 
-            });
+                });
+            }
         }
         
         File d = new File(OUTPUT_DIR);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
@@ -135,7 +135,8 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
         testFile = new File(OUTPUT_DIR + File.separator + IMAGE_7.get("date") + ".jpg");
         ImageIO.write(testImageBuffer, "jpg", testFile);
     }
-    
+
+    @SuppressWarnings("PMD.JUnit4TestShouldUseAfterAnnotation")
     @AfterClass
     public static void tearDown() {
         core.stop();

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -156,6 +156,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         }
     }
 
+    @SuppressWarnings("PMD.JUnit4TestShouldUseAfterAnnotation")
     @AfterClass
     public static void classTearDown() {
         if (ypJson != null) {

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -112,45 +112,49 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             fail("Could not setup the JSON YoloProcessor");
         }
 
-        vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
-        vantiq.setAccessToken(testAuthToken);
+        if (testVantiqServer != null && testAuthToken != null) {
+            vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
+            vantiq.setAccessToken(testAuthToken);
+        }
     }
 
     @AfterClass
     public static void deleteFromVantiq() throws InterruptedException {
         // Deleting files saved as documents
-        for (int i = 0; i < vantiqSavedFiles.size(); i++) {
-            Thread.sleep(1000);
-            vantiq.deleteOne(VANTIQ_DOCUMENTS, vantiqSavedFiles.get(i), new BaseResponseHandler() {
+        if (vantiq != null && vantiq.isAuthenticated()) {
+            for (int i = 0; i < vantiqSavedFiles.size(); i++) {
+                Thread.sleep(1000);
+                vantiq.deleteOne(VANTIQ_DOCUMENTS, vantiqSavedFiles.get(i), new BaseResponseHandler() {
 
-                @Override
-                public void onSuccess(Object body, Response response) {
-                    super.onSuccess(body, response);
-                }
+                    @Override
+                    public void onSuccess(Object body, Response response) {
+                        super.onSuccess(body, response);
+                    }
 
-                @Override
-                public void onError(List<VantiqError> errors, Response response) {
-                    super.onError(errors, response);
-                }
+                    @Override
+                    public void onError(List<VantiqError> errors, Response response) {
+                        super.onError(errors, response);
+                    }
 
-            });
-        }
-        // Deleting files saved as images
-        for (int i = 0; i < vantiqSavedImageFiles.size(); i++) {
-            Thread.sleep(1000);
-            vantiq.deleteOne(VANTIQ_IMAGES, vantiqSavedImageFiles.get(i), new BaseResponseHandler() {
+                });
+            }
+            // Deleting files saved as images
+            for (int i = 0; i < vantiqSavedImageFiles.size(); i++) {
+                Thread.sleep(1000);
+                vantiq.deleteOne(VANTIQ_IMAGES, vantiqSavedImageFiles.get(i), new BaseResponseHandler() {
 
-                @Override
-                public void onSuccess(Object body, Response response) {
-                    super.onSuccess(body, response);
-                }
+                    @Override
+                    public void onSuccess(Object body, Response response) {
+                        super.onSuccess(body, response);
+                    }
 
-                @Override
-                public void onError(List<VantiqError> errors, Response response) {
-                    super.onError(errors, response);
-                }
+                    @Override
+                    public void onError(List<VantiqError> errors, Response response) {
+                        super.onError(errors, response);
+                    }
 
-            });
+                });
+            }
         }
     }
 
@@ -166,10 +170,12 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             deleteDirectory(OUTPUT_DIR);
         }
 
-        // Double check that everything was deleted from VANTIQ
-        deleteSource(vantiq);
-        deleteType(vantiq);
-        deleteRule(vantiq);
+        if (vantiq != null && vantiq.isAuthenticated()) {
+            // Double check that everything was deleted from VANTIQ
+            deleteSource(vantiq);
+            deleteType(vantiq);
+            deleteRule(vantiq);
+        }
     }
 
     @Test

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -54,6 +54,7 @@ import io.vantiq.extjsdk.ExtensionServiceMessage;
 import okhttp3.Response;
 import okio.BufferedSource;
 
+@SuppressWarnings("PMD.ExcessiveClassLength")
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class TestYoloProcessor extends NeuralNetTestBase {
 

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -122,9 +122,9 @@ public class TestYoloProcessor extends NeuralNetTestBase {
     public static void deleteFromVantiq() throws InterruptedException {
         // Deleting files saved as documents
         if (vantiq != null && vantiq.isAuthenticated()) {
-            for (int i = 0; i < vantiqSavedFiles.size(); i++) {
+            for (String vantiqSavedFile : vantiqSavedFiles) {
                 Thread.sleep(1000);
-                vantiq.deleteOne(VANTIQ_DOCUMENTS, vantiqSavedFiles.get(i), new BaseResponseHandler() {
+                vantiq.deleteOne(VANTIQ_DOCUMENTS, vantiqSavedFile, new BaseResponseHandler() {
 
                     @Override
                     public void onSuccess(Object body, Response response) {
@@ -135,13 +135,12 @@ public class TestYoloProcessor extends NeuralNetTestBase {
                     public void onError(List<VantiqError> errors, Response response) {
                         super.onError(errors, response);
                     }
-
                 });
             }
             // Deleting files saved as images
-            for (int i = 0; i < vantiqSavedImageFiles.size(); i++) {
+            for (String vantiqSavedImageFile : vantiqSavedImageFiles) {
                 Thread.sleep(1000);
-                vantiq.deleteOne(VANTIQ_IMAGES, vantiqSavedImageFiles.get(i), new BaseResponseHandler() {
+                vantiq.deleteOne(VANTIQ_IMAGES, vantiqSavedImageFile, new BaseResponseHandler() {
 
                     @Override
                     public void onSuccess(Object body, Response response) {
@@ -152,7 +151,6 @@ public class TestYoloProcessor extends NeuralNetTestBase {
                     public void onError(List<VantiqError> errors, Response response) {
                         super.onError(errors, response);
                     }
-
                 });
             }
         }
@@ -281,7 +279,6 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         } catch (Exception e) {
             fail("Should not fail with label and meta file, and anchors: " + e.getClass().getName() + "::" + e.getMessage());
         }
-
     }
     
     @Test
@@ -518,7 +515,6 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         labelTestHelper(false);
-
     }
 
     @Test
@@ -527,7 +523,6 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         labelTestHelper(true);
-
     }
 
     // Helper function to test the "labelImage" option
@@ -638,7 +633,6 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         // The savedResolution is not a map which is not allowed, should not do any resizing
         config.put("savedResolution", "jibberish");
         checkInvalidResizing(config);
-        
     }
     
     // Helper function to test invalid resizing
@@ -1013,7 +1007,6 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             Thread.sleep(1000);
             checkUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_DOCUMENTS);
             vantiqSavedFiles.add(results.getLastFilename());
-
         } finally {
             // delete the directory even if the test fails
             if (d.exists()) {
@@ -1209,7 +1202,6 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
             ypImageSaver.close();
         }
-
     }
     
     @Test
@@ -1411,7 +1403,6 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             
             assert resizedImage.getWidth() == CROPPED_WIDTH;
             assert resizedImage.getHeight() == CROPPED_HEIGHT;
-
         } finally {
             if (d.exists()) {
                 deleteDirectory(OUTPUT_DIR);
@@ -1469,11 +1460,9 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             byte[] imageBytes = source.readByteArray();
             InputStream imageStream = new ByteArrayInputStream(imageBytes);
             BufferedImage resizedImage = ImageIO.read(imageStream);
-            
-            
+
             assert resizedImage.getWidth() == CROPPED_WIDTH;
             assert resizedImage.getHeight() == CROPPED_HEIGHT;
-
         } finally {
             ypImageSaver.close();
         }
@@ -1545,10 +1534,8 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             InputStream imageStream = new ByteArrayInputStream(imageBytes);
             resizedImage = ImageIO.read(imageStream);
             
-            
             assert resizedImage.getWidth() == CROPPED_WIDTH;
             assert resizedImage.getHeight() == CROPPED_HEIGHT;
-
         } finally {
             if (d.exists()) {
                 deleteDirectory(OUTPUT_DIR);
@@ -1610,7 +1597,6 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             // Since savedResolution was set, the image dimensions should correspond to the longEdge value
             assert resizedImage.getWidth() == RESIZED_IMAGE_WIDTH;
             assert resizedImage.getHeight() == RESIZED_IMAGE_HEIGHT;
-
         } finally {
             if (d.exists()) {
                 deleteDirectory(OUTPUT_DIR);
@@ -1673,7 +1659,6 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             // Since the savedResolution was too large, image dimensions should correspond to the preCrop values
             assert resizedImage.getWidth() == CROPPED_WIDTH;
             assert resizedImage.getHeight() == CROPPED_HEIGHT;
-
         } finally {
             if (d.exists()) {
                 deleteDirectory(OUTPUT_DIR);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -141,8 +141,8 @@ public class TestYoloQueries extends NeuralNetTestBase {
         if (vantiq != null && vantiq.isAuthenticated()) {
             deleteSource(vantiq);
 
-            for (int i = 0; i < vantiqUploadFiles.size(); i++) {
-                deleteFileFromVantiq(vantiqUploadFiles.get(i));
+            for (String vantiqUploadFile : vantiqUploadFiles) {
+                deleteFileFromVantiq(vantiqUploadFile);
             }
         }
         deleteDirectory(OUTPUT_DIR);
@@ -152,8 +152,8 @@ public class TestYoloQueries extends NeuralNetTestBase {
     public void deleteOldFiles() {
         if (vantiq != null && vantiq.isAuthenticated()) {
             // Deleting all the files from VANTIQ, and deleting local directory for next test
-            for (int i = 0; i < vantiqUploadFiles.size(); i++) {
-                deleteFileFromVantiq(vantiqUploadFiles.get(i));
+            for (String vantiqUploadFile : vantiqUploadFiles) {
+                deleteFileFromVantiq(vantiqUploadFile);
             }
         }
         deleteDirectory(OUTPUT_DIR);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -113,20 +113,23 @@ public class TestYoloQueries extends NeuralNetTestBase {
     
     @BeforeClass
     public static void setup() {
-        vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
-        vantiq.setAccessToken(testAuthToken);
-        
-        // Add files to be deleted from VANTIQ later
-        vantiqUploadFiles.add(IMAGE_1.get("filename"));
-        vantiqUploadFiles.add(IMAGE_2.get("filename"));
-        vantiqUploadFiles.add(IMAGE_3.get("filename"));
-        vantiqUploadFiles.add(IMAGE_4.get("filename"));
-        vantiqUploadFiles.add(IMAGE_5.get("filename"));
-        vantiqUploadFiles.add(IMAGE_6.get("filename"));
-        vantiqUploadFiles.add(IMAGE_7.get("filename"));
-        vantiqUploadFiles.add(IMAGE_8.get("filename"));
-        
-        setupSource(createSourceDef());
+        if (testAuthToken != null && testVantiqServer != null) {
+
+            vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
+            vantiq.setAccessToken(testAuthToken);
+
+            // Add files to be deleted from VANTIQ later
+            vantiqUploadFiles.add(IMAGE_1.get("filename"));
+            vantiqUploadFiles.add(IMAGE_2.get("filename"));
+            vantiqUploadFiles.add(IMAGE_3.get("filename"));
+            vantiqUploadFiles.add(IMAGE_4.get("filename"));
+            vantiqUploadFiles.add(IMAGE_5.get("filename"));
+            vantiqUploadFiles.add(IMAGE_6.get("filename"));
+            vantiqUploadFiles.add(IMAGE_7.get("filename"));
+            vantiqUploadFiles.add(IMAGE_8.get("filename"));
+
+            setupSource(createSourceDef());
+        }
     }
     
     @AfterClass
@@ -135,19 +138,23 @@ public class TestYoloQueries extends NeuralNetTestBase {
             core.stop();
             core = null;
         }
-        deleteSource(vantiq);
-        deleteDirectory(OUTPUT_DIR);
-        
-        for (int i = 0; i < vantiqUploadFiles.size(); i++) {
-            deleteFileFromVantiq(vantiqUploadFiles.get(i));
+        if (vantiq != null && vantiq.isAuthenticated()) {
+            deleteSource(vantiq);
+
+            for (int i = 0; i < vantiqUploadFiles.size(); i++) {
+                deleteFileFromVantiq(vantiqUploadFiles.get(i));
+            }
         }
+        deleteDirectory(OUTPUT_DIR);
     }
     
     @After
     public void deleteOldFiles() {
-        // Deleting all the files from VANTIQ, and deleting local directory for next test
-        for (int i = 0; i < vantiqUploadFiles.size(); i++) {
-            deleteFileFromVantiq(vantiqUploadFiles.get(i));
+        if (vantiq != null && vantiq.isAuthenticated()) {
+            // Deleting all the files from VANTIQ, and deleting local directory for next test
+            for (int i = 0; i < vantiqUploadFiles.size(); i++) {
+                deleteFileFromVantiq(vantiqUploadFiles.get(i));
+            }
         }
         deleteDirectory(OUTPUT_DIR);
     }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -131,7 +131,8 @@ public class TestYoloQueries extends NeuralNetTestBase {
             setupSource(createSourceDef());
         }
     }
-    
+
+    @SuppressWarnings("PMD.JUnit4TestShouldUseAfterAnnotation")
     @AfterClass
     public static void tearDown() {
         if (core != null) {

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueriesLocationMapper.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueriesLocationMapper.java
@@ -59,6 +59,7 @@ public class TestYoloQueriesLocationMapper extends NeuralNetTestBase {
         vantiq.setAccessToken(testAuthToken);
     }
 
+    @SuppressWarnings("PMD.JUnit4TestShouldUseAfterAnnotation")
     @AfterClass
     public static void tearDown() {
         if (core != null) {

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueriesLocationMapper.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueriesLocationMapper.java
@@ -65,9 +65,11 @@ public class TestYoloQueriesLocationMapper extends NeuralNetTestBase {
             core.stop();
             core = null;
         }
-        deleteSource(vantiq);
+        if (vantiq != null && vantiq.isAuthenticated()) {
+            deleteSource(vantiq);
+            deleteFilesFromVantiq();
+        }
         deleteDirectory(OUTPUT_DIR);
-        deleteFilesFromVantiq();
     }
 
     @After
@@ -79,7 +81,9 @@ public class TestYoloQueriesLocationMapper extends NeuralNetTestBase {
             core.stop();
             core = null;
         }
-        deleteSource(vantiq);
+        if (vantiq != null && vantiq.isAuthenticated()) {
+            deleteSource(vantiq);
+        }
     }
 
     @Test

--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Utils.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Utils.java
@@ -48,7 +48,7 @@ public class Utils {
 
     public static List<String> OPC_PUBLIC_SERVERS = Arrays.asList(
             // OPC_PUBLIC_SERVER_1,  // requires credentials & registration :-(
-            OPC_PUBLIC_SERVER_2,
+            // OPC_PUBLIC_SERVER_2,
             OPC_PUBLIC_SERVER_3,
             // OPC_PUBLIC_SERVER_4,  // not responding
             // OPC_PUBLIC_SERVER_5,  // returns that the service is unsupported.

--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Utils.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Utils.java
@@ -27,6 +27,7 @@ import org.junit.Assume;
 /**
  * A collection of Utility methods used by the OPC UA Extension Source unit tests
  */
+@SuppressWarnings("PMD.TooManyFields")
 @Slf4j
 public class Utils {
 

--- a/testConnector/src/test/java/io/vantiq/extsrc/testConnector/NoSendTestConnectorCore.java
+++ b/testConnector/src/test/java/io/vantiq/extsrc/testConnector/NoSendTestConnectorCore.java
@@ -45,14 +45,18 @@ public class NoSendTestConnectorCore extends TestConnectorCore {
 
     @Override
     public void close() {
-        client.declareUnhealthy();
+        if (client != null) {
+            client.declareUnhealthy();
+        }
         super.close();
         closed = true;
     }
 
     @Override
     public void stop() {
-        client.declareUnhealthy();
+        if (client != null) {
+            client.declareUnhealthy();
+        }
         super.stop();
         closed = true;
     }

--- a/udpSource/src/test/java/io/vantiq/extsrc/udp/TestConfigurableUDPSource.java
+++ b/udpSource/src/test/java/io/vantiq/extsrc/udp/TestConfigurableUDPSource.java
@@ -11,6 +11,7 @@ package io.vantiq.extsrc.udp;
 
 import static org.junit.Assume.assumeTrue;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -325,7 +326,7 @@ public class TestConfigurableUDPSource extends UDPTestBase {
         
         try {
             ConfigurableUDPSource.setupServer(config);
-            assert false; // Should throw RTE for an invalid or missing authToken
+            fail("Should fail with invalid authToken"); // Should throw RTE for an invalid or missing authToken
         } catch (RuntimeException e) {}
         
         config.put("authToken", "token");
@@ -337,9 +338,9 @@ public class TestConfigurableUDPSource extends UDPTestBase {
         assert ConfigurableUDPSource.targetVantiqServer.equals("ws://localhost:8080");
         assert ConfigurableUDPSource.MAX_UDP_DATA == 1024;
         assert ConfigurableUDPSource.LISTENING_PORT == 3141;
-        assertTrue ("Listen Addr: " + ConfigurableUDPSource.LISTENING_ADDRESS +
-                            " =?= localhost: " + InetAddress.getLocalHost(),
-                ConfigurableUDPSource.LISTENING_ADDRESS.equals(InetAddress.getLocalHost()));
+        assertTrue ("Listen Addr: " + ConfigurableUDPSource.LISTENING_ADDRESS.getHostName() +
+                            " =?= localhost: " + InetAddress.getLocalHost().getHostName(),
+                ConfigurableUDPSource.LISTENING_ADDRESS.getHostName().equals(InetAddress.getLocalHost().getHostName()));
         assert ConfigurableUDPSource.authToken.equals("token");
         
         

--- a/udpSource/src/test/java/io/vantiq/extsrc/udp/TestConfigurableUDPSource.java
+++ b/udpSource/src/test/java/io/vantiq/extsrc/udp/TestConfigurableUDPSource.java
@@ -318,9 +318,9 @@ public class TestConfigurableUDPSource extends UDPTestBase {
         assert secondHandler.getVariable().get("data") == null;
         
     }
-    
+
+    @SuppressWarnings({"PMD.JUnitUseExpected", "unchecked", "rawtypes"})
     @Test
-    @SuppressWarnings({"unchecked", "rawtypes"})
     public void testSetupServer() throws UnknownHostException, IOException {
         Map config = new LinkedHashMap<>();
         

--- a/udpSource/src/test/java/io/vantiq/extsrc/udp/TestConfigurableUDPSource.java
+++ b/udpSource/src/test/java/io/vantiq/extsrc/udp/TestConfigurableUDPSource.java
@@ -9,6 +9,7 @@
 
 package io.vantiq.extsrc.udp;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -345,12 +346,13 @@ public class TestConfigurableUDPSource extends UDPTestBase {
         // Moreover, on Jenkins, InetAddress.getLocalHost() seems to return the loopback address
         // during the setup code, but here returns the IP address. Socket stuff works around
         // that by verifying that can connect to ourselves
+
         ServerSocket ss = new ServerSocket(9999);
-        ss.getInetAddress();
+        // Here, if we can't connect, it'll through an exception, failing the test
         Socket s = new Socket(ConfigurableUDPSource.LISTENING_ADDRESS, 9999);
-        assertTrue ("Listen Addr: " + ConfigurableUDPSource.LISTENING_ADDRESS +
-                            " =?= localhost: " + ss.getInetAddress(),
-                ConfigurableUDPSource.LISTENING_ADDRESS.equals(s.getInetAddress()));
+        assertEquals ("Listen Addr: " + ConfigurableUDPSource.LISTENING_ADDRESS +
+                            " =?= localhost: " + s.getInetAddress(),
+                s.getInetAddress(), ConfigurableUDPSource.LISTENING_ADDRESS);
         assert ConfigurableUDPSource.authToken.equals("token");
         
         

--- a/udpSource/src/test/java/io/vantiq/extsrc/udp/TestConfigurableUDPSource.java
+++ b/udpSource/src/test/java/io/vantiq/extsrc/udp/TestConfigurableUDPSource.java
@@ -10,6 +10,7 @@
 package io.vantiq.extsrc.udp;
 
 import static org.junit.Assume.assumeTrue;
+import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -25,7 +26,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import io.vantiq.extjsdk.Utils;
 import org.junit.After;
@@ -337,7 +337,9 @@ public class TestConfigurableUDPSource extends UDPTestBase {
         assert ConfigurableUDPSource.targetVantiqServer.equals("ws://localhost:8080");
         assert ConfigurableUDPSource.MAX_UDP_DATA == 1024;
         assert ConfigurableUDPSource.LISTENING_PORT == 3141;
-        assert ConfigurableUDPSource.LISTENING_ADDRESS.equals(InetAddress.getLocalHost());
+        assertTrue ("Listen Addr: " + ConfigurableUDPSource.LISTENING_ADDRESS +
+                            " =?= localhost: " + InetAddress.getLocalHost(),
+                ConfigurableUDPSource.LISTENING_ADDRESS.equals(InetAddress.getLocalHost()));
         assert ConfigurableUDPSource.authToken.equals("token");
         
         

--- a/udpSource/src/test/java/io/vantiq/extsrc/udp/TestConfigurableUDPSource.java
+++ b/udpSource/src/test/java/io/vantiq/extsrc/udp/TestConfigurableUDPSource.java
@@ -11,7 +11,6 @@ package io.vantiq.extsrc.udp;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.BufferedWriter;
@@ -347,7 +346,7 @@ public class TestConfigurableUDPSource extends UDPTestBase {
         // during the setup code, but here returns the IP address. Socket stuff works around
         // that by verifying that can connect to ourselves
 
-        ServerSocket ss = new ServerSocket(9999);
+        new ServerSocket(9999);
         // Here, if we can't connect, it'll through an exception, failing the test
         Socket s = new Socket(ConfigurableUDPSource.LISTENING_ADDRESS, 9999);
         assertEquals ("Listen Addr: " + ConfigurableUDPSource.LISTENING_ADDRESS +


### PR DESCRIPTION
Fixes #262 
Fixes #261

Remove server from public list that's dropped offline (for now).  Make the properly configured opcua tests pass

Fixed a bunch of other connectors that fail things where they should just skip the tests.

At this point, when this is merged, with no relevant gradle props defined, the tests that should skip all just skip.  Most things pass except for 3 in OR connector (some coords are different & some online camera appears to no longer work).  Also, a couple of tests in the test connector fail -- looks like there some test setup issue (`start` doesn't appear to be called so there are some variables left null).

I'll leave those for now. 