### PR TITLE
Add documentation for baseConfigProperties and include examples

### DIFF
--- a/CSVSource/src/test/resources/csvImpl.json
+++ b/CSVSource/src/test/resources/csvImpl.json
@@ -3,5 +3,10 @@
    "baseType" : "EXTENSION",
    "verticle" : "service:extensionSource",
    "config" : {},
-   "operations": [ "notification" ]
+   "operations": [ "notification" ],
+   "baseConfigProperties": [
+      "csvConfig.fileFolderPath",
+      "csvConfig.fileExtension",
+      "csvConfig.maxLinesInEvent"
+   ]
 }

--- a/EasyModbusSource/src/test/resources/EasyModbusImpl.json
+++ b/EasyModbusSource/src/test/resources/EasyModbusImpl.json
@@ -3,5 +3,9 @@
    "baseType" : "EXTENSION",
    "verticle" : "service:extensionSource",
    "config" : {},
-   "operations": [ "select","publish","notification" ]
+   "operations": [ "select","publish","notification" ],
+   "baseConfigProperties": [
+      "easyModbusConfig.general.TCPAddress",
+      "easyModbusConfig.general.TCPPort"
+   ]
 }

--- a/README.md
+++ b/README.md
@@ -310,6 +310,26 @@ vantiq -s <profileName> load sourceimpls exampleImpl.json
 
 where `<profileName>` is replaced by the VANTIQ profile name, and `exampleImpl.json` identifies the file containing the definition to be loaded.
 
+Source Implementation documents may also include `baseConfigProperties`- a list of strings that represent source 
+configuration options for the connector in question. By including this field, the listed configuration properties will 
+automatically be made available for configuration by a Vantiq Assembly. Typically, the source config options included 
+in the `baseConfigProperties` are the required properties for any instance of the connector. The following example 
+demonstrates how to include the 'baseConfigProperties':
+
+```
+{
+   "name" : "EXAMPLE",
+   "baseType" : "EXTENSION",
+   "verticle" : "service:extensionSource",
+   "config" : {},
+   "baseConfigProperties": [
+        "exampleConfigOption",
+        "nested.config.example1",
+        "nested.config.example2",
+   ] 
+}
+```
+
 Once that type is loaded, you can create a source of that type. This is done by first selecting the EXAMPLE type for the source,
 
 ![Creating a source, step 1](docs/images/createSource1.png)

--- a/jmsSource/src/test/resources/jmsImpl.json
+++ b/jmsSource/src/test/resources/jmsImpl.json
@@ -2,5 +2,10 @@
    "name" : "JMS",
    "baseType" : "EXTENSION",
    "verticle" : "service:extensionSource",
-   "config" : {}
+   "config" : {},
+   "baseConfigProperties": [
+      "jmsConfig.general.providerURL",
+      "jmsConfig.general.connectionFactory",
+      "jmsConfig.general.initialContext"
+   ]
 }

--- a/objectRecognitionSource/src/test/resources/objRecImpl.json
+++ b/objectRecognitionSource/src/test/resources/objRecImpl.json
@@ -2,5 +2,9 @@
    "name" : "OBJECT_RECOGNITION",
    "baseType" : "EXTENSION",
    "verticle" : "service:extensionSource",
-   "config" : {}
+   "config" : {},
+   "baseConfigProperties": [
+      "objRecConfig.dataSource.type",
+      "objRecConfig.neuralNet.type"
+   ]
 }

--- a/objectRecognitionSource/src/test/resources/objRecImpl.json
+++ b/objectRecognitionSource/src/test/resources/objRecImpl.json
@@ -5,6 +5,7 @@
    "config" : {},
    "baseConfigProperties": [
       "objRecConfig.dataSource.type",
+      "objRecConfig.dataSource.camera",
       "objRecConfig.neuralNet.type"
    ]
 }

--- a/opcuaSource/src/test/resources/opcuaImpl.json
+++ b/opcuaSource/src/test/resources/opcuaImpl.json
@@ -2,5 +2,10 @@
    "name" : "OPCUA",
    "baseType" : "EXTENSION",
    "verticle" : "service:extensionSource",
-   "config" : {}
+   "config" : {},
+   "baseConfigProperties": [
+      "opcUAInformation.discoveryEndpoint",
+      "opcUAInformation.securityPolicy",
+      "opcUAInformation.monitoredItems"
+   ]
 }

--- a/testConnector/src/test/resources/testConnectorImpl.json
+++ b/testConnector/src/test/resources/testConnectorImpl.json
@@ -2,5 +2,8 @@
   "name" : "TestConnector",
   "baseType" : "EXTENSION",
   "verticle" : "service:extensionSource",
-  "config" : {}
+  "config" : {},
+  "baseConfigProperties": [
+    "testConfig.general"
+  ]
 }

--- a/udpSource/src/main/resources/udpImpl.json
+++ b/udpSource/src/main/resources/udpImpl.json
@@ -1,6 +1,0 @@
-{
-   "name" : "UDP",
-   "baseType" : "EXTENSION",
-   "verticle" : "service:extensionSource",
-   "config" : {}
-}

--- a/udpSource/src/test/resources/udpImpl.json
+++ b/udpSource/src/test/resources/udpImpl.json
@@ -1,11 +1,11 @@
 {
-   "name" : "JDBC",
+   "name" : "UDP",
    "baseType" : "EXTENSION",
    "verticle" : "service:extensionSource",
    "config" : {},
    "baseConfigProperties": [
-      "jdbcConfig.general.username",
-      "jdbcConfig.general.password",
-      "jdbcConfig.general.dbURL"
+      "udpSourceConfig.general",
+      "udpSourceConfig.incoming",
+      "udpSourceConfig.outgoing"
    ]
 }


### PR DESCRIPTION
Closes #286 

Adding documentation for baseConfigProperties, along with examples for each connector's sourceimpl document. Also moved UDP sourceimpl from `main/resources` to `test/resources`