### PR TITLE
Updating OkHttp to the latest version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ group 'io.vantiq'
 ext {
     slf4jApiVersion = '1.7.25'
     eclipseMiloVersion = '0.2.1'
-    vantiqSDKVersion = "1.0.28"
+    vantiqSDKVersion = '1.0.28'
 }
 
 

--- a/extjsdk/README.md
+++ b/extjsdk/README.md
@@ -18,8 +18,7 @@ ExtensionWebSocketListener to handle various message types.
 4.	Copy and connect extjsdk.jar to your project.
 5.	Include the following dependencies through Gradle, Maven, or whatever build manager you are using. Links to the
 dependencies on mvnrepository.com are included.
-	*	[com.squareup.okhttp3:okhttp Version 3.4.1](https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp/3.4.1)
-	*	[com.squareup.okhttp3:okhttp-ws Version 3.4.1](https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp-ws/3.4.1)
+	*	[com.squareup.okhttp3:okhttp Version 4.9.1](https://mvnrepository.com/artifact/com.squareup.okhttp3/okhttp/4.9.1)
 	*	[com.fasterxml.jackson.core:jackson-databind Version 2.9.3](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.9.3)
     *   [org.slf4j:slf4j-api Version 1.7.25](https://mvnrepository.com/artifact/org.slf4j/slf4j-api/1.7.25)
 

--- a/extjsdk/README.md
+++ b/extjsdk/README.md
@@ -35,6 +35,7 @@ qualified class name, appended by a '#' and the name of the source they are asso
 
 ## <a name="serverConfig" id="serverConfig"></a>Connector Startup Configuration
 Generally, connectors need a minimum of three configuration properties at startup:
+
 *   `targetServer`: The URL of the Vantiq server to which the connector should connect.
 *   `authToken`: The access token that the connector will use to authenticate to the desired namespace.
 *   `source(s)`: The name of the source in the namespace (or in some cases a list of comma-separated source names) 
@@ -47,6 +48,7 @@ The SDK includes a utility method to retrieve the startup configuration document
 directory if it is not found in the `serverConfig` subdirectory (i.e. `<connectorWorkingDirector>/server.config`).
 
 In addition to the minimum configuration properties, the `server.config` file can also include the following property:
+
 *   `sendPings`: A boolean property that, if set to `true`, enables the SDK to send ping messages to the Vantiq Server. 
 The ping messages are handled by the underlying OkHttp library.
 

--- a/extjsdk/README.md
+++ b/extjsdk/README.md
@@ -46,6 +46,10 @@ The SDK includes a utility method to retrieve the startup configuration document
 `<connectorWorkingDirector>/serverConfig/server.config`. The SDK will also look for the file in the working connector 
 directory if it is not found in the `serverConfig` subdirectory (i.e. `<connectorWorkingDirector>/server.config`).
 
+In addition to the minimum configuration properties, the `server.config` file can also include the following property:
+*   `sendPings`: A boolean property that, if set to `true`, enables the SDK to send ping messages to the Vantiq Server. 
+The ping messages are handled by the underlying OkHttp library.
+
 For users who may not want to write the `authToken` property to a file because of its sensitive nature, the 
 `Utils.obtainServerConfig()` method will also search for this value in an environment variable named 
 `CONNECTOR_AUTH_TOKEN`. If the `authToken` is specified in the `server.config` document, that value will take precedence.
@@ -59,6 +63,7 @@ variable instead):
 authToken=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 sources=MySourceName
 targetServer=https://dev.vantiq.com/
+sendPings=true
 ```
 
 ## Program Flow

--- a/extjsdk/build.gradle
+++ b/extjsdk/build.gradle
@@ -22,7 +22,7 @@ ext {
     metricsVersion = '4.0.2'
     rxjavaVersion = '2.1.11'
     slf4jApiVersion = '1.7.25'
-    okhttpVersion = '3.4.1'
+    okhttpVersion = '4.9.1'
 }
 
 // Copies the README and licenses into the jar
@@ -75,7 +75,6 @@ dependencies {
 
 
     compile "com.squareup.okhttp3:okhttp:${okhttpVersion}"
-    compile "com.squareup.okhttp3:okhttp-ws:${okhttpVersion}"
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
 
     testCompile group: 'junit', name: 'junit', version: '4.12'

--- a/extjsdk/build.gradle
+++ b/extjsdk/build.gradle
@@ -71,7 +71,6 @@ dependencies {
     compile "org.slf4j:slf4j-api:1.7.25"
     compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.0"
 
-
     compile "com.squareup.okhttp3:okhttp:${okhttpVersion}"
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
 

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -17,8 +17,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 // WebSocket imports
 import okhttp3.*;
-import okhttp3.ws.WebSocket;
-import okhttp3.ws.WebSocketCall;
 
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -32,6 +30,7 @@ import java.util.Queue;
 import com.google.common.collect.EvictingQueue;
 
 // Logging
+import okio.ByteString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -298,9 +297,8 @@ public class ExtensionWebSocketClient {
                     .readTimeout(0, TimeUnit.MILLISECONDS)
                     .writeTimeout(0, TimeUnit.MILLISECONDS)
                     .build();
-            WebSocketCall.create(client, new Request.Builder()
-                    .url(validifyUrl(url))
-                    .build()).enqueue(listener);
+            Request request = new Request.Builder().url(validifyUrl(url)).build();
+            webSocket = client.newWebSocket(request, listener);
         }
         return webSocketFuture;
     }
@@ -511,7 +509,7 @@ public class ExtensionWebSocketClient {
             byte[] bytes = mapper.writeValueAsBytes(obj);
             synchronized (this) {
                 if (webSocket != null) {
-                    this.webSocket.sendMessage(RequestBody.create(WebSocket.BINARY, bytes));
+                    this.webSocket.send(ByteString.of(bytes));
                 }
             }
         }

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2018 Vantiq, Inc.
+ * Copyright (c) 2021 Vantiq, Inc.
  *
  * All rights reserved.
  * 
@@ -9,14 +9,16 @@
 
 package io.vantiq.extjsdk;
 
-// Author: Alex Blumer
-// Email: alex.j.blumer@gmail.com
+// Authors: Alex Blumer, Namir Fawaz, Fred Carter
+// Email: support@vantiq.com
 
 // For decoding of the messages received
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 // WebSocket imports
-import okhttp3.*;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.WebSocket;
 
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -293,10 +295,17 @@ public class ExtensionWebSocketClient {
             webSocketFuture = new CompletableFuture<>();
 
             // Start the connection attempt
-            OkHttpClient client = new OkHttpClient.Builder()
+            OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder()
                     .readTimeout(0, TimeUnit.MILLISECONDS)
-                    .writeTimeout(0, TimeUnit.MILLISECONDS)
-                    .build();
+                    .writeTimeout(0, TimeUnit.MILLISECONDS);
+
+            boolean sendPings = Utils.obtainSendPingStatus();
+            if (sendPings) {
+                clientBuilder.pingInterval(5000, TimeUnit.MILLISECONDS);
+            }
+
+            OkHttpClient client = clientBuilder.build();
+
             Request request = new Request.Builder().url(validifyUrl(url)).build();
             webSocket = client.newWebSocket(request, listener);
         }

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
 import okio.ByteString;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,30 +38,36 @@ public class ExtensionWebSocketListener extends WebSocketListener {
      * {@link #setHttpHandler}
      */
     Handler<Response> httpHandler = null;
+
     /**
      * {@link Handler} that handles Publish requests received by this listener. Set by {@link #setPublishHandler}
      */
     Handler<ExtensionServiceMessage> publishHandler = null;
+
     /**
      * {@link Handler} that handles Query requests received by this listener. Set by {@link #setQueryHandler}
      */
     Handler<ExtensionServiceMessage> queryHandler = null;
+
     /**
      * {@link Handler} that handles Configuration messages received by this listener. Configuration messages are sent
      * in response to connection messages, so this should be set before sending the connection message to a source. Set
      * by {@link #setConfigHandler}
      */
     Handler<ExtensionServiceMessage> configHandler = null;
+
     /**
      * {@link Handler} that handles responses to auth messages, both successful and not. Strictly speaking, it handles
      * all Http responses received by this listener before and upon successful authentication, as no other
      * Http responses are expected until after authorization. Set by {@link #setAuthHandler}
      */
     Handler<Response> authHandler = null;
+
     /**
      * {@link Handler} that handles reconnect messages. Set by {@link #setReconnectHandler}
      */
     Handler<ExtensionServiceMessage> reconnectHandler = null;
+
     /**
      * An Slf4j logger
      */
@@ -75,6 +82,7 @@ public class ExtensionWebSocketListener extends WebSocketListener {
      * {@link ObjectMapper} used to translate the received message into a {@link Map}
      */
     ObjectMapper mapper = new ObjectMapper();
+
     /**
      * Whether this listener has been closed, and should not make any more changes to its client.
      */
@@ -102,6 +110,7 @@ public class ExtensionWebSocketListener extends WebSocketListener {
     public void setHttpHandler(Handler<Response> httpHandler) {
         this.httpHandler = httpHandler;
     }
+
     /**
      * Set the {@link Handler} for any Publish messages that are received.
      * <br>
@@ -114,6 +123,7 @@ public class ExtensionWebSocketListener extends WebSocketListener {
     public void setPublishHandler(Handler<ExtensionServiceMessage> publishHandler) {
         this.publishHandler = publishHandler;
     }
+
     /**
      * Set the {@link Handler} for any queries that are received.
      * <br>
@@ -131,6 +141,7 @@ public class ExtensionWebSocketListener extends WebSocketListener {
     public void setQueryHandler(Handler<ExtensionServiceMessage> queryHandler) {
         this.queryHandler = queryHandler;
     }
+
     /**
      * Set the {@link Handler} for any Configuration messages that are returned.
      * <p>
@@ -147,6 +158,7 @@ public class ExtensionWebSocketListener extends WebSocketListener {
     public void setConfigHandler(Handler<ExtensionServiceMessage> configHandler) {
         this.configHandler = configHandler;
     }
+
     /**
      * Set the {@link Handler} for the result of any message received before a successful authentication attempt,
      * and the result of the authentication attempt.
@@ -161,6 +173,7 @@ public class ExtensionWebSocketListener extends WebSocketListener {
     public void setAuthHandler(Handler<Response> authHandler) {
         this.authHandler = authHandler;
     }
+
     /**
      * Set the {@link Handler} that will deal with any reconnect messages received. These will occur when an event 
      * happens on the Vantiq servers that requires the source to shut down. To restart the connection, just call 
@@ -200,12 +213,11 @@ public class ExtensionWebSocketListener extends WebSocketListener {
      * @param response  The {@link okhttp3.Response} associated with the opening of the connection. Currently not used.
      */
     @Override
-    public void onOpen(WebSocket webSocket, okhttp3.Response response) {
+    public void onOpen(@NotNull WebSocket webSocket, @NotNull okhttp3.Response response) {
         this.client.webSocketFuture.complete(true);
         log.info("WebSocket open");
     }
 
-    
     /**
      * Translate the received message and pass it on to the related handler. Additionally, updates the client about
      * successful authentications and source connections.
@@ -214,7 +226,7 @@ public class ExtensionWebSocketListener extends WebSocketListener {
      * @param bodyBytes  The {@link ByteString} containing the message received.
      */
     @Override
-    public void onMessage(WebSocket webSocket, ByteString bodyBytes) {
+    public void onMessage(@NotNull WebSocket webSocket, ByteString bodyBytes) {
         // Extract the original message from the body
         byte[] data = bodyBytes.toByteArray();
 
@@ -435,7 +447,7 @@ public class ExtensionWebSocketListener extends WebSocketListener {
      * @param reason    The {@link String} describing why it closed
      */
     @Override
-    public void onClosing(WebSocket webSocket, int code, String reason) {
+    public void onClosing(@NotNull WebSocket webSocket, int code, @NotNull String reason) {
         log.info("Closing websocket code: {}", code);
         log.debug(reason);
     }
@@ -448,7 +460,7 @@ public class ExtensionWebSocketListener extends WebSocketListener {
      * @param reason    The {@link String} describing why it closed
      */
     @Override
-    public void onClosed(WebSocket webSocket, int code, String reason) {
+    public void onClosed(@NotNull WebSocket webSocket, int code, @NotNull String reason) {
         log.info("Closed websocket code: {}", code);
         log.debug(reason);
         if (client.isOpen() && client.webSocket != null) {
@@ -464,7 +476,7 @@ public class ExtensionWebSocketListener extends WebSocketListener {
      * @param response  The {@link okhttp3.Response} that caused the failure, if any.
      */
     @Override
-    public void onFailure(WebSocket webSocket, Throwable t, okhttp3.Response response) {
+    public void onFailure(@NotNull WebSocket webSocket, @NotNull Throwable t, okhttp3.Response response) {
         if (t instanceof EOFException) { // An EOF exception appears on closing the websocket connection
             if (t.getMessage() != null) {
                 log.error("EOFException: {}", t.getMessage());

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketListener.java
@@ -27,6 +27,7 @@ import java.util.Map;
  * A listener that deals with messages received from a Vantiq deployment for Extension sources. It uses {@link Handler}
  * to allow users to specify how different types of messages are dealt with.
  */
+@SuppressWarnings("PMD.GuardLogStatement")
 public class ExtensionWebSocketListener extends WebSocketListener {
     // Each Handler effectively says what to do when receiving a message of its message type, or a response to its
     // message type in the case of authenticationHandler
@@ -468,11 +469,9 @@ public class ExtensionWebSocketListener extends WebSocketListener {
             if (t.getMessage() != null) {
                 log.error("EOFException: {}", t.getMessage());
             }
-        }
-        else if (t instanceof ConnectException) {
+        } else if (t instanceof ConnectException) {
             log.error("{}: {}", t.getClass().toString(), t.getMessage());
-        }
-        else {
+        } else {
             log.error("Failure occurred in listener", t);
         }
 

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/Handler.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/Handler.java
@@ -10,7 +10,7 @@
 package io.vantiq.extjsdk;
 
 // Author: Alex Blumer
-// Email: alex.j.blumer@gmail.com
+// Email: support@vantiq.com
 
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
@@ -10,6 +10,7 @@ import java.util.Properties;
 
 public class Utils {
 
+    public static final String SEND_PING_PROPERTY_NAME = "sendPings";
     public static final String PORT_PROPERTY_NAME = "tcpProbePort";
     public static final String SERVER_CONFIG_DIR = "serverConfig";
     public static final String SERVER_CONFIG_FILENAME = "server.config";
@@ -84,4 +85,30 @@ public class Utils {
             return null;
         }
     }
+
+    public static boolean obtainSendPingStatus() {
+        File configFile = new File(SERVER_CONFIG_DIR, SERVER_CONFIG_FILENAME);
+        Properties properties = new Properties();
+
+        try {
+            if (!configFile.exists()) {
+                configFile = new File(SERVER_CONFIG_FILENAME);
+                if (!configFile.exists()) {
+                    return false;
+                }
+            }
+            properties.load(Files.newInputStream(configFile.toPath()));
+            String sendPingString = properties.getProperty(SEND_PING_PROPERTY_NAME);
+            if (sendPingString != null) {
+                return Boolean.parseBoolean(sendPingString);
+            } else {
+                return false;
+            }
+        } catch (IOException e) {
+            log.error("An error occurred while trying to retrieve the sendPings value.", e);
+            return false;
+        }
+    }
+
+    // TODO NAMIR - Add helper that returns the properties object since that code is repeated
 }

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/ExtjsdkTestBase.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/ExtjsdkTestBase.java
@@ -10,7 +10,7 @@
 package io.vantiq.extjsdk;
 
 //Author: Alex Blumer
-//Email: alex.j.blumer@gmail.com
+//Email: support@vantiq.com
 
 import java.util.function.Supplier;
 

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/FalseClient.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/FalseClient.java
@@ -10,7 +10,7 @@
 package io.vantiq.extjsdk;
 
 //Author: Alex Blumer
-//Email: alex.j.blumer@gmail.com
+//Email: support@vantiq.com
 
 
 import java.io.IOException;

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/FalseClient.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/FalseClient.java
@@ -12,7 +12,6 @@ package io.vantiq.extjsdk;
 //Author: Alex Blumer
 //Email: support@vantiq.com
 
-
 import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/FalseWebSocket.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/FalseWebSocket.java
@@ -49,19 +49,23 @@ public class FalseWebSocket implements WebSocket {
     public boolean close(int code, String reason) {
         return true;
     }
+
     @Override
     public void cancel() {
 
     }
+
     @Override
     public long queueSize() {
         return 0;
     }
+
     @NotNull
     @Override
     public Request request() {
         return new Request.Builder().build();
     }
+
     @Override
     public boolean send(String s) {
         return false;
@@ -88,141 +92,170 @@ public class FalseWebSocket implements WebSocket {
         public void write(@NotNull Buffer source, long byteCount) {
 
         }
+
         @NotNull
         @Override
         public Timeout timeout() {
             return new Timeout();
         }
+
         @Override
         public boolean isOpen() {
             return false;
         }
+
         @Override
         public void close() {
 
         }
+
         @NotNull
         @Override
         public Buffer buffer() {
             return new Buffer();
         }
+
         @NotNull
         @Override
         public BufferedSink write(@NotNull ByteString byteString, int offset, int byteCount) {
             return new FalseBufferedSink();
         }
+
         @NotNull
         @Override
         public BufferedSink write(@NotNull byte[] source) {
             return new FalseBufferedSink();
         }
+
         @Override
         public long writeAll(@NotNull Source source) {
             return 0;
         }
+
         @NotNull
         @Override
         public BufferedSink write(@NotNull Source source, long byteCount) {
             return new FalseBufferedSink();
         }
+
         @NotNull
         @Override
         public BufferedSink write(@NotNull byte[] bytes, int i, int i1) {
             return new FalseBufferedSink();
         }
+
         @Override
         public int write(ByteBuffer src) {
             return 0;
         }
+
         @NotNull
         @Override
         public BufferedSink writeUtf8(@NotNull String string) {
             return new FalseBufferedSink();
         }
+
         @NotNull
         @Override
         public BufferedSink writeUtf8(@NotNull String string, int beginIndex, int endIndex) {
             return new FalseBufferedSink();
         }
+
         @NotNull
         @Override
         public BufferedSink writeUtf8CodePoint(int codePoint) {
             return new FalseBufferedSink();
         }
+
         @NotNull
         @Override
         public BufferedSink writeString(@NotNull String string, @NotNull Charset charset) {
             return new FalseBufferedSink();
         }
+
         @NotNull
         @Override
         public BufferedSink writeString(@NotNull String string, int beginIndex, int endIndex, @NotNull Charset charset) {
             return new FalseBufferedSink();
         }
+
         @NotNull
         @Override
         public BufferedSink writeByte(int b) {
             return new FalseBufferedSink();
         }
+
         @NotNull
         @Override
         public BufferedSink writeShort(int s) {
             return new FalseBufferedSink();
         }
+
         @NotNull
         @Override
         public BufferedSink writeShortLe(int s) {
             return new FalseBufferedSink();
         }
+
         @NotNull
         @Override
         public BufferedSink writeInt(int i) {
             return new FalseBufferedSink();
         }
+
         @NotNull
         @Override
         public BufferedSink writeIntLe(int i) {
             return new FalseBufferedSink();
         }
+
         @NotNull
         @Override
         public BufferedSink writeLong(long v) {
             return new FalseBufferedSink();
         }
+
         @NotNull
         @Override
         public BufferedSink writeLongLe(long v) {
             return new FalseBufferedSink();
         }
+
         @NotNull
         @Override
         public BufferedSink writeDecimalLong(long v) {
             return new FalseBufferedSink();
         }
+
         @NotNull
         @Override
         public BufferedSink writeHexadecimalUnsignedLong(long v) {
             return new FalseBufferedSink();
         }
+
         @Override
         public void flush() {
 
         }
+
         @NotNull
         @Override
         public BufferedSink emit() {
             return new FalseBufferedSink();
         }
+
         @NotNull
         @Override
         public BufferedSink emitCompleteSegments() {
             return new FalseBufferedSink();
         }
+
         @NotNull
         @Override
         public OutputStream outputStream() {
             return new ByteArrayOutputStream();
         }
+
         @NotNull
         @Override
         public Buffer getBuffer() {

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/FalseWebSocket.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/FalseWebSocket.java
@@ -12,8 +12,7 @@ package io.vantiq.extjsdk;
 //Authors: Alex Blumer, Namir Fawaz, Fred Carter
 //Email: support@vantiq.com
 
-
-import java.io.IOException;
+import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -25,6 +24,7 @@ import okio.BufferedSink;
 import okio.ByteString;
 import okio.Source;
 import okio.Timeout;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * The WebSocket used by {@link FalseClient}. The data stored here can be accessed through 
@@ -38,7 +38,7 @@ public class FalseWebSocket implements WebSocket {
     }
     
     @Override
-    public boolean send(ByteString bytes) {
+    public boolean send(@NotNull ByteString bytes) {
         s.write(bytes);
         return true;
     }
@@ -46,18 +46,29 @@ public class FalseWebSocket implements WebSocket {
     //================================ Necessary to implement WebSocket ================================
 
     @Override
-    public boolean close(int code, String reason) {return true;}
+    public boolean close(int code, String reason) {
+        return true;
+    }
     @Override
-    public void cancel() {}
+    public void cancel() {
+
+    }
     @Override
-    public long queueSize() {return 0;}
+    public long queueSize() {
+        return 0;
+    }
+    @NotNull
     @Override
-    public Request request() {return null;}
+    public Request request() {
+        return new Request.Builder().build();
+    }
     @Override
-    public boolean send(String s) {return false;}
+    public boolean send(String s) {
+        return false;
+    }
 
     // Buffered Sink implementation
-    public class FalseBufferedSink implements BufferedSink {
+    public static class FalseBufferedSink implements BufferedSink {
         ByteString savedBytes = null;
         
         public byte[] retrieveSentBytes() {
@@ -65,73 +76,158 @@ public class FalseWebSocket implements WebSocket {
         }
         
         // Called by FalseWebSocket.send()
+        @NotNull
         @Override
-        public BufferedSink write(ByteString source) {
+        public BufferedSink write(@NotNull ByteString source) {
             savedBytes = source;
-            return null;
+            return new FalseBufferedSink();
         }
 
         //================================ Necessary to implement BufferedSink ================================
         @Override
-        public void write(Buffer source, long byteCount) {}
+        public void write(@NotNull Buffer source, long byteCount) {
+
+        }
+        @NotNull
         @Override
-        public Timeout timeout() {return null;}
+        public Timeout timeout() {
+            return new Timeout();
+        }
         @Override
-        public boolean isOpen() {return false;}
+        public boolean isOpen() {
+            return false;
+        }
         @Override
-        public void close() {}
+        public void close() {
+
+        }
+        @NotNull
         @Override
-        public Buffer buffer() {return null;}
+        public Buffer buffer() {
+            return new Buffer();
+        }
+        @NotNull
         @Override
-        public BufferedSink write(ByteString byteString, int offset, int byteCount) {return null;}
+        public BufferedSink write(@NotNull ByteString byteString, int offset, int byteCount) {
+            return new FalseBufferedSink();
+        }
+        @NotNull
         @Override
-        public BufferedSink write(byte[] source) {return null;}
+        public BufferedSink write(@NotNull byte[] source) {
+            return new FalseBufferedSink();
+        }
         @Override
-        public long writeAll(Source source) {return 0;}
+        public long writeAll(@NotNull Source source) {
+            return 0;
+        }
+        @NotNull
         @Override
-        public BufferedSink write(Source source, long byteCount) {return null;}
+        public BufferedSink write(@NotNull Source source, long byteCount) {
+            return new FalseBufferedSink();
+        }
+        @NotNull
         @Override
-        public BufferedSink write(byte[] bytes, int i, int i1) {return null;}
+        public BufferedSink write(@NotNull byte[] bytes, int i, int i1) {
+            return new FalseBufferedSink();
+        }
         @Override
-        public int write(ByteBuffer src) {return 0;}
+        public int write(ByteBuffer src) {
+            return 0;
+        }
+        @NotNull
         @Override
-        public BufferedSink writeUtf8(String string) {return null;}
+        public BufferedSink writeUtf8(@NotNull String string) {
+            return new FalseBufferedSink();
+        }
+        @NotNull
         @Override
-        public BufferedSink writeUtf8(String string, int beginIndex, int endIndex) {return null;}
+        public BufferedSink writeUtf8(@NotNull String string, int beginIndex, int endIndex) {
+            return new FalseBufferedSink();
+        }
+        @NotNull
         @Override
-        public BufferedSink writeUtf8CodePoint(int codePoint)  {return null;}
+        public BufferedSink writeUtf8CodePoint(int codePoint) {
+            return new FalseBufferedSink();
+        }
+        @NotNull
         @Override
-        public BufferedSink writeString(String string, Charset charset)  {return null;}
+        public BufferedSink writeString(@NotNull String string, @NotNull Charset charset) {
+            return new FalseBufferedSink();
+        }
+        @NotNull
         @Override
-        public BufferedSink writeString(String string, int beginIndex, int endIndex, Charset charset) {return null;}
+        public BufferedSink writeString(@NotNull String string, int beginIndex, int endIndex, @NotNull Charset charset) {
+            return new FalseBufferedSink();
+        }
+        @NotNull
         @Override
-        public BufferedSink writeByte(int b) {return null;}
+        public BufferedSink writeByte(int b) {
+            return new FalseBufferedSink();
+        }
+        @NotNull
         @Override
-        public BufferedSink writeShort(int s) {return null;}
+        public BufferedSink writeShort(int s) {
+            return new FalseBufferedSink();
+        }
+        @NotNull
         @Override
-        public BufferedSink writeShortLe(int s) {return null;}
+        public BufferedSink writeShortLe(int s) {
+            return new FalseBufferedSink();
+        }
+        @NotNull
         @Override
-        public BufferedSink writeInt(int i) {return null;}
+        public BufferedSink writeInt(int i) {
+            return new FalseBufferedSink();
+        }
+        @NotNull
         @Override
-        public BufferedSink writeIntLe(int i) {return null;}
+        public BufferedSink writeIntLe(int i) {
+            return new FalseBufferedSink();
+        }
+        @NotNull
         @Override
-        public BufferedSink writeLong(long v) {return null;}
+        public BufferedSink writeLong(long v) {
+            return new FalseBufferedSink();
+        }
+        @NotNull
         @Override
-        public BufferedSink writeLongLe(long v) {return null;}
+        public BufferedSink writeLongLe(long v) {
+            return new FalseBufferedSink();
+        }
+        @NotNull
         @Override
-        public BufferedSink writeDecimalLong(long v) {return null;}
+        public BufferedSink writeDecimalLong(long v) {
+            return new FalseBufferedSink();
+        }
+        @NotNull
         @Override
-        public BufferedSink writeHexadecimalUnsignedLong(long v) {return null;}
+        public BufferedSink writeHexadecimalUnsignedLong(long v) {
+            return new FalseBufferedSink();
+        }
         @Override
-        public void flush() {}
+        public void flush() {
+
+        }
+        @NotNull
         @Override
-        public BufferedSink emit() {return null;}
+        public BufferedSink emit() {
+            return new FalseBufferedSink();
+        }
+        @NotNull
         @Override
-        public BufferedSink emitCompleteSegments() {return null;}
+        public BufferedSink emitCompleteSegments() {
+            return new FalseBufferedSink();
+        }
+        @NotNull
         @Override
-        public OutputStream outputStream() {return null;}
+        public OutputStream outputStream() {
+            return new ByteArrayOutputStream();
+        }
+        @NotNull
         @Override
-        public Buffer getBuffer() {return null;}
+        public Buffer getBuffer() {
+            return new Buffer();
+        }
     }
 }
 

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/FalseWebSocket.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/FalseWebSocket.java
@@ -67,7 +67,7 @@ public class FalseWebSocket implements WebSocket {
     }
 
     @Override
-    public boolean send(String s) {
+    public boolean send(@NotNull String s) {
         return false;
     }
 

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/FalseWebSocket.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/FalseWebSocket.java
@@ -9,7 +9,7 @@
 
 package io.vantiq.extjsdk;
 
-//Author: Alex Blumer, Namir Fawaz, Fred Carter
+//Authors: Alex Blumer, Namir Fawaz, Fred Carter
 //Email: support@vantiq.com
 
 

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/FalseWebSocket.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/FalseWebSocket.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2018 Vantiq, Inc.
+ * Copyright (c) 2021 Vantiq, Inc.
  *
  * All rights reserved.
  * 
@@ -9,16 +9,17 @@
 
 package io.vantiq.extjsdk;
 
-//Author: Alex Blumer
-//Email: alex.j.blumer@gmail.com
+//Author: Alex Blumer, Namir Fawaz, Fred Carter
+//Email: support@vantiq.com
 
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
-import okhttp3.RequestBody;
-import okhttp3.ws.WebSocket;
+import okhttp3.Request;
+import okhttp3.WebSocket;
 import okio.Buffer;
 import okio.BufferedSink;
 import okio.ByteString;
@@ -37,83 +38,100 @@ public class FalseWebSocket implements WebSocket {
     }
     
     @Override
-    public void sendMessage(RequestBody message) throws IOException {
-        message.writeTo(s);
+    public boolean send(ByteString bytes) {
+        s.write(bytes);
+        return true;
     }
 
+    //================================ Necessary to implement WebSocket ================================
+
     @Override
-    public void sendPing(Buffer payload) throws IOException {}
+    public boolean close(int code, String reason) {return true;}
     @Override
-    public void close(int code, String reason) throws IOException {}
-    
+    public void cancel() {}
+    @Override
+    public long queueSize() {return 0;}
+    @Override
+    public Request request() {return null;}
+    @Override
+    public boolean send(String s) {return false;}
+
+    // Buffered Sink implementation
     public class FalseBufferedSink implements BufferedSink {
-        byte[] savedBytes = null;
+        ByteString savedBytes = null;
         
         public byte[] retrieveSentBytes() {
-            return savedBytes;
+            return savedBytes != null ? savedBytes.toByteArray() : null;
         }
         
-        // Called by RequestBody.writeTo
+        // Called by FalseWebSocket.send()
         @Override
-        public BufferedSink write(byte[] source, int offset, int byteCount) throws IOException {
+        public BufferedSink write(ByteString source) {
             savedBytes = source;
             return null;
         }
-        
-    //================================ Necessary to implement BufferedSink ================================
+
+        //================================ Necessary to implement BufferedSink ================================
         @Override
-        public void write(Buffer source, long byteCount) throws IOException {}
+        public void write(Buffer source, long byteCount) {}
         @Override
         public Timeout timeout() {return null;}
         @Override
-        public void close() throws IOException {}
+        public boolean isOpen() {return false;}
+        @Override
+        public void close() {}
         @Override
         public Buffer buffer() {return null;}
         @Override
-        public BufferedSink write(ByteString byteString) throws IOException {return null;}
+        public BufferedSink write(ByteString byteString, int offset, int byteCount) {return null;}
         @Override
-        public BufferedSink write(byte[] source) throws IOException {return null;}
+        public BufferedSink write(byte[] source) {return null;}
         @Override
-        public long writeAll(Source source) throws IOException {return 0;}
+        public long writeAll(Source source) {return 0;}
         @Override
-        public BufferedSink write(Source source, long byteCount) throws IOException {return null;}
+        public BufferedSink write(Source source, long byteCount) {return null;}
         @Override
-        public BufferedSink writeUtf8(String string) throws IOException {return null;}
+        public BufferedSink write(byte[] bytes, int i, int i1) {return null;}
         @Override
-        public BufferedSink writeUtf8(String string, int beginIndex, int endIndex) throws IOException {return null;}
+        public int write(ByteBuffer src) {return 0;}
         @Override
-        public BufferedSink writeUtf8CodePoint(int codePoint) throws IOException {return null;}
+        public BufferedSink writeUtf8(String string) {return null;}
         @Override
-        public BufferedSink writeString(String string, Charset charset) throws IOException {return null;}
+        public BufferedSink writeUtf8(String string, int beginIndex, int endIndex) {return null;}
         @Override
-        public BufferedSink writeString(String string, int beginIndex, int endIndex, Charset charset)
-                throws IOException {return null;}
+        public BufferedSink writeUtf8CodePoint(int codePoint)  {return null;}
         @Override
-        public BufferedSink writeByte(int b) throws IOException {return null;}
+        public BufferedSink writeString(String string, Charset charset)  {return null;}
         @Override
-        public BufferedSink writeShort(int s) throws IOException {return null;}
+        public BufferedSink writeString(String string, int beginIndex, int endIndex, Charset charset) {return null;}
         @Override
-        public BufferedSink writeShortLe(int s) throws IOException {return null;}
+        public BufferedSink writeByte(int b) {return null;}
         @Override
-        public BufferedSink writeInt(int i) throws IOException {return null;}
+        public BufferedSink writeShort(int s) {return null;}
         @Override
-        public BufferedSink writeIntLe(int i) throws IOException {return null;}
+        public BufferedSink writeShortLe(int s) {return null;}
         @Override
-        public BufferedSink writeLong(long v) throws IOException {return null;}
+        public BufferedSink writeInt(int i) {return null;}
         @Override
-        public BufferedSink writeLongLe(long v) throws IOException {return null;}
+        public BufferedSink writeIntLe(int i) {return null;}
         @Override
-        public BufferedSink writeDecimalLong(long v) throws IOException {return null;}
+        public BufferedSink writeLong(long v) {return null;}
         @Override
-        public BufferedSink writeHexadecimalUnsignedLong(long v) throws IOException {return null;}
+        public BufferedSink writeLongLe(long v) {return null;}
         @Override
-        public void flush() throws IOException {}
+        public BufferedSink writeDecimalLong(long v) {return null;}
         @Override
-        public BufferedSink emit() throws IOException {return null;}
+        public BufferedSink writeHexadecimalUnsignedLong(long v) {return null;}
         @Override
-        public BufferedSink emitCompleteSegments() throws IOException {return null;}
+        public void flush() {}
+        @Override
+        public BufferedSink emit() {return null;}
+        @Override
+        public BufferedSink emitCompleteSegments() {return null;}
         @Override
         public OutputStream outputStream() {return null;}
+        @Override
+        public Buffer getBuffer() {return null;}
     }
 }
 

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
@@ -468,7 +468,7 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase {
     }
     
     // Merely makes several private functions public
-    private static class OpenExtensionWebSocketClient extends ExtensionWebSocketClient{
+    private static class OpenExtensionWebSocketClient extends ExtensionWebSocketClient {
         public OpenExtensionWebSocketClient(String sourceName) {
             super(sourceName);
         }

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
@@ -9,7 +9,7 @@
 
 package io.vantiq.extjsdk;
 
-//Author: Alex Blumer, Namir Fawaz, Fred Carter
+//Authors: Alex Blumer, Namir Fawaz, Fred Carter
 //Email: support@vantiq.com
 
 import okhttp3.Request;

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
@@ -517,10 +517,12 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase {
         public void cancel() {
 
         }
+
         @Override
         public long queueSize() {
             return 0;
         }
+
         @Override
         public boolean send(@NotNull String s) {
             return false;

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
@@ -9,12 +9,11 @@
 
 package io.vantiq.extjsdk;
 
-//Author: Alex Blumer
-//Email: alex.j.blumer@gmail.com
+//Author: Alex Blumer, Namir Fawaz, Fred Carter
+//Email: support@vantiq.com
 
-import okhttp3.ws.WebSocket;
-import okio.Buffer;
-import okhttp3.RequestBody;
+import okhttp3.Request;
+import okhttp3.WebSocket;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -24,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import okio.ByteString;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,7 +31,7 @@ import org.junit.Test;
 import static org.junit.Assert.fail;
 
 
-public class TestExtensionWebSocketClient extends ExtjsdkTestBase{
+public class TestExtensionWebSocketClient extends ExtjsdkTestBase {
     
     // Note: testing of connections occurs in TestExtensionWebSocketListener, as more of the relevant interactions occur
     // through ExtensionWebSocketListener
@@ -277,7 +277,7 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase{
         
         // Should make sourceConnection be recreated
         client.setAutoReconnect(true);
-        client.getListener().onMessage(TestListener.createReconnectMessage(""));
+        client.getListener().onMessage(null, TestListener.createReconnectMessage(""));
 
         assert !client.isConnected();
         assert !client.getSourceConnectionFuture().isDone(); 
@@ -357,7 +357,7 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase{
         newClient.webSocketFuture = CompletableFuture.completedFuture(true);
         newClient.authFuture = CompletableFuture.completedFuture(true);
         newClient.sourceFuture = CompletableFuture.completedFuture(false);
-        newClient.listener.onMessage(testListener.createConfigResponse(new LinkedHashMap<>(), srcName));
+        newClient.listener.onMessage(null, testListener.createConfigResponse(new LinkedHashMap<>(), srcName));
         assert newClient.failedMessageQueue.size() == 0;
 
         // Now lets do the same thing with a query
@@ -375,7 +375,7 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase{
         newClient.webSocketFuture = CompletableFuture.completedFuture(true);
         newClient.authFuture = CompletableFuture.completedFuture(true);
         newClient.sourceFuture = CompletableFuture.completedFuture(false);
-        newClient.listener.onMessage(testListener.createConfigResponse(new LinkedHashMap<>(), srcName));
+        newClient.listener.onMessage(null, testListener.createConfigResponse(new LinkedHashMap<>(), srcName));
         assert newClient.failedMessageQueue.size() == 0;
     }
 
@@ -482,23 +482,17 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase{
         
         Map<String,Object> lastData = null;
         boolean messageReceived = false;
-        
-        
+
         @Override
-        public void sendMessage(RequestBody body) {
-            Buffer buf = new Buffer();
+        public boolean send(ByteString bytes) {
             try {
-                body.writeTo(buf);
+                lastData = mapper.readValue(bytes.toByteArray(), Map.class);
             } catch (IOException e) {
                 e.printStackTrace();
             }
-            try {
-                lastData = mapper.readValue(buf.inputStream(), Map.class);
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-            
+
             messageReceived = true;
+            return messageReceived;
         }
         
         public boolean compareData(String key, Object expectedVal) {
@@ -511,9 +505,21 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase{
         }
 
         @Override
-        public void sendPing(Buffer payload) throws IOException {}
+        public boolean close(int code, String reason) {
+            client.getListener().onClosed(null, code,reason);
+            return true;
+        }
+
+        //================================ Necessary to implement WebSocket ================================
+
         @Override
-        public void close(int code, String reason) throws IOException {client.getListener().onClose(code,reason);}
+        public void cancel() {}
+        @Override
+        public long queueSize() {return 0;}
+        @Override
+        public Request request() {return null;}
+        @Override
+        public boolean send(String s) {return false;}
     }
     
     public static Object getTransformVal(Map map, String loc) {

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketListener.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketListener.java
@@ -9,7 +9,7 @@
 
 package io.vantiq.extjsdk;
 
-//Author: Alex Blumer
+//Authors: Alex Blumer, Namir Fawaz, Fred Carter
 //Email: support@vantiq.com
 
 import okhttp3.ResponseBody;

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketListener.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketListener.java
@@ -366,7 +366,6 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase {
 
         body = TestListener.createReconnectMessage(srcName);
         listener.onMessage(client.webSocket, body);
-        
     }
     
     @Test
@@ -390,6 +389,7 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase {
     private void open() {
         client.completeWebSocketConnection(true);
     }
+
     private void authenticate(boolean success) {
         if (!client.isOpen()) {
             open();
@@ -397,6 +397,7 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase {
         client.authenticate("unused");
         listener.onMessage(client.webSocket, TestListener.createAuthenticationResponse(success));
     }
+
     private void connectToSource(String sourceName, Map config) {
         if (!client.isAuthed()) {
             authenticate(true);
@@ -405,12 +406,10 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase {
         listener.onMessage(client.webSocket, TestListener.createConfigResponse(config, sourceName));
     }
 
-    
-    
-
     private class TestHandlerESM extends Handler<ExtensionServiceMessage> {
         public String lastOp = "";
         public ExtensionServiceMessage lastMessage = null;
+
         @Override
         public void handleMessage(ExtensionServiceMessage message) {
             lastOp = message.getOp();
@@ -420,13 +419,16 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase {
         public boolean compareOp(String expectedOp) {
             return lastOp.equals(expectedOp);
         }
+
         public boolean compareMessage(ExtensionServiceMessage expectedMessage) {
             if (lastMessage == expectedMessage) return true; // null case
             return lastMessage.equals(expectedMessage);
         }
+
         public boolean compareSourceName(String sourceName) {
             return lastMessage.getSourceName().equals(sourceName);
         }
+
         public boolean compareValue(String key, Object expectedVal) {
             Object actualVal = ((Map)lastMessage.getObject()).get(key);
             return expectedVal.equals(actualVal);
@@ -435,21 +437,27 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase {
     
     private class TestHandlerResp extends Handler<Response> {
         public Response lastMessage = null;
+
         @Override
         public void handleMessage(Response message) {
             lastMessage = message;
         }
 
         public boolean compareMessage(Response expectedMessage) {
-            if (lastMessage == expectedMessage) {return true;} // null case
+            if (lastMessage == expectedMessage) {
+                return true; // null case
+            }
             return expectedMessage.equals(lastMessage);
         }
+
         public boolean compareStatus(Integer expectedStatus) {
             return expectedStatus.equals(lastMessage.getStatus());
         }
+
         public boolean compareBody(Object expectedBody) {
             return lastMessage.getBody().equals(expectedBody);
         }
+
         public boolean compareHeader(String headerName, String expectedVal) {
             Object actualVal = lastMessage.getHeader(headerName);
             return expectedVal.equals(actualVal);

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketListener.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketListener.java
@@ -26,7 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-public class TestExtensionWebSocketListener extends ExtjsdkTestBase{
+public class TestExtensionWebSocketListener extends ExtjsdkTestBase {
 
     ExtensionWebSocketListener listener;
     FalseClient client;
@@ -37,6 +37,7 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase{
     TestHandlerESM rHandler;
     TestHandlerResp hHandler;
     String srcName;
+
     @Before
     public void setUp() {
         srcName = "src";
@@ -116,7 +117,7 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase{
     public void testSourceConnectionFailFirst() {
         authenticate(true);
         
-        listener.onMessage(null, TestListener.errorMessage());
+        listener.onMessage(client.webSocket, TestListener.errorMessage());
         
         assert !client.getSourceConnectionFuture().getNow(true); // It should be set to false now
         
@@ -144,7 +145,7 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase{
         
         authenticate(true);
         
-        listener.onMessage(null, TestListener.errorMessage());
+        listener.onMessage(client.webSocket, TestListener.errorMessage());
         
         assert !client.getSourceConnectionFuture().getNow(true); // It should be set to false now
         
@@ -170,7 +171,7 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase{
         publishMessage.put(key, val);
         
         ByteString body = TestListener.createPublishMessage(publishMessage, srcName);
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         
         assert pHandler.compareOp(ExtensionServiceMessage.OP_PUBLISH);
         assert pHandler.compareSourceName(srcName);
@@ -187,7 +188,7 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase{
         queryMessage.put(key, val);
         
         ByteString body = TestListener.createQueryMessage(queryMessage, srcName);
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         
         assert qHandler.compareOp(ExtensionServiceMessage.OP_QUERY);
         assert qHandler.compareSourceName( srcName);
@@ -201,7 +202,7 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase{
         Response resp = new Response().status(200);
         ByteString body = TestListener.createHttpMessage(resp);
         
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         
         assert hHandler.compareStatus(200);
     }
@@ -213,7 +214,7 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase{
         Response resp = new Response().status(403);
         ByteString body = TestListener.createHttpMessage(resp);
         
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         
         assert !client.getSourceConnectionFuture().getNow(true); // It should be set to false now
         assert hHandler.compareStatus(403);
@@ -225,7 +226,7 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase{
         
         ByteString body = TestListener.createReconnectMessage(srcName);
         
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         
         assert !client.isConnected();
         assert rHandler.compareOp(ExtensionServiceMessage.OP_RECONNECT_REQUIRED);
@@ -238,29 +239,29 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase{
         listener.close();
         
         ByteString body = TestListener.createReconnectMessage(srcName);
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         assert rHandler.compareMessage(null);
         
         body = TestListener.createHttpMessage(new Response().status(200));
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         assert hHandler.compareMessage(null);
         
         aHandler.lastMessage = null; // Resetting from auth in connectToSource
         body = TestListener.createAuthenticationResponse(true);
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         assert aHandler.compareMessage(null);
         
         body = TestListener.createQueryMessage(new LinkedHashMap(), srcName);
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         assert qHandler.compareMessage(null);
         
         body = TestListener.createPublishMessage(new LinkedHashMap(), srcName);
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         assert pHandler.compareMessage(null);
         
         cHandler.lastMessage = null; // Resetting from message in connectToSource
         body = TestListener.createConfigResponse(new LinkedHashMap(), srcName);
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         assert cHandler.compareMessage(null);
     }
     
@@ -272,7 +273,7 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase{
         connectToSource(srcName, null);
 
         ByteString body = TestListener.createQueryMessage(new LinkedHashMap(), srcName);
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         Response resp = null;
         try {
             resp = client.getLastMessageAsResponse();
@@ -311,28 +312,28 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase{
         // Every message should not error out due to EWSL catching and logging the error
         // Every message should be saved before the error occurs.
         ByteString body = TestListener.createAuthenticationResponse(true);
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         assert client.isAuthed();
         assert aHandler.compareStatus(200);
 
         body = TestListener.createHttpMessage(new Response().status(200));
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         assert hHandler.compareStatus(200);
 
         body = TestListener.createConfigResponse(new LinkedHashMap(), srcName);
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         assert cHandler.compareOp(ExtensionServiceMessage.OP_CONFIGURE_EXTENSION);
 
         body = TestListener.createQueryMessage(new LinkedHashMap(), srcName);
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         assert qHandler.compareOp(ExtensionServiceMessage.OP_QUERY);
 
         body = TestListener.createPublishMessage(new LinkedHashMap(), srcName);
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         assert pHandler.compareOp(ExtensionServiceMessage.OP_PUBLISH);
         
         body = TestListener.createReconnectMessage(srcName);
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         assert rHandler.compareOp(ExtensionServiceMessage.OP_RECONNECT_REQUIRED);
     }
     
@@ -349,22 +350,22 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase{
 
         // All that is expected is that no NPEs are thrown
         ByteString body = TestListener.createAuthenticationResponse(true);
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
 
         body = TestListener.createHttpMessage(new Response().status(200));
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
 
         body = TestListener.createConfigResponse(new LinkedHashMap(), srcName);
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
 
         body = TestListener.createQueryMessage(new LinkedHashMap(), srcName);
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
 
         body = TestListener.createPublishMessage(new LinkedHashMap(), srcName);
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
 
         body = TestListener.createReconnectMessage(srcName);
-        listener.onMessage(null, body);
+        listener.onMessage(client.webSocket, body);
         
     }
     
@@ -394,14 +395,14 @@ public class TestExtensionWebSocketListener extends ExtjsdkTestBase{
             open();
         }
         client.authenticate("unused");
-        listener.onMessage(null, TestListener.createAuthenticationResponse(success));
+        listener.onMessage(client.webSocket, TestListener.createAuthenticationResponse(success));
     }
     private void connectToSource(String sourceName, Map config) {
         if (!client.isAuthed()) {
             authenticate(true);
         }
         client.connectToSource();
-        listener.onMessage(null, TestListener.createConfigResponse(config, sourceName));
+        listener.onMessage(client.webSocket, TestListener.createConfigResponse(config, sourceName));
     }
 
     

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestListener.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestListener.java
@@ -29,7 +29,8 @@ public class TestListener extends ExtensionWebSocketListener {
     public TestListener(ExtensionWebSocketClient client) {
         super(client);
     }
-    
+
+    FalseWebSocket falseWebSocket = new FalseWebSocket();
     public Handler<Response> getAuthHandler() {
         return authHandler;
     }
@@ -54,7 +55,7 @@ public class TestListener extends ExtensionWebSocketListener {
      * @param success   Whether the authentication response should respond as a success 
      */
     public void receiveAuthenticationResponse(boolean success) {
-        this.onMessage(null, createAuthenticationResponse(success));
+        this.onMessage(falseWebSocket, createAuthenticationResponse(success));
     }
     /**
      * Makes the listener receive a configuration message, signifying a successful source connection. A failed
@@ -63,7 +64,7 @@ public class TestListener extends ExtensionWebSocketListener {
      * @param sourceName    The name of the source for which the connection succeeded.
      */
     public void receiveConfigResponse(Map<String,Object> config, String sourceName) {
-        this.onMessage(null, createConfigResponse(config, sourceName));
+        this.onMessage(falseWebSocket, createConfigResponse(config, sourceName));
     }
     /**
      * Makes the listener receive a Publish message
@@ -71,7 +72,7 @@ public class TestListener extends ExtensionWebSocketListener {
      * @param sourceName    The name of the source that sent the message
      */
     public void receivePublishMessage(Map<String,Object> message, String sourceName) {
-        this.onMessage(null, createPublishMessage(message, sourceName));
+        this.onMessage(falseWebSocket, createPublishMessage(message, sourceName));
     }
     /**
      * Makes the listener receive a Query message
@@ -79,27 +80,27 @@ public class TestListener extends ExtensionWebSocketListener {
      * @param sourceName    The name of the source that sent the message
      */
     public void receiveQueryMessage(Map<String,Object> message, String sourceName) {
-        this.onMessage(null, createQueryMessage(message, sourceName));
+        this.onMessage(falseWebSocket, createQueryMessage(message, sourceName));
     }
     /**
      * Makes the listener receive a reconnect message
      * @param sourceName    The name of the source that sent the message
      */
     public void receiveReconnectMessage(String sourceName) {
-        this.onMessage(null, createReconnectMessage(sourceName));
+        this.onMessage(falseWebSocket, createReconnectMessage(sourceName));
     }
     /**
      * Makes the listener receive an HTTP message.
      * @param resp The {@link Response} that the listener will receive
      */
     public void receiveHttpMessage(Response resp) {
-        this.onMessage(null, createHttpMessage(resp));
+        this.onMessage(falseWebSocket, createHttpMessage(resp));
     }
     /**
      * Makes the listener receive a simple HTTP error message. This is a {@link Response} with status code 400.
      */
     public void receiveErrorMessage() {
-        this.onMessage(null, errorMessage());
+        this.onMessage(falseWebSocket, errorMessage());
     }
 
     public static MediaType JSON = MediaType.parse("application/json; charset=utf-8");
@@ -143,7 +144,7 @@ public class TestListener extends ExtensionWebSocketListener {
             return ByteString.of(mapper.writeValueAsBytes(body));
         }
         catch (Exception e) {
-            return null;
+            return ByteString.EMPTY;
         }
     }
     /**
@@ -160,7 +161,7 @@ public class TestListener extends ExtensionWebSocketListener {
             return ByteString.of(mapper.writeValueAsBytes(body));
         }
         catch (Exception e) {
-            return null;
+            return ByteString.EMPTY;
         }
     }
     /**
@@ -177,7 +178,7 @@ public class TestListener extends ExtensionWebSocketListener {
             return ByteString.of(mapper.writeValueAsBytes(body));
         }
         catch (Exception e) {
-            return null;
+            return ByteString.EMPTY;
         }
     }
     /**
@@ -190,7 +191,7 @@ public class TestListener extends ExtensionWebSocketListener {
             return ByteString.of(mapper.writeValueAsBytes(resp));
         }
         catch (Exception e) {
-            return null;
+            return ByteString.EMPTY;
         }
     }
     /**
@@ -206,7 +207,7 @@ public class TestListener extends ExtensionWebSocketListener {
             return ByteString.of(mapper.writeValueAsBytes(body));
         }
         catch (Exception e) {
-            return null;
+            return ByteString.EMPTY;
         }
     }
     

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestListener.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestListener.java
@@ -49,6 +49,8 @@ public class TestListener extends ExtensionWebSocketListener {
     public Handler<ExtensionServiceMessage> getReconnectHandler() {
         return reconnectHandler;
     }
+
+    public static final ObjectMapper mapper = new ObjectMapper();
     
     /**
      * Makes the listener receive a response specifying either a successful or failed authentication
@@ -57,6 +59,7 @@ public class TestListener extends ExtensionWebSocketListener {
     public void receiveAuthenticationResponse(boolean success) {
         this.onMessage(falseWebSocket, createAuthenticationResponse(success));
     }
+
     /**
      * Makes the listener receive a configuration message, signifying a successful source connection. A failed
      * connection is sent using {@link #errorMessage()}.
@@ -66,6 +69,7 @@ public class TestListener extends ExtensionWebSocketListener {
     public void receiveConfigResponse(Map<String,Object> config, String sourceName) {
         this.onMessage(falseWebSocket, createConfigResponse(config, sourceName));
     }
+
     /**
      * Makes the listener receive a Publish message
      * @param message       The object sent with the Publish
@@ -74,6 +78,7 @@ public class TestListener extends ExtensionWebSocketListener {
     public void receivePublishMessage(Map<String,Object> message, String sourceName) {
         this.onMessage(falseWebSocket, createPublishMessage(message, sourceName));
     }
+
     /**
      * Makes the listener receive a Query message
      * @param message       The data to be received along with the Query message
@@ -82,6 +87,7 @@ public class TestListener extends ExtensionWebSocketListener {
     public void receiveQueryMessage(Map<String,Object> message, String sourceName) {
         this.onMessage(falseWebSocket, createQueryMessage(message, sourceName));
     }
+
     /**
      * Makes the listener receive a reconnect message
      * @param sourceName    The name of the source that sent the message
@@ -89,6 +95,7 @@ public class TestListener extends ExtensionWebSocketListener {
     public void receiveReconnectMessage(String sourceName) {
         this.onMessage(falseWebSocket, createReconnectMessage(sourceName));
     }
+
     /**
      * Makes the listener receive an HTTP message.
      * @param resp The {@link Response} that the listener will receive
@@ -96,15 +103,13 @@ public class TestListener extends ExtensionWebSocketListener {
     public void receiveHttpMessage(Response resp) {
         this.onMessage(falseWebSocket, createHttpMessage(resp));
     }
+
     /**
      * Makes the listener receive a simple HTTP error message. This is a {@link Response} with status code 400.
      */
     public void receiveErrorMessage() {
         this.onMessage(falseWebSocket, errorMessage());
     }
-
-    public static MediaType JSON = MediaType.parse("application/json; charset=utf-8");
-    public static final ObjectMapper mapper = new ObjectMapper();
     
     /**
      * Create a ResponseBody with a simple error. This is a {@link Response} with status code 400.
@@ -114,6 +119,7 @@ public class TestListener extends ExtensionWebSocketListener {
         String errorString = "{\"status\":400}";
         return ByteString.of(errorString.getBytes());
     }
+
     /**
      * Creates a response specifying either a successful or failed authentication
      * @param success   Whether the authentication response should respond as a success
@@ -127,6 +133,7 @@ public class TestListener extends ExtensionWebSocketListener {
             return errorMessage();
         }
     }
+
     /**
      * Creates a configuration message, signifying a successful source connection. A failed
      * connection is sent using {@link #errorMessage()}.
@@ -147,6 +154,7 @@ public class TestListener extends ExtensionWebSocketListener {
             return ByteString.EMPTY;
         }
     }
+
     /**
      * Creates a Publish message
      * @param message       The object sent with the Publish
@@ -164,6 +172,7 @@ public class TestListener extends ExtensionWebSocketListener {
             return ByteString.EMPTY;
         }
     }
+
     /**
      * Creates a Query message
      * @param message       The data to be received along with the Query message
@@ -181,6 +190,7 @@ public class TestListener extends ExtensionWebSocketListener {
             return ByteString.EMPTY;
         }
     }
+
     /**
      * Creates an HTTP message.
      * @param resp The {@link Response} that the listener will receive
@@ -194,6 +204,7 @@ public class TestListener extends ExtensionWebSocketListener {
             return ByteString.EMPTY;
         }
     }
+
     /**
      * Creates a reconnect message
      * @param sourceName    Name of the source that sent the message

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestListener.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestListener.java
@@ -134,7 +134,7 @@ public class TestListener extends ExtensionWebSocketListener {
      * @param sourceName    The name of the source for which the connection succeeded.
      * @return              A ByteString representing the message
      */
-    public static ByteString createConfigResponse(Map<String,Object> config, String sourceName) {
+    public static ByteString createConfigResponse(Map<String, Object> config, String sourceName) {
         try {
             Map<String,Object> body = mapper.readValue(sampleConfigBody, Map.class);
             Map<String,Object> c = new LinkedHashMap<>();
@@ -153,7 +153,7 @@ public class TestListener extends ExtensionWebSocketListener {
      * @param sourceName    The name of the source that sent the message
      * @return              A ByteString representing the message
      */
-    public static ByteString createPublishMessage(Map<String,Object> message, String sourceName) {
+    public static ByteString createPublishMessage(Map<String, Object> message, String sourceName) {
         try {
             Map<String,Object> body = mapper.readValue(samplePublishBody, Map.class);
             body.put("resourceId", sourceName);
@@ -170,7 +170,7 @@ public class TestListener extends ExtensionWebSocketListener {
      * @param sourceName    The name of the source that sent the message
      * @return              A ByteString representing the message
      */
-    public static ByteString createQueryMessage(Map<String,Object> message, String sourceName) {
+    public static ByteString createQueryMessage(Map<String, Object> message, String sourceName) {
         try {
             Map<String,Object> body = mapper.readValue(sampleQueryBody, Map.class);
             body.put("resourceId", sourceName);

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestListener.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestListener.java
@@ -9,7 +9,7 @@
 
 package io.vantiq.extjsdk;
 
-//Author: Alex Blumer, Namir Fawaz, Fred Carter
+//Authors: Alex Blumer, Namir Fawaz, Fred Carter
 //Email: support@vantiq.com
 
 

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestListener.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestListener.java
@@ -9,8 +9,8 @@
 
 package io.vantiq.extjsdk;
 
-//Author: Alex Blumer
-//Email: alex.j.blumer@gmail.com
+//Author: Alex Blumer, Namir Fawaz, Fred Carter
+//Email: support@vantiq.com
 
 
 import java.util.LinkedHashMap;
@@ -19,7 +19,7 @@ import java.util.Map;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import okhttp3.MediaType;
-import okhttp3.ResponseBody;
+import okio.ByteString;
 
 /**
  * A listener that contains methods to create sample responses and send those messages to itself, and getters for
@@ -54,16 +54,16 @@ public class TestListener extends ExtensionWebSocketListener {
      * @param success   Whether the authentication response should respond as a success 
      */
     public void receiveAuthenticationResponse(boolean success) {
-        this.onMessage(createAuthenticationResponse(success));
+        this.onMessage(null, createAuthenticationResponse(success));
     }
     /**
      * Makes the listener receive a configuration message, signifying a successful source connection. A failed
-     * connection is sent using {@link #sendErrorMessage}.
+     * connection is sent using {@link #errorMessage()}.
      * @param config        The configuration document that will be received
      * @param sourceName    The name of the source for which the connection succeeded.
      */
     public void receiveConfigResponse(Map<String,Object> config, String sourceName) {
-        this.onMessage(createConfigResponse(config, sourceName));
+        this.onMessage(null, createConfigResponse(config, sourceName));
     }
     /**
      * Makes the listener receive a Publish message
@@ -71,7 +71,7 @@ public class TestListener extends ExtensionWebSocketListener {
      * @param sourceName    The name of the source that sent the message
      */
     public void receivePublishMessage(Map<String,Object> message, String sourceName) {
-        this.onMessage(createPublishMessage(message, sourceName));
+        this.onMessage(null, createPublishMessage(message, sourceName));
     }
     /**
      * Makes the listener receive a Query message
@@ -79,27 +79,27 @@ public class TestListener extends ExtensionWebSocketListener {
      * @param sourceName    The name of the source that sent the message
      */
     public void receiveQueryMessage(Map<String,Object> message, String sourceName) {
-        this.onMessage(createQueryMessage(message, sourceName));
+        this.onMessage(null, createQueryMessage(message, sourceName));
     }
     /**
      * Makes the listener receive a reconnect message
      * @param sourceName    The name of the source that sent the message
      */
     public void receiveReconnectMessage(String sourceName) {
-        this.onMessage(createReconnectMessage(sourceName));
+        this.onMessage(null, createReconnectMessage(sourceName));
     }
     /**
      * Makes the listener receive an HTTP message.
      * @param resp The {@link Response} that the listener will receive
      */
     public void receiveHttpMessage(Response resp) {
-        this.onMessage(createHttpMessage(resp));
+        this.onMessage(null, createHttpMessage(resp));
     }
     /**
      * Makes the listener receive a simple HTTP error message. This is a {@link Response} with status code 400.
      */
     public void receiveErrorMessage() {
-        this.onMessage(errorMessage());
+        this.onMessage(null, errorMessage());
     }
 
     public static MediaType JSON = MediaType.parse("application/json; charset=utf-8");
@@ -109,17 +109,18 @@ public class TestListener extends ExtensionWebSocketListener {
      * Create a ResponseBody with a simple error. This is a {@link Response} with status code 400.
      * @return  A ResponseBody representing the message
      */
-    public static ResponseBody errorMessage() {
-        return ResponseBody.create(JSON, "{\"status\":400}");
+    public static ByteString errorMessage() {
+        String errorString = "{\"status\":400}";
+        return ByteString.of(errorString.getBytes());
     }
     /**
      * Creates a response specifying either a successful or failed authentication
      * @param success   Whether the authentication response should respond as a success
      * @return              A ResponseBody representing the message
      */
-    public static ResponseBody createAuthenticationResponse(boolean success) {
+    public static ByteString createAuthenticationResponse(boolean success) {
         if (success) {
-            return ResponseBody.create(JSON, sampleAuthResponseBody);
+            return ByteString.of(sampleAuthResponseBody.getBytes());
         }
         else {
             return errorMessage();
@@ -127,19 +128,19 @@ public class TestListener extends ExtensionWebSocketListener {
     }
     /**
      * Creates a configuration message, signifying a successful source connection. A failed
-     * connection is sent using {@link #sendErrorMessage}.
+     * connection is sent using {@link #errorMessage()}.
      * @param config        The configuration document that will be received
      * @param sourceName    The name of the source for which the connection succeeded.
-     * @return              A ResponseBody representing the message
+     * @return              A ByteString representing the message
      */
-    public static ResponseBody createConfigResponse(Map<String,Object> config, String sourceName) {
+    public static ByteString createConfigResponse(Map<String,Object> config, String sourceName) {
         try {
             Map<String,Object> body = mapper.readValue(sampleConfigBody, Map.class);
             Map<String,Object> c = new LinkedHashMap<>();
             c.put("config", config);
             body.put("resourceId", sourceName);
             body.put("object", c);
-            return ResponseBody.create(JSON, mapper.writeValueAsBytes(body));
+            return ByteString.of(mapper.writeValueAsBytes(body));
         }
         catch (Exception e) {
             return null;
@@ -149,14 +150,14 @@ public class TestListener extends ExtensionWebSocketListener {
      * Creates a Publish message
      * @param message       The object sent with the Publish
      * @param sourceName    The name of the source that sent the message
-     * @return              A ResponseBody representing the message
+     * @return              A ByteString representing the message
      */
-    public static ResponseBody createPublishMessage(Map<String,Object> message, String sourceName) {
+    public static ByteString createPublishMessage(Map<String,Object> message, String sourceName) {
         try {
             Map<String,Object> body = mapper.readValue(samplePublishBody, Map.class);
             body.put("resourceId", sourceName);
             body.put("object", message);
-            return ResponseBody.create(JSON, mapper.writeValueAsBytes(body));
+            return ByteString.of(mapper.writeValueAsBytes(body));
         }
         catch (Exception e) {
             return null;
@@ -166,14 +167,14 @@ public class TestListener extends ExtensionWebSocketListener {
      * Creates a Query message
      * @param message       The data to be received along with the Query message
      * @param sourceName    The name of the source that sent the message
-     * @return              A ResponseBody representing the message
+     * @return              A ByteString representing the message
      */
-    public static ResponseBody createQueryMessage(Map<String,Object> message, String sourceName) {
+    public static ByteString createQueryMessage(Map<String,Object> message, String sourceName) {
         try {
             Map<String,Object> body = mapper.readValue(sampleQueryBody, Map.class);
             body.put("resourceId", sourceName);
             body.put("object", message);
-            return ResponseBody.create(JSON, mapper.writeValueAsBytes(body));
+            return ByteString.of(mapper.writeValueAsBytes(body));
         }
         catch (Exception e) {
             return null;
@@ -182,11 +183,11 @@ public class TestListener extends ExtensionWebSocketListener {
     /**
      * Creates an HTTP message.
      * @param resp The {@link Response} that the listener will receive
-     * @return              A ResponseBody representing the message
+     * @return              A ByteString representing the message
      */
-    public static ResponseBody createHttpMessage(Response resp) {
+    public static ByteString createHttpMessage(Response resp) {
         try {
-            return ResponseBody.create(JSON, mapper.writeValueAsBytes(resp));
+            return ByteString.of(mapper.writeValueAsBytes(resp));
         }
         catch (Exception e) {
             return null;
@@ -195,14 +196,14 @@ public class TestListener extends ExtensionWebSocketListener {
     /**
      * Creates a reconnect message
      * @param sourceName    Name of the source that sent the message
-     * @return              A ResponseBody representing the message
+     * @return              A ByteString representing the message
      */
-    public static ResponseBody createReconnectMessage(String sourceName) {
+    public static ByteString createReconnectMessage(String sourceName) {
         try {
             Map<String,Object> body = new LinkedHashMap<>();
             body.put("resourceId", sourceName);
             body.put("op", ExtensionServiceMessage.OP_RECONNECT_REQUIRED);
-            return ResponseBody.create(JSON, mapper.writeValueAsBytes(body));
+            return ByteString.of(mapper.writeValueAsBytes(body));
         }
         catch (Exception e) {
             return null;

--- a/udpSource/build.gradle
+++ b/udpSource/build.gradle
@@ -53,9 +53,6 @@ dependencies {
    // compile 'extjsdk' // extjsdk.jar must be in
     compile project(":extjsdk")
     
-    compile 'com.squareup.okhttp3:okhttp:3.4.1'
-    compile 'com.squareup.okhttp3:okhttp-ws:3.4.1'
-    
     compile "org.slf4j:slf4j-api:1.7.25"
     compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.0"
     


### PR DESCRIPTION
Closes #260 
Closes #204 
Closes #195

Updates the OkHttp library to the latest stable release. Since version 3.5, OkHttp has folded in the separate `-ws` package into the general okhttp one. The majority of these changes convert our old WebSocket implementations to use the newer version.

This PR also adds the ability to configure the OkHttp client to send pings to the Vantiq Server, which can be specified by including a `sendPings` property in the `server.config` file.