### PR TITLE
Fixing outstandingNotifications NPE

### DIFF
--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -799,7 +799,6 @@ public class ExtensionWebSocketClient {
         // Saving and nulling before closing so EWSListener can know when it is closed by the client 
         WebSocket socket = webSocket;
         webSocket = null;
-        outstandingNotifications = null;
         if (socket != null) {
             try {
                 socket.close(1000, "Closed by client");

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/TestExtensionWebSocketClient.java
@@ -308,6 +308,31 @@ public class TestExtensionWebSocketClient extends ExtjsdkTestBase {
     }
 
     @Test
+    public void testOpenAndClose() {
+        // Setup a client and listener and mark things "connected"
+        FalseClient newClient = new FalseClient(srcName);
+        TestListener testListener = new TestListener(newClient);
+        newClient.listener = testListener;
+
+        // Lets initiate the full connection and send a notification
+        newClient.initiateFullConnection("doesn't matter", "also doesn't matter");
+        newClient.webSocketFuture = CompletableFuture.completedFuture(true);
+        newClient.authFuture = CompletableFuture.completedFuture(true);
+        newClient.sourceFuture = CompletableFuture.completedFuture(true);
+        newClient.sendNotification("blah");
+
+        // Now we close the client
+        newClient.close();
+
+        // Now reopen and try to send a notification again
+        newClient.initiateFullConnection("doesn't matter", "also doesn't matter");
+        newClient.webSocketFuture = CompletableFuture.completedFuture(true);
+        newClient.authFuture = CompletableFuture.completedFuture(true);
+        newClient.sourceFuture = CompletableFuture.completedFuture(true);
+        newClient.sendNotification("blah2");
+    }
+
+    @Test
     public void testBadNotificationArguments() {
         markSourceConnected(true);
 


### PR DESCRIPTION
Closes #273 

Removes the call to nullify outstandingNotifications. This means we'll no longer run into the issue that closing/reinitiating the SDK client's websocket will result in NPEs that prevent the user from sending notifications back to Vantiq.