### PR TITLE
Fix Utils to only read server.config file once

### DIFF
--- a/extjsdk/build.gradle
+++ b/extjsdk/build.gradle
@@ -71,6 +71,8 @@ dependencies {
     compile "org.slf4j:slf4j-api:1.7.25"
     compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.0"
 
+    compile "org.apache.commons:commons-lang3:3.12.0"
+
     compile "com.squareup.okhttp3:okhttp:${okhttpVersion}"
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
 

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
@@ -1,5 +1,7 @@
 package io.vantiq.extjsdk;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -8,7 +10,7 @@ import java.util.Properties;
 public class Utils {
 
     // String used by methods to synch on
-    private static final String SYNCH_LOCK = "sycnhLockString";
+    private static final String SYNCH_LOCK = "synchLockString";
 
     public static final String SEND_PING_PROPERTY_NAME = "sendPings";
     public static final String PORT_PROPERTY_NAME = "tcpProbePort";
@@ -17,7 +19,7 @@ public class Utils {
     public static final String SECRET_CREDENTIALS = "CONNECTOR_AUTH_TOKEN";
 
     // The properties object containing the data from the server configuration file
-    public static Properties serverConfigProperties;
+    private static Properties serverConfigProperties;
 
     public static Properties obtainServerConfig() {
         return obtainServerConfig(SERVER_CONFIG_FILENAME);
@@ -44,7 +46,7 @@ public class Utils {
                 // We only set it if the value is not empty and if the authToken wasn't already specified in the
                 // server.config
                 String secretAuthToken = System.getenv(SECRET_CREDENTIALS);
-                if (secretAuthToken != null && !secretAuthToken.trim().isEmpty()
+                if (secretAuthToken != null && !StringUtils.isBlank(secretAuthToken)
                         && serverConfigProperties.getProperty("authToken") == null) {
                     serverConfigProperties.setProperty("authToken", secretAuthToken);
                 }
@@ -120,7 +122,6 @@ public class Utils {
      */
     public static void clearServerConfigProperties() {
         synchronized (SYNCH_LOCK) {
-            serverConfigProperties.clear();
             serverConfigProperties = null;
         }
     }

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
@@ -15,6 +15,7 @@ package io.vantiq.extjsdk;
 import okhttp3.Request;
 import okhttp3.WebSocket;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,14 +42,21 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase {
     String srcName;
     String queryAddress;
     FalseWebSocket socket;
+    File serverConfigFile;
     
     @Before
-    public void setup() {
+    public void setup() throws IOException {
         srcName = "src";
         socket = new FalseWebSocket();
         client = new OpenExtensionWebSocketClient(srcName); // OpenExtensionWebSocketClient just makes a few functions public
         client.webSocket = socket;
         queryAddress = "gobbledygook";
+
+        // Make initial Utils.obtainServerConfig() call so that we don't get errors later on
+        serverConfigFile = new File("server.config");
+        serverConfigFile.createNewFile();
+        serverConfigFile.deleteOnExit();
+        Utils.obtainServerConfig();
     }
     
     @After
@@ -57,6 +65,7 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase {
         client = null;
         socket = null;
         queryAddress = null;
+        serverConfigFile.delete();
     }
     
     @Test

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestUtils.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestUtils.java
@@ -36,61 +36,41 @@ public class TestUtils  {
 
     @Test
     public void testGetConfigAlone() throws Exception {
-        BufferedWriter bw = null;
-        File f = null;
-        try {
-            Path p = Files.createFile( Paths.get("server.config"));
-            f = new File(p.toString());
-            f.deleteOnExit();
-            
-            bw = fillProps(p, true);
+        Path p = Files.createFile( Paths.get("server.config"));
+        File f = new File(p.toString());
+        f.deleteOnExit();
 
+        try (BufferedWriter bw = fillProps(p, true)) {
             checkPropBeforeObtainingServer();
             checkProps();
             Utils.clearServerConfigProperties();
             checkPropBeforeObtainingServer();
         } finally {
-            if (bw != null) {
-                bw.close();
-            }
-            if (f != null) {
-                //noinspection ResultOfMethodCallIgnored
-                f.delete();
-            }
+            //noinspection ResultOfMethodCallIgnored
+            f.delete();
         }
     }
 
     @Test
     public void testGetConfigInDir() throws Exception {
-        BufferedWriter bw = null;
-        File f = null;
-        File dir = null;
-        try {
-            dir = new File("serverConfig");
-            //noinspection ResultOfMethodCallIgnored
-            dir.mkdir();
-            dir.deleteOnExit();
-            Path p = Files.createFile(Paths.get("serverConfig/server.config"));
-            f = new File(p.toString());
-            f.deleteOnExit();
-            bw = fillProps(p, true);
+        File dir = new File("serverConfig");
+        //noinspection ResultOfMethodCallIgnored
+        dir.mkdir();
+        dir.deleteOnExit();
+        Path p = Files.createFile(Paths.get("serverConfig/server.config"));
+        File f = new File(p.toString());
+        f.deleteOnExit();
 
+        try (BufferedWriter bw = fillProps(p, true)) {
             checkPropBeforeObtainingServer();
             checkProps();
             Utils.clearServerConfigProperties();
             checkPropBeforeObtainingServer();
         } finally {
-            if (bw != null) {
-                bw.close();
-            }
-            if (f != null) {
-                //noinspection ResultOfMethodCallIgnored
-                f.delete();
-            }
-            if (dir != null) {
-                //noinspection ResultOfMethodCallIgnored
-                dir.delete();
-            }
+            //noinspection ResultOfMethodCallIgnored
+            f.delete();
+            //noinspection ResultOfMethodCallIgnored
+            dir.delete();
         }
     }
 
@@ -102,35 +82,24 @@ public class TestUtils  {
     }
 
     private void doEnvVarTests(boolean includeAuthToken) throws Exception {
-        BufferedWriter bw = null;
-        File f = null;
-        File dir = null;
-        try {
-            dir = new File("serverConfig");
-            //noinspection ResultOfMethodCallIgnored
-            dir.mkdir();
-            dir.deleteOnExit();
-            Path p = Files.createFile(Paths.get("serverConfig/server.config"));
-            f = new File(p.toString());
-            f.deleteOnExit();
-            bw = fillProps(p, includeAuthToken);
+        File dir = new File("serverConfig");
+        //noinspection ResultOfMethodCallIgnored
+        dir.mkdir();
+        dir.deleteOnExit();
+        Path p = Files.createFile(Paths.get("serverConfig/server.config"));
+        File f = new File(p.toString());
+        f.deleteOnExit();
 
+        try (BufferedWriter bw = fillProps(p, includeAuthToken)){
             checkPropBeforeObtainingServer();
             checkProps();
             Utils.clearServerConfigProperties();
             checkPropBeforeObtainingServer();
         } finally {
-            if (bw != null) {
-                bw.close();
-            }
-            if (f != null) {
-                //noinspection ResultOfMethodCallIgnored
-                f.delete();
-            }
-            if (dir != null) {
-                //noinspection ResultOfMethodCallIgnored
-                dir.delete();
-            }
+            //noinspection ResultOfMethodCallIgnored
+            f.delete();
+            //noinspection ResultOfMethodCallIgnored
+            dir.delete();
         }
     }
     
@@ -161,6 +130,7 @@ public class TestUtils  {
         assert props.getProperty(Utils.PORT_PROPERTY_NAME).contains(FAKE_PORT);
     }
 
+    @SuppressWarnings("PMD.EmptyCatchBlock")
     private void checkPropBeforeObtainingServer() {
         try {
             Utils.obtainSendPingStatus();

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestUtils.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestUtils.java
@@ -46,7 +46,8 @@ public class TestUtils  {
 
             checkPropBeforeObtainingServer();
             checkProps();
-            clearProps();
+            Utils.clearServerConfigProperties();
+            checkPropBeforeObtainingServer();
         } finally {
             if (bw != null) {
                 bw.close();
@@ -75,7 +76,8 @@ public class TestUtils  {
 
             checkPropBeforeObtainingServer();
             checkProps();
-            clearProps();
+            Utils.clearServerConfigProperties();
+            checkPropBeforeObtainingServer();
         } finally {
             if (bw != null) {
                 bw.close();
@@ -114,7 +116,8 @@ public class TestUtils  {
 
             checkPropBeforeObtainingServer();
             checkProps();
-            clearProps();
+            Utils.clearServerConfigProperties();
+            checkPropBeforeObtainingServer();
         } finally {
             if (bw != null) {
                 bw.close();
@@ -159,23 +162,18 @@ public class TestUtils  {
 
     private void checkPropBeforeObtainingServer() {
         try {
-            Boolean noUse = Utils.obtainSendPingStatus();
+            Utils.obtainSendPingStatus();
             fail("We should not get here, an exception should be thrown first");
         } catch (Exception e) {
             // Expected to catch exception here.
         }
 
         try {
-            Integer noUse = Utils.obtainTCPProbePort();
+            Utils.obtainTCPProbePort();
             fail("We should not get here, an exception should be thrown first");
         } catch (Exception e) {
             // Expected to catch exception here.
         }
-    }
-
-    private void clearProps() {
-        Utils.clearServerConfigProperties();
-        assert Utils.serverConfigProperties == null;
     }
     
     @Before

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestUtils.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestUtils.java
@@ -90,7 +90,7 @@ public class TestUtils  {
         File f = new File(p.toString());
         f.deleteOnExit();
 
-        try (BufferedWriter bw = fillProps(p, includeAuthToken)){
+        try (BufferedWriter bw = fillProps(p, includeAuthToken)) {
             checkPropBeforeObtainingServer();
             checkProps();
             Utils.clearServerConfigProperties();

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestUtils.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestUtils.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Properties;
 
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 public class TestUtils  {
@@ -18,6 +19,8 @@ public class TestUtils  {
     private static final String FAKE_URL = "http://somewhere/else";
     private static final String FAKE_TOKEN = "xxxx====";
     private static final String FAKE_SOURCE = "someSource";
+    private static final String FAKE_PORT = "8000";
+    private static final String FAKE_PINGS = "true";
     public static final String TARGET_SERVER_PROP = "targetServer";
     public static final String AUTH_TOKEN_PROP = "authToken";
     public static final String OTHER_PROP = "otherProperty";
@@ -40,8 +43,10 @@ public class TestUtils  {
             f.deleteOnExit();
             
             bw = fillProps(p, true);
-           
+
+            checkPropBeforeObtainingServer();
             checkProps();
+            clearProps();
         } finally {
             if (bw != null) {
                 bw.close();
@@ -67,8 +72,10 @@ public class TestUtils  {
             f = new File(p.toString());
             f.deleteOnExit();
             bw = fillProps(p, true);
-            
+
+            checkPropBeforeObtainingServer();
             checkProps();
+            clearProps();
         } finally {
             if (bw != null) {
                 bw.close();
@@ -105,7 +112,9 @@ public class TestUtils  {
             f.deleteOnExit();
             bw = fillProps(p, includeAuthToken);
 
+            checkPropBeforeObtainingServer();
             checkProps();
+            clearProps();
         } finally {
             if (bw != null) {
                 bw.close();
@@ -128,6 +137,8 @@ public class TestUtils  {
             bw.append(AUTH_TOKEN_PROP + " = " + FAKE_TOKEN + "\n");
         }
         bw.append(OTHER_PROP + " = " + FAKE_SOURCE + "\n");
+        bw.append(Utils.SEND_PING_PROPERTY_NAME + " = " + FAKE_PINGS + "\n");
+        bw.append(Utils.PORT_PROPERTY_NAME + " = " + FAKE_PORT + "\n");
         bw.close();
         return bw;
     }
@@ -140,6 +151,31 @@ public class TestUtils  {
         assert props.getProperty(AUTH_TOKEN_PROP).contains(FAKE_TOKEN);
         assert props.getProperty(OTHER_PROP) != null;
         assert props.getProperty(OTHER_PROP).contains(FAKE_SOURCE);
+        assert props.getProperty(Utils.SEND_PING_PROPERTY_NAME) != null;
+        assert props.getProperty(Utils.SEND_PING_PROPERTY_NAME).contains(FAKE_PINGS);
+        assert props.getProperty(Utils.PORT_PROPERTY_NAME) != null;
+        assert props.getProperty(Utils.PORT_PROPERTY_NAME).contains(FAKE_PORT);
+    }
+
+    private void checkPropBeforeObtainingServer() {
+        try {
+            Boolean noUse = Utils.obtainSendPingStatus();
+            fail("We should not get here, an exception should be thrown first");
+        } catch (Exception e) {
+            // Expected to catch exception here.
+        }
+
+        try {
+            Integer noUse = Utils.obtainTCPProbePort();
+            fail("We should not get here, an exception should be thrown first");
+        } catch (Exception e) {
+            // Expected to catch exception here.
+        }
+    }
+
+    private void clearProps() {
+        Utils.clearServerConfigProperties();
+        assert Utils.serverConfigProperties == null;
     }
     
     @Before

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestUtils.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestUtils.java
@@ -31,6 +31,7 @@ public class TestUtils  {
     @Before
     public void setup() {
         envVarAuthToken = System.getenv(SECRET_CREDENTIALS);
+        Utils.clearServerConfigProperties();
     }
 
     @Test

--- a/testConnector/src/test/java/io/vantiq/extsrc/testConnector/TestTestConnectorConfig.java
+++ b/testConnector/src/test/java/io/vantiq/extsrc/testConnector/TestTestConnectorConfig.java
@@ -11,11 +11,14 @@ package io.vantiq.extsrc.testConnector;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import io.vantiq.extjsdk.Utils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,12 +34,20 @@ public class TestTestConnectorConfig {
     String sourceName;
     String authToken;
     String targetVantiqServer;
+    File serverConfigFile;
 
     @Before
-    public void setup() {
+    public void setup() throws IOException {
         sourceName = "src";
         authToken = "token";
         targetVantiqServer = "dev.vantiq.com";
+
+        // Make initial Utils.obtainServerConfig() call so that we don't get errors later on
+        serverConfigFile = new File("server.config");
+        serverConfigFile.createNewFile();
+        serverConfigFile.deleteOnExit();
+        Utils.obtainServerConfig();
+
         nCore = new NoSendTestConnectorCore(sourceName, authToken, targetVantiqServer);
         handler = new TestConnectorHandleConfiguration(nCore);
     }
@@ -44,6 +55,7 @@ public class TestTestConnectorConfig {
     @After
     public void tearDown() {
         nCore.stop();
+        serverConfigFile.delete();
     }
 
     @Test

--- a/testConnector/src/test/java/io/vantiq/extsrc/testConnector/TestTestConnectorCore.java
+++ b/testConnector/src/test/java/io/vantiq/extsrc/testConnector/TestTestConnectorCore.java
@@ -12,12 +12,15 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.ArrayList;
 import java.util.Base64;
 
+import io.vantiq.extjsdk.Utils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -37,6 +40,7 @@ public class TestTestConnectorCore {
     private static String environmentVariable;
     private static String filename;
     private static String fileContents;
+    private static File serverConfigFile;
 
     private static final String NONEXISTENT_ENV_VAR = "anEnvironmentVariableThatIsUnlikelyToExist";
 
@@ -48,10 +52,16 @@ public class TestTestConnectorCore {
     }
 
     @Before
-    public void setup() {
+    public void setup() throws IOException {
         sourceName = "src";
         authToken = "token";
         targetVantiqServer = "dev.vantiq.com";
+
+        // Make initial Utils.obtainServerConfig() call so that we don't get errors later on
+        serverConfigFile = new File("server.config");
+        serverConfigFile.createNewFile();
+        serverConfigFile.deleteOnExit();
+        Utils.obtainServerConfig();
 
         core = new NoSendTestConnectorCore(sourceName, authToken, targetVantiqServer);
         core.start(10);
@@ -60,6 +70,7 @@ public class TestTestConnectorCore {
     @After
     public void tearDown() {
         core.stop();
+        serverConfigFile.delete();
     }
 
     @Test


### PR DESCRIPTION
Closes #265 

Changes the Utils class to only read the server.config when using the `obtainServerConfig()` method(s). The config properties are now stored in a static variable, which other methods use to access individual properties.

The `obtainServerConfig()` method _**MUST**_ be called before calling the other Util methods, otherwise a RuntimeException will be thrown. This still needs to be documented in the README.