### PR TITLE
Make tests more tolerant of unpredictability in public servers.

### DIFF
--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Connection.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Connection.java
@@ -8,6 +8,7 @@
 
 package io.vantiq.extsrc.opcua.uaOperations;
 
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -743,7 +744,9 @@ public class Connection extends OpcUaTestBase {
         }
     }
 
-        private static int invocationCount = 0;
+    private static int invocationCount = 0;
+
+    @SuppressWarnings({"PMD.CognitiveComplexity", "PMD.GuardLogStatement"})
     public void makeConnection(boolean runAsync,
                                String secPolicy,
                                String msgSecMode,
@@ -791,7 +794,9 @@ public class Connection extends OpcUaTestBase {
                 String host = opcuri.getHost();
                 int    port = opcuri.getPort();
                 log.info("Making socket connection to {}:{}", host, port);
-                Socket serverSock = new Socket(host, port);
+
+                // We don't use the result so we won't save it.  We just care that it completes w/o error
+                new Socket(host, port);
                 // If we get this far, the server has accepted the connection so there's something out there.
                 // We'll assume it's our OPC server & let the test proceed
             } catch (UnknownHostException | URISyntaxException badURL) {
@@ -818,6 +823,8 @@ public class Connection extends OpcUaTestBase {
             } catch (ExecutionException e) {
                 if (e.getCause() instanceof UaException) {
                     UaException uae = (UaException) e.getCause();
+
+
                     log.error("Got error: {}", uae.getStatusCode().toString());
                     // Unfortunately, not all errors are reported reasonably.  So we'll look for our "acceptable errors"
                     // in the returned strings...
@@ -842,9 +849,9 @@ public class Connection extends OpcUaTestBase {
 
         log.info("Found {} servers to which we may be able to connect.", workingServers);
         log.info("Successfully connected to {} servers.", successfulConnections);
-        assertTrue("No responding servers found to test.", workingServers != 0);
-        assertTrue("No successful connections: (count: " + successfulConnections + ")",
-                successfulConnections != 0);
+        assertNotEquals("No responding servers found to test.", 0, workingServers);
+        assertNotEquals("No successful connections: (count: " + successfulConnections + ")", 0,
+                successfulConnections);
     }
 
     public void performConnection(Map config, boolean runAsync, boolean startProcessOnly) throws ExecutionException {

--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Connection.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Connection.java
@@ -789,7 +789,7 @@ public class Connection extends OpcUaTestBase {
                 // We cannot just use the URL since we don't have handling for the opc.tcp scheme.
                 // We'll just do a basic socket connection as that's where most of the issues w/r/t availability are.
                 String host = opcuri.getHost();
-                int    port = opcuri.getPort();
+                int port = opcuri.getPort();
                 log.info("Making socket connection to {}:{}", host, port);
 
                 // We don't use the result so we won't save it.  We just care that it completes w/o error

--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Connection.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Connection.java
@@ -9,7 +9,6 @@
 package io.vantiq.extsrc.opcua.uaOperations;
 
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.eclipse.milo.opcua.stack.core.UaException;
@@ -743,8 +742,6 @@ public class Connection extends OpcUaTestBase {
             fail("Unexpected Exception: " + e.getClass().getName() + " -- " + e.getMessage());
         }
     }
-
-    private static int invocationCount = 0;
 
     @SuppressWarnings({"PMD.CognitiveComplexity", "PMD.GuardLogStatement"})
     public void makeConnection(boolean runAsync,

--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Utils.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Utils.java
@@ -27,7 +27,7 @@ import org.junit.Assume;
 /**
  * A collection of Utility methods used by the OPC UA Extension Source unit tests
  */
-@SuppressWarnings("PMD.TooManyFields")
+@SuppressWarnings({"PMD.TooManyFields", "PMD.StaticVariableNameCheck"})
 @Slf4j
 public class Utils {
 
@@ -37,15 +37,15 @@ public class Utils {
     //
     // At present, we'll check the "write value" stuff only on our internal server.
 
-    public static String OPC_PUBLIC_SERVER_1  = "opc.tcp://opcua.rocks:4840";    // Different vendors servers...
-    public static String OPC_PUBLIC_SERVER_2  = "opc.tcp://opcuaserver.com:48484";    // Different vendors servers...
-    public static String OPC_PUBLIC_SERVER_3  = "opc.tcp://opcua-demo.factry.io:51210";
-    public static String OPC_PUBLIC_SERVER_4  = "opc.tcp://commsvr.com:51234/UA/CAS_UA_Server";
-    public static String OPC_PUBLIC_SERVER_5  = "opc.tcp://milo.digitalpetri.com:62541/milo";
-    public static String OPC_PUBLIC_SERVER_6  = "opc.tcp://opcua.123mc.com:4840/";
-    public static String OPC_PUBLIC_SERVER_7  = "opc.tcp://mfactorengineering.com:4840";
+    public static final String OPC_PUBLIC_SERVER_1  = "opc.tcp://opcua.rocks:4840";    // Different vendors servers...
+    public static final String OPC_PUBLIC_SERVER_2  = "opc.tcp://opcuaserver.com:48484";    // Different vendors servers...
+    public static final String OPC_PUBLIC_SERVER_3  = "opc.tcp://opcua-demo.factry.io:51210";
+    public static final String OPC_PUBLIC_SERVER_4  = "opc.tcp://commsvr.com:51234/UA/CAS_UA_Server";
+    public static final String OPC_PUBLIC_SERVER_5  = "opc.tcp://milo.digitalpetri.com:62541/milo";
+    public static final String OPC_PUBLIC_SERVER_6  = "opc.tcp://opcua.123mc.com:4840/";
+    public static final String OPC_PUBLIC_SERVER_7  = "opc.tcp://mfactorengineering.com:4840";
 
-    public static List<String> OPC_PUBLIC_SERVERS = Arrays.asList(
+    public static final List<String> OPC_PUBLIC_SERVERS = Arrays.asList(
             OPC_PUBLIC_SERVER_1,
             OPC_PUBLIC_SERVER_2,
             OPC_PUBLIC_SERVER_3,
@@ -55,16 +55,13 @@ public class Utils {
             OPC_PUBLIC_SERVER_7     // Flaky support -- sometimes times out after discovery, sometimes before
     );
 
-    public static String OPC_INPROCESS_SERVER = "opc.tcp://localhost:12686/milo";
-    public static String OPC_PUBLIC_SERVER_NO_GOOD = "opc.tcp://opcuaserver.com:4840";
+    public static final String OPC_INPROCESS_SERVER = "opc.tcp://localhost:12686/milo";
+    public static final String OPC_PUBLIC_SERVER_NO_GOOD = "opc.tcp://opcuaserver.com:4840";
 
-    public static String EXAMPLE_NS_SCALAR_INT32_IDENTIFIER = "HelloWorld/ScalarTypes/Int32";
-    public static String EXAMPLE_NS_SCALAR_INT32_TYPE = "Int32";
-    public static String EXAMPLE_NS_SCALAR_STRING_IDENTIFIER = "HelloWorld/ScalarTypes/String";
-    public static String EXAMPLE_NS_SCALAR_STRING_TYPE = "String";
-
-    public static String OPC_UA_CORE_NAMESPACE = Namespaces.OPC_UA;
-
+    public static final String EXAMPLE_NS_SCALAR_INT32_IDENTIFIER = "HelloWorld/ScalarTypes/Int32";
+    public static final String EXAMPLE_NS_SCALAR_INT32_TYPE = "Int32";
+    public static final String EXAMPLE_NS_SCALAR_STRING_IDENTIFIER = "HelloWorld/ScalarTypes/String";
+    public static final String EXAMPLE_NS_SCALAR_STRING_TYPE = "String";
 
     /**
      * Turn an exception into readable text for test diagnostics
@@ -111,7 +108,7 @@ public class Utils {
      * @return The OpcUaESClient created
      * @throws ExecutionException Errors returned by underlying connection if connection attempt fails.
      */
-    static public OpcUaESClient makeConnection(Map config, boolean runAsync, OpcUaTestBase testInstance, boolean startProcessOnly) throws ExecutionException {
+    public static OpcUaESClient makeConnection(Map config, boolean runAsync, OpcUaTestBase testInstance, boolean startProcessOnly) throws ExecutionException {
         return makeConnection(config, runAsync, testInstance, startProcessOnly, false);
     }
 
@@ -125,7 +122,8 @@ public class Utils {
      * @return The OpcUaESClient created
      * @throws ExecutionException Errors returned by underlying connection if connection attempt fails.
      */
-    static public OpcUaESClient makeConnection(Map config,
+    @SuppressWarnings("PMD.CognitiveComplexity")
+    public static OpcUaESClient makeConnection(Map config,
                                                boolean runAsync,
                                                OpcUaTestBase testInstance,
                                                boolean startProcessOnly,

--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Utils.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Utils.java
@@ -37,27 +37,23 @@ public class Utils {
     //
     // At present, we'll check the "write value" stuff only on our internal server.
 
-    public static String OPC_PUBLIC_SERVER_1 = "opc.tcp://opcuaserver.com:48010";
-    public static String OPC_PUBLIC_SERVER_2 = "opc.tcp://opcua.rocks:4840";
-    public static String OPC_PUBLIC_SERVER_3 = "opc.tcp://opcua-demo.factry.io:51210";
-    public static String OPC_PUBLIC_SERVER_4 = "opc.tcp://commsvr.com:51234/UA/CAS_UA_Server";
-    public static String OPC_PUBLIC_SERVER_5 = "opc.tcp://uademo.prosysopc.com:53530";
-    public static String OPC_PUBLIC_SERVER_6 = "opc.tcp://demo.ascolab.com:4841";
-    public static String OPC_PUBLIC_SERVER_7 = "opc.tcp://milo.digitalpetri.com:62541/milo";
-    public static String OPC_PUBLIC_SERVER_8 = "opc.tcp://opcuademo.sterfive.com:26543";
-    public static String OPC_PUBLIC_SERVER_9 = "http://opcua.demo-this.com:51211/UA/SampleServer";
+    public static String OPC_PUBLIC_SERVER_1  = "opc.tcp://opcua.rocks:4840";    // Different vendors servers...
+    public static String OPC_PUBLIC_SERVER_2  = "opc.tcp://opcuaserver.com:48484";    // Different vendors servers...
+    public static String OPC_PUBLIC_SERVER_3  = "opc.tcp://opcua-demo.factry.io:51210";
+    public static String OPC_PUBLIC_SERVER_4  = "opc.tcp://commsvr.com:51234/UA/CAS_UA_Server";
+    public static String OPC_PUBLIC_SERVER_5  = "opc.tcp://milo.digitalpetri.com:62541/milo";
+    public static String OPC_PUBLIC_SERVER_6  = "opc.tcp://opcua.123mc.com:4840/";
+    public static String OPC_PUBLIC_SERVER_7  = "opc.tcp://mfactorengineering.com:4840";
 
     public static List<String> OPC_PUBLIC_SERVERS = Arrays.asList(
-            // OPC_PUBLIC_SERVER_1,  // requires credentials & registration :-(
-            // OPC_PUBLIC_SERVER_2,
+            OPC_PUBLIC_SERVER_1,
+            OPC_PUBLIC_SERVER_2,
             OPC_PUBLIC_SERVER_3,
-            // OPC_PUBLIC_SERVER_4,  // not responding
-            // OPC_PUBLIC_SERVER_5,  // returns that the service is unsupported.
-            // OPC_PUBLIC_SERVER_6,  // unknown host
-            OPC_PUBLIC_SERVER_7,     // Flaky support -- sometimes times out after discovery, sometimes before
-            OPC_PUBLIC_SERVER_8
-            // OPC_PUBLIC_SERVER_9    // #9 is offline
-            );
+            OPC_PUBLIC_SERVER_4,  // not responding
+            OPC_PUBLIC_SERVER_5,  // returns that the service is unsupported.
+            OPC_PUBLIC_SERVER_6,
+            OPC_PUBLIC_SERVER_7     // Flaky support -- sometimes times out after discovery, sometimes before
+    );
 
     public static String OPC_INPROCESS_SERVER = "opc.tcp://localhost:12686/milo";
     public static String OPC_PUBLIC_SERVER_NO_GOOD = "opc.tcp://opcuaserver.com:4840";
@@ -129,7 +125,11 @@ public class Utils {
      * @return The OpcUaESClient created
      * @throws ExecutionException Errors returned by underlying connection if connection attempt fails.
      */
-    static public OpcUaESClient makeConnection(Map config, boolean runAsync, OpcUaTestBase testInstance, boolean startProcessOnly, boolean expectFailure) throws ExecutionException {
+    static public OpcUaESClient makeConnection(Map config,
+                                               boolean runAsync,
+                                               OpcUaTestBase testInstance,
+                                               boolean startProcessOnly,
+                                               boolean expectFailure) throws ExecutionException {
         Map<String, String> opcConfig = (Map<String, String>) config.get(OpcConstants.CONFIG_OPC_UA_INFORMATION);
         String discoveryPoint = opcConfig.get(OpcConstants.CONFIG_DISCOVERY_ENDPOINT);
 
@@ -150,7 +150,7 @@ public class Utils {
                 } else {
                     log.debug("Connection completed within wait time: " + discoveryPoint);
                 }
-                assert cf.isCancelled() == false;
+                assert !cf.isCancelled();
                 if (discoveryPoint == OPC_PUBLIC_SERVER_NO_GOOD || expectFailure) {
                     // This one will complete with an unreachable-style error
                     assert cf.isCompletedExceptionally();
@@ -188,11 +188,11 @@ public class Utils {
                 // Then we can get these exceptions when attempting to connect to the bad server.  If that's our
                 // connection target, this this is expected.  Otherwise, it's a failure.
                 if (discoveryPoint != OPC_PUBLIC_SERVER_NO_GOOD || !e.getMessage().contains("UnresolvedAddressException")) {
-                    fail("Unexpected general exception: " + Utils.errFromExc(e));
+                    throw(e);
                 }
             } else {
                 // These are bad...
-                fail("Unexpected general exception: " + Utils.errFromExc(e));
+                throw(e);
             }
         }
         catch (Exception e) {

--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Utils.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/Utils.java
@@ -19,7 +19,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.milo.opcua.stack.core.util.Namespaces;
 
 import static org.junit.Assert.fail;
 import org.junit.Assume;


### PR DESCRIPTION
Fixes #282

1) Curate list to remove habitual offenders.
2) Have test to simple socket connection to server.  If that fails, skip that server since
we're not testing network capabilities.