### PR TITLE
Update reconnect protocol to deal with half-open connections

### DIFF
--- a/extjsdk/build.gradle
+++ b/extjsdk/build.gradle
@@ -54,6 +54,10 @@ tasks.withType(Test) {
     if (rootProject.hasProperty("TestVantiqServer")) {
         systemProperty "TestVantiqServer", rootProject.findProperty("TestVantiqServer") ?: "empty"
     }
+
+    if (rootProject.hasProperty("TestRepeatedConnects")) {
+        systemProperty "TestRepeatedConnects", rootProject.findProperty("TestRepeatedConnects") ?: "empty"
+    }
     // Use the build dir as a base to get our various test artifacts.
     systemProperty "buildDir", "${buildDir}"
 }

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionServiceMessage.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionServiceMessage.java
@@ -25,6 +25,7 @@ import java.util.Map;
  * Created by fcarter 7 Jun 2018
  */
 
+@SuppressWarnings("PMD.TooManyFields")
 public class ExtensionServiceMessage {
     public static final String RESOURCE_NAME_SOURCES = "sources";
     public static final String OP_CONFIGURE_EXTENSION = "configureExtension";

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionServiceMessage.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionServiceMessage.java
@@ -43,7 +43,7 @@ public class ExtensionServiceMessage {
     // This is sent on any CONNECT_EXTENSION messages.  It is used when a connector
     // "re-connects" to the server to verify that it's the same connector connecting in
     // (otherwise, the reconnect is rejected).  So, while it's send on all CONNECT... calls,
-    // it's use is in only in the reconnect case (that is, usurping an existing connection).
+    // its use is only in the reconnect case (that is, usurping an existing connection).
     // The name's a bit confusing, but CONNECT_SECRET sounds too much like something you need
     // to connect (which, under normal circumstances, you don't).
     public static final String RECONNECT_SECRET = "reconnectSecret";

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionServiceMessage.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionServiceMessage.java
@@ -39,7 +39,7 @@ public class ExtensionServiceMessage {
     public static final String PROPERTY_MESSAGE_HEADERS = "messageHeaders";
 
     // Set in parameters to allow reconnect after network half-open situation
-    public static String RECONNECT_SECRET = "reconnectSecret";
+    public static final String RECONNECT_SECRET = "reconnectSecret";
 
     public String address;
     public Map    messageHeaders;

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionServiceMessage.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionServiceMessage.java
@@ -38,6 +38,9 @@ public class ExtensionServiceMessage {
     public static final String RESPONSE_ADDRESS_HEADER = "X-Reply-Address";
     public static final String PROPERTY_MESSAGE_HEADERS = "messageHeaders";
 
+    // Set in parameters to allow reconnect after network half-open situation
+    public static String RECONNECT_SECRET = "reconnectSecret";
+
     public String address;
     public Map    messageHeaders;
 

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionServiceMessage.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionServiceMessage.java
@@ -40,6 +40,12 @@ public class ExtensionServiceMessage {
     public static final String PROPERTY_MESSAGE_HEADERS = "messageHeaders";
 
     // Set in parameters to allow reconnect after network half-open situation
+    // This is sent on any CONNECT_EXTENSION messages.  It is used when a connector
+    // "re-connects" to the server to verify that it's the same connector connecting in
+    // (otherwise, the reconnect is rejected).  So, while it's send on all CONNECT... calls,
+    // it's use is in only in the reconnect case (that is, usurping an existing connection).
+    // The name's a bit confusing, but CONNECT_SECRET sounds too much like something you need
+    // to connect (which, under normal circumstances, you don't).
     public static final String RECONNECT_SECRET = "reconnectSecret";
 
     public String address;

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.*;
 import java.util.Queue;
+import java.util.UUID;
 
 import com.google.common.collect.EvictingQueue;
 
@@ -179,6 +180,12 @@ public class ExtensionWebSocketClient {
     public ExtensionWebSocketClient (String sourceName) {
         this(sourceName, DEFAULT_FAILED_MESSAGE_QUEUE_SIZE);
     }
+
+    /**
+     * Unique identifier for this loader's class.  This is set on load and then left.  This
+     * shared secret allows instances of this client to perform reconnects to the server.
+     */
+    protected final static String clientReconnectSecret = UUID.randomUUID().toString();
 
     /**
      * Creates an {@link ExtensionWebSocketClient} that will connect to the source {@code sourceName}.
@@ -643,6 +650,8 @@ public class ExtensionWebSocketClient {
     protected void doConnectionToSource() {
         ExtensionServiceMessage connectMessage = new ExtensionServiceMessage("");
         connectMessage.connectExtension(ExtensionServiceMessage.RESOURCE_NAME_SOURCES, sourceName, null);
+        connectMessage.parameters = new HashMap<String, String>();
+        connectMessage.parameters.put(ExtensionServiceMessage.RECONNECT_SECRET, clientReconnectSecret);
         send(connectMessage);
         log.trace("Connect message sent.");
     }

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -185,7 +185,7 @@ public class ExtensionWebSocketClient {
      * Unique identifier for this loader's class.  This is set on load and then left.  This
      * shared secret allows instances of this client to perform reconnects to the server.
      */
-    protected final static String clientReconnectSecret = UUID.randomUUID().toString();
+    protected static final String clientReconnectSecret = UUID.randomUUID().toString();
 
     /**
      * Creates an {@link ExtensionWebSocketClient} that will connect to the source {@code sourceName}.

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/RoundTripTestBase.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/RoundTripTestBase.java
@@ -29,6 +29,7 @@ public class RoundTripTestBase {
     public static String testSourceName = null;
     public static String testTypeName = null;
     public static String testRuleName = null;
+    public static Boolean testRepeatedConnectsEnabled = null;
     public static final String TEST_IMPL_NAME = "TEST_SOURCE_IMPL";
 
     static Vantiq vantiq;
@@ -40,6 +41,8 @@ public class RoundTripTestBase {
         testSourceName = System.getProperty("EntConTestSourceName", "testSourceName");
         testTypeName = System.getProperty("EntConTestTypeName", "testTypeName");
         testRuleName = System.getProperty("EntConTestRuleName", "testRuleName");
+        testRepeatedConnectsEnabled =
+                Boolean.valueOf(System.getProperty("TestRepeatedConnects", "false"));
         assumeTrue("Tests require system property 'buildDir' to be set -- should be extjsdk/build",
                 System.getProperty("buildDir") != null);
 

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/RoundTripTestBase.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/RoundTripTestBase.java
@@ -21,6 +21,7 @@ import static org.junit.Assume.assumeTrue;
 import io.vantiq.client.Vantiq;
 import io.vantiq.client.VantiqResponse;
 
+@SuppressWarnings("PMD.MutableStaticState")
 public class RoundTripTestBase {
     public static final String UNUSED = "unused";
 

--- a/extjsdk/src/test/resources/simulateUnstableNetwork.sh
+++ b/extjsdk/src/test/resources/simulateUnstableNetwork.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Shell script for Mac OS that will turn off then on wifi to monkey with network.
+# This allows for manual testing for connector disconnection recovery.
+
+for ((i = 0; i < 100; i++)) do
+    echo Attempt $i;
+    echo disabling network;
+    networksetup -setnetworkserviceenabled Wi-Fi off;
+    echo sleeping for 10 seconds;
+    sleep 10;
+    echo reconnecting network;
+    networksetup -setnetworkserviceenabled Wi-Fi on;
+    echo sleeping for a minute;
+    sleep 60;
+done

--- a/extjsdk/src/test/resources/simulateUnstableNetwork.sh
+++ b/extjsdk/src/test/resources/simulateUnstableNetwork.sh
@@ -1,16 +1,17 @@
 #!/bin/sh
+# shellcheck disable=SC3005,SC3018
 
 # Shell script for Mac OS that will turn off then on wifi to monkey with network.
 # This allows for manual testing for connector disconnection recovery.
 
 for ((i = 0; i < 100; i++)) do
-    echo Attempt $i;
-    echo disabling network;
+    echo "Attempt $i";
+    echo "disabling network";
     networksetup -setnetworkserviceenabled Wi-Fi off;
-    echo sleeping for 10 seconds;
+    echo "sleeping for 10 seconds";
     sleep 10;
-    echo reconnecting network;
+    echo "reconnecting network";
     networksetup -setnetworkserviceenabled Wi-Fi on;
-    echo sleeping for a minute;
+    echo "sleeping for a minute";
     sleep 60;
 done


### PR DESCRIPTION
Fixes #275 -- will require fix to Vantiq/vantiq-Issues#295 to work completely.

Adds _reconnect secret_ to the connection requests.  This secret allows a connector to usurp its old connection to Vantiq.  This is required when the server fails to notice that the connection between the connector and the server has been unavailable.  This is not uncommon in unstable network connection cases.  When this happens, the connector's attempts to reconnect are rejected by the server because it (thinks it) already has a connection for the source in question.

This fix, in a parallel with the server side fix, allows the connector, using a _reconnect secret_ to assert that it is the connection the server thinks it knows about.  The server will, then, honor the connection & close the old, now defunct, session.

The fix uses parts of the connect extension message not previous used, so old servers will ignore it. And it is optional, so old clients talking to new servers will be fine.