### PR TITLE
Correctly handle simultaneous queries involving dates

### DIFF
--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
@@ -22,6 +22,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,8 +102,8 @@ public class JDBC {
      *                          Array if nothing was returned)
      * @throws VantiqSQLException
      */
-    public HashMap[] processQuery(String sqlQuery) throws VantiqSQLException {
-        HashMap[] rsArray = null;
+    public Map[] processQuery(String sqlQuery) throws VantiqSQLException {
+        Map[] rsArray = null;
 
         if (isAsync) {
             try (Connection conn = ds.getConnection();
@@ -119,7 +120,7 @@ public class JDBC {
 
             try (Statement stmt = conn.createStatement();
                  ResultSet rs = stmt.executeQuery(sqlQuery)) {
-                rsArray = createMapFromResults(rs);
+                 rsArray = createMapFromResults(rs);
             } catch (SQLException e) {
                 // Handle errors for JDBC
                 reportSQLError(e);
@@ -215,11 +216,12 @@ public class JDBC {
      *                       (or an empty HashMap Array if the ResultSet was empty).
      * @throws VantiqSQLException
      */
-    HashMap[] createMapFromResults(ResultSet queryResults) throws VantiqSQLException {
-        ArrayList<HashMap> rows = new ArrayList<HashMap>();
+    @SuppressWarnings({"rawtypes", "unchedked"})
+    Map[] createMapFromResults(ResultSet queryResults) throws VantiqSQLException {
+        ArrayList<HashMap<String, Object>> rows = new ArrayList<HashMap<String, Object>>();
         try {
             if (!queryResults.next()) { 
-                return rows.toArray(new HashMap[rows.size()]);
+                return rows.toArray(new HashMap[0]);
             } else {
                 ResultSetMetaData md = queryResults.getMetaData(); 
                 int columns = md.getColumnCount();
@@ -231,7 +233,7 @@ public class JDBC {
                 
                 // Iterate over rows of Result Set and create a map for each row
                 do {
-                    HashMap row = new HashMap(columns);
+                    HashMap<String, Object> row = new HashMap<>(columns);
                     for (int i=1; i<=columns; ++i) {
                         // Check column type to retrieve data in appropriate manner
                         int columnType = md.getColumnType(i);
@@ -274,8 +276,7 @@ public class JDBC {
         } catch (SQLException e) {
             reportSQLError(e);
         }
-        HashMap[] rowsArray = rows.toArray(new HashMap[rows.size()]);
-        return rowsArray;
+        return rows.toArray(new HashMap[0]);
     }
     
     /**

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
@@ -51,10 +51,6 @@ public class JDBC {
 
     // Used if asynchronous publish/query handling has been specified
     private HikariDataSource ds = null;
-
-    DateFormat dfTimestamp  = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-    DateFormat dfDate       = new SimpleDateFormat("yyyy-MM-dd");
-    DateFormat dfTime       = new SimpleDateFormat("HH:mm:ss.SSSZ");
     
     /**
      * The method used to setup the connection to the SQL Database, using the values retrieved from the source config.
@@ -227,6 +223,11 @@ public class JDBC {
             } else {
                 ResultSetMetaData md = queryResults.getMetaData(); 
                 int columns = md.getColumnCount();
+
+                // These formatters need to be local as they are not threadsafe.  Issue #290
+                DateFormat dfTimestamp  = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+                DateFormat dfDate       = new SimpleDateFormat("yyyy-MM-dd");
+                DateFormat dfTime       = new SimpleDateFormat("HH:mm:ss.SSSZ");
                 
                 // Iterate over rows of Result Set and create a map for each row
                 do {

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
@@ -14,9 +14,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Timer;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CompletableFuture;import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.ExecutorService;
 
@@ -51,7 +49,7 @@ public class JDBCCore {
     final static String SELECT_STATEMENT_IDENTIFIER = "select";
     
     // Used to check row bundling in tests
-    public HashMap[] lastRowBundle = null;
+    public Map[] lastRowBundle = null;
 
     ExecutorService queryPool = null;
     ExecutorService publishPool = null;
@@ -193,7 +191,7 @@ public class JDBCCore {
                 String queryString = (String) request.get("query");
                 // Check if SQL Query is an update statement, or query statement
                 if (queryString.trim().toLowerCase().startsWith(SELECT_STATEMENT_IDENTIFIER)) {
-                    HashMap[] queryArray = localJDBC.processQuery(queryString);
+                    Map[] queryArray = localJDBC.processQuery(queryString);
                     sendDataFromQuery(queryArray, message);
                 } else {
                     int data = localJDBC.processPublish(queryString);
@@ -299,9 +297,9 @@ public class JDBCCore {
             return;
         }
         try {
-            HashMap[] queryMap = localJDBC.processQuery(pollQuery);
+            Map[] queryMap = localJDBC.processQuery(pollQuery);
             if (queryMap != null) {
-                for (HashMap h : queryMap) {
+                for (Map h : queryMap) {
                     if (client.isConnected()) {
                         client.sendNotification(h);
                     } else {
@@ -324,7 +322,7 @@ public class JDBCCore {
     * @param queryArray     A HashMap Array containing the retrieved data from processQuery().
     * @param message        The Query message
     */
-   public void sendDataFromQuery(HashMap[] queryArray, ExtensionServiceMessage message) {
+   public void sendDataFromQuery(Map[] queryArray, ExtensionServiceMessage message) {
        Map<String, ?> request = (Map<String, ?>) message.getObject();
        String replyAddress = ExtensionServiceMessage.extractReplyAddress(message);
        
@@ -346,7 +344,7 @@ public class JDBCCore {
            // Otherwise, send messages containing 'bundleFactor' number of rows
            int len = queryArray.length;
            for (int i = 0; i < len; i += bundleFactor) {
-               HashMap[] rowBundle = Arrays.copyOfRange(queryArray, i, Math.min(queryArray.length, i+bundleFactor));
+               Map[] rowBundle = Arrays.copyOfRange(queryArray, i, Math.min(queryArray.length, i+bundleFactor));
                
                // If we reached the last row, send with 200 code
                if  (i + bundleFactor >= len) {

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -521,6 +521,7 @@ public class TestJDBC extends TestJDBCBase {
             t.start();
         }
 
+        // Now, wait for all the threads to complete, checking that they all ran exception free.
         Exception trapped = null;
         for (Thread t: threads) {
             try {

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -23,10 +23,8 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.AfterClass;
@@ -40,7 +38,7 @@ import io.vantiq.client.Vantiq;
 import io.vantiq.client.VantiqResponse;
 import io.vantiq.extsrc.jdbcSource.exception.VantiqSQLException;
 
-@SuppressWarnings("PMD.ExcessiveClassLength")
+@SuppressWarnings({"PMD.ExcessiveClassLength", "rawtypes"})
 public class TestJDBC extends TestJDBCBase {
     
     // Queries to be tested
@@ -208,14 +206,14 @@ public class TestJDBC extends TestJDBCBase {
             try {
                 dropTablesJDBC.processPublish(DELETE_TABLE);
             } catch (VantiqSQLException e) {
-                // Shoudn't throw Exception
+                // Shouldn't throw Exception
             }
             
             // Delete second table
             try {
                 dropTablesJDBC.processPublish(DELETE_TABLE_EXTENDED_TYPES);
             } catch (VantiqSQLException e) {
-                // Shoudn't throw Exception
+                // Shouldn't throw Exception
             }
             
             // Delete third table
@@ -298,11 +296,13 @@ public class TestJDBC extends TestJDBCBase {
             deleteProcedure();
             deleteRule();
         }
+
         // Close JDBCCore if still open
         if (core != null) {
             core.close();
             core = null;
         }
+
         // Close JDBC if still open
         if (jdbc != null) {
             jdbc.close();
@@ -319,7 +319,7 @@ public class TestJDBC extends TestJDBCBase {
         
         // Try processPublish with a nonsense query
         try {
-            queryResult = jdbc.processPublish("jibberish");
+            jdbc.processPublish("jibberish");
             fail("Should have thrown an exception");
         } catch (VantiqSQLException e) {
             // Expected behavior
@@ -349,12 +349,12 @@ public class TestJDBC extends TestJDBCBase {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
         jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
         
-        HashMap[] queryResult;
+        Map[] queryResult;
         int deleteResult;
         
         // Try processQuery with a nonsense query
         try {
-            queryResult = jdbc.processQuery("jibberish");
+            jdbc.processQuery("jibberish");
             fail("Should have thrown exception.");
         } catch (VantiqSQLException e) {
             // Expected behavior
@@ -394,7 +394,7 @@ public class TestJDBC extends TestJDBCBase {
     public void testExtendedTypes() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
         jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
-        HashMap[] queryResult;
+        Map[] queryResult;
         int publishResult;
         
         // Create table with odd types including timestamps, dates, times, and decimals
@@ -444,7 +444,6 @@ public class TestJDBC extends TestJDBCBase {
     public void testParallelDates() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
         jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
-        HashMap[] queryResult;
         int publishResult;
 
 
@@ -604,7 +603,7 @@ public class TestJDBC extends TestJDBCBase {
         jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
         
         int publishResult;
-        HashMap[] queryResult;
+        Map[] queryResult;
         
         // Create table with all supported data type values
         try {
@@ -678,12 +677,12 @@ public class TestJDBC extends TestJDBCBase {
                     assert queryResult[0].get("ts").equals(FORMATTED_TIMESTAMP);
                 }
                 if (i != 1) {
-                    assertTrue("Expected " + DATE + ", but got " + queryResult[0].get("testDate"),
-                            queryResult[0].get("testDate").equals(DATE));
+                    assertEquals("Expected " + DATE + ", but got " + queryResult[0].get("testDate"),
+                            DATE, queryResult[0].get("testDate"));
                 }
                 if (i != 2) {
-                    assertTrue("Expected " + FORMATTED_TIME + ", but got " + queryResult[0].get("testTime"),
-                         queryResult[0].get("testTime").equals(FORMATTED_TIME));
+                    assertEquals("Expected " + FORMATTED_TIME + ", but got " + queryResult[0].get("testTime"),
+                         FORMATTED_TIME, queryResult[0].get("testTime"));
                 }
                 if (i != 3) {
                     assert queryResult[0].get("testInt").toString().equals(TEST_INT);
@@ -707,12 +706,10 @@ public class TestJDBC extends TestJDBCBase {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
         assumeTrue(testDBURL.contains("mysql"));
         jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
-        HashMap[] queryResult;
-        int publishResult;
-        
+
         // Check error code for selecting from non-existent table
         try {
-            queryResult = jdbc.processQuery(NO_TABLE);
+            jdbc.processQuery(NO_TABLE);
             fail("Should have thrown an exception.");
         } catch (VantiqSQLException e) {
             String message = e.getMessage();
@@ -721,7 +718,7 @@ public class TestJDBC extends TestJDBCBase {
         
         // Check error code for selecting non-existent field
         try {
-            queryResult = jdbc.processQuery(NO_FIELD);
+            jdbc.processQuery(NO_FIELD);
             fail("Should have thrown an exception.");
         } catch (VantiqSQLException e) {
             String message = e.getMessage();
@@ -730,7 +727,7 @@ public class TestJDBC extends TestJDBCBase {
         
         // Check error code for syntax error
         try {
-            queryResult = jdbc.processQuery(SYNTAX_ERROR);
+            jdbc.processQuery(SYNTAX_ERROR);
             fail("Should have thrown an exception.");
         } catch (VantiqSQLException e) {
             String message = e.getMessage();
@@ -739,7 +736,7 @@ public class TestJDBC extends TestJDBCBase {
         
         // Check error code for using INSERT with executeQuery() method
         try {
-            queryResult = jdbc.processQuery(PUBLISH_QUERY);
+            jdbc.processQuery(PUBLISH_QUERY);
             fail("Should have thrown an exception.");
         } catch (VantiqSQLException e) {
             String message = e.getMessage();
@@ -748,7 +745,7 @@ public class TestJDBC extends TestJDBCBase {
         
         // Check error code for INSERT not matching columns
         try {
-            publishResult = jdbc.processPublish(INSERT_NO_FIELD);
+            jdbc.processPublish(INSERT_NO_FIELD);
             fail("Should have thrown an exception.");
         } catch (VantiqSQLException e) {
             String message = e.getMessage();
@@ -757,13 +754,12 @@ public class TestJDBC extends TestJDBCBase {
         
         // Check error code for inserting wrong types
         try {
-            publishResult = jdbc.processPublish(INSERT_WRONG_TYPE);
+            jdbc.processPublish(INSERT_WRONG_TYPE);
             fail("Should have thrown an exception.");
         } catch (VantiqSQLException e) {
             String message = e.getMessage();
             assert message.contains("1366");
         }
-        
     }
     
     @Test
@@ -1280,11 +1276,7 @@ public class TestJDBC extends TestJDBCBase {
         where.put("name", testTopicName);
         VantiqResponse response = vantiq.select("system.topics", null, where, null);
         ArrayList responseBody = (ArrayList) response.getBody();
-        if (responseBody.isEmpty()) {
-            return false;
-        } else {
-            return true;
-        }
+        return !responseBody.isEmpty();
     }
 
     public static void setupTopic() {
@@ -1305,11 +1297,7 @@ public class TestJDBC extends TestJDBCBase {
         where.put("name", testProcedureName);
         VantiqResponse response = vantiq.select("system.procedures", null, where, null);
         ArrayList responseBody = (ArrayList) response.getBody();
-        if (responseBody.isEmpty()) {
-            return false;
-        } else {
-            return true;
-        }
+        return !responseBody.isEmpty();
     }
 
     public static void setupProcedure() {

--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -814,8 +814,11 @@ camera is inaccessible in non-Query mode, (i.e. if the video stream has ended).
 
 The options are as follows. Remember to prepend "DS" when using an option in a Query.
 
-*   camera: Required for Config, optional for Query. The URL of the camera to read images from. For queries, defaults
+* camera: Required for Config, optional for Query. The URL of the camera to read images from. For queries, defaults
     to the camera specified in the Config.
+* rtspConfig:
+    * rtsp_transport: Protocol to use for lower rtsp transport.  This is ignored if the scheme for the camera is
+neither`rtsp` or `rtsps`. Default is `tcp`.
 
 The timestamp is captured immediately before the image is grabbed from the camera. The additional data is:
 

--- a/objectRecognitionSource/build.gradle
+++ b/objectRecognitionSource/build.gradle
@@ -20,19 +20,6 @@ repositories {
 
 mainClassName = 'io.vantiq.extsrc.objectRecognition.ObjectRecognitionMain'
 
-// Used to check if OpenCV is needed, and compile with OpenCV or throw errors if needed
-// Should be "**/<source file name>.java" for every file that need openCV to run
-def opencvDependentSourceFilePatterns = new ArrayList<String>(
-    [
-        "**/CameraRetriever.java",
-        "**/FileRetriever.java",
-        "**/NetworkStreamRetriever.java"
-    ]
-)
-def opencvDependentFiles = sourceSets.main.java.matching(
-        { delegate.setIncludes(opencvDependentSourceFilePatterns) }
-)
-
 // Used to automatically ignore tests for implementations that have been removed.
 // The tests should be called "Test<source file name>.java"
 // And should be included in the list as "**/Test<source file name>.java"
@@ -46,24 +33,7 @@ def standardImplementationTestPatterns = new ArrayList<String>(
     ]
 )
 
-// This is the version of OpenCV that you will be using. Should be "XYZ" for version X.Y.Z
-
-def opencvVersion = "410"   // Default value.  We'll use the OPENCV_LOC env. variable to find the version present.
-
-if (System.env.OPENCV_LOC != null ) {
-    def ocv = new File(System.env.OPENCV_LOC)
-    ocv.eachFile { fname ->
-        if (fname.name.startsWith("opencv-") && fname.name.endsWith(".jar")) {
-            opencvVersion = fname.name.substring("opencv-".length(), fname.name.lastIndexOf(".jar"))
-            logger.warn("Detected OpenCV Version ${opencvVersion}")
-        }
-    }
-} else {
-    logger.warn("No OPENCV Located via OPENCV_LOC env. variable.  Defaulting to OpenCV Version ${opencvVersion}")
-}
 // Add the logConfig folder to the classpath so that changes to logConfig/log4j2.xml will be used for logging
-// and set java.library.path to the contents of the environment variable OPENCV_LOC so the OpenCV native libraries are
-// usable 
 startScripts{
     doLast{
         def windowsScriptFile = file getWindowsScript()
@@ -71,14 +41,6 @@ startScripts{
         // Add the log Config to the top of the classpath
         windowsScriptFile.text = windowsScriptFile.text.replace("CLASSPATH=", "CLASSPATH=%APP_HOME%\\logConfig;")
         unixScriptFile.text = unixScriptFile.text.replace('CLASSPATH=', 'CLASSPATH=$APP_HOME/logConfig:')
-        
-        if (!opencvDependentFiles.getFiles().isEmpty()) { // Only set java.library.path for OpenCV if we need it
-            // Set the path to the location of the native libraries
-            windowsScriptFile.text = windowsScriptFile.text.replace('DEFAULT_JVM_OPTS=',
-                    'DEFAULT_JVM_OPTS=-Djava.library.path=%OPENCV_LOC%;%TENSORFLOW_JNI%')
-            unixScriptFile.text = unixScriptFile.text.replace('DEFAULT_JVM_OPTS=',
-                    'DEFAULT_JVM_OPTS=-Djava.library.path=$OPENCV_LOC:$TENSORFLOW_JNI')
-        }
     }
 }
 
@@ -100,52 +62,24 @@ applicationDistribution.from("src/main/resources") {
 
 test {
     // set heap size for the test JVM(s)
+    // Java CV seems to impart more memory requirements for getting the same test results
+    // with gradle that we do with the IDE (even though the IDE is running tests via gradle).
     minHeapSize = "2048m"
     maxHeapSize = "2048m"
 }
 
 tasks.withType(Test) {
-    def os = org.gradle.internal.os.OperatingSystem.current()
-    if (os.isWindows()) {
-        systemProperty "java.library.path", "${System.env.OPENCV_LOC};${System.env.TENSORFLOW_JNI}"
-    } else {
-        systemProperty "java.library.path", "${System.env.OPENCV_LOC}:${System.env.TENSORFLOW_JNI}"
-    }
     if (rootProject.hasProperty("TestAuthToken")) {
+        println('Setting TestAuthToken')
         systemProperty "TestAuthToken", rootProject.findProperty("TestAuthToken") ?: "empty"
     }
     if (rootProject.hasProperty("TestVantiqServer")) {
+        println('Setting TestVantiqServer')
+
         systemProperty "TestVantiqServer", rootProject.findProperty("TestVantiqServer") ?: "empty"
     }
     // Use the build dir as a base to get our various test artifacts.
     systemProperty "buildDir", "${buildDir}"
-}
-
-// Logs a warning if the .dll/.so/.dylib cannot be found for OpenCV when OpenCV is needed
-assemble.doLast {
-    def os = org.gradle.internal.os.OperatingSystem.current()
-    // Only need to warn about missing libraries if there are files dependent on OpenCV
-    if (!opencvDependentFiles.getFiles().isEmpty()) {
-        if (os.isWindows()) {
-            if (!file("${System.env.OPENCV_LOC}\\opencv_java${opencvVersion}.dll").exists()) {
-                logger.warn("Cannot find opencv_java${opencvVersion}.dll in '${System.env.OPENCV_LOC}'. Ensure that the requested "
-                    + "file exists at the folder specified in the environment variable OPENCV_LOC")
-            }
-        } else if (os.isLinux()) {
-            if (!file("${System.env.OPENCV_LOC}/libopencv_java${opencvVersion}.so").exists()) {
-                logger.warn("Cannot find libopencv_java${opencvVersion}.so in '${System.env.OPENCV_LOC}'. Ensure that the requested "
-                    + "file exists at the folder specified in the environment variable OPENCV_LOC")
-            }
-        } else if (os.isMacOsX()) {
-            if (!file("${System.env.OPENCV_LOC}/libopencv_java${opencvVersion}.dylib").exists()) {
-                logger.warn("Cannot find libopencv_java${opencvVersion}.dylib in '${System.env.OPENCV_LOC}/'. Ensure that the "
-                    + "requested file exists at the folder specified in the environment variable OPENCV_LOC")
-            }
-        } else {
-            logger.warn("Compiling unknown file system. Please ensure that the compiled OpenCV C++ library is inside " 
-                + "'${System.env.OPENCV_LOC}' so that the program can function correctly")
-        }
-    }
 }
 
 compileJava.doFirst {
@@ -181,8 +115,9 @@ configurations {
 }
 
 ext {
-    currentCocoVersion = 1.2
-    lombokVersion = "1.16.18"
+    currentCocoVersion = '1.2'
+    lombokVersion = '1.16.18'
+    javaCvVersion = '1.5.6'
 }
 
 dependencies {
@@ -225,28 +160,8 @@ dependencies {
     metaTest "vantiq.models:coco:1.1@meta"
     metaTest "vantiq.models:coco:1.1@pb"
 
-
-    // This imports OpenCV if it is needed, and throws an error if OpenCV is needed but not properly setup
-    // The opencv
-    if (!opencvDependentFiles.getFiles().isEmpty()) { // Only look for OpenCV if we need it
-        if (System.env.OPENCV_LOC == null ) { // Fail out if OpenCV is not available 
-            // Setting depFileNames to the files still dependent on OpenCV
-            def depFileNames = "'"
-            opencvDependentFiles.getFiles().forEach {file -> depFileNames += file.getName() + "', '"}
-            depFileNames = depFileNames.substring(0, depFileNames.length() - 3) // Remove the last ", '"
-            throw new Exception("Environment variable 'OPENCV_LOC' is not set. Either set it to a location containing " + 
-            "opencv-${opencvVersion}.jar and the compiled OpenCV library, or remove the following files: ${depFileNames}")
-        } else if (!file("${System.env.OPENCV_LOC}/opencv-${opencvVersion}.jar").exists()) { // Fail out if the OpenCV jar is missing
-            // Setting depFileNames to the files still dependent on OpenCV
-            def depFileNames = "'"
-            opencvDependentFiles.getFiles().forEach {file -> depFileNames += file.getName() + "', '"}
-            depFileNames = depFileNames.substring(0, depFileNames.length() - 3) // Remove the last ", '"
-            throw new Exception("Could not find opencv-${opencvVersion}.jar in '${System.env.OPENCV_LOC}'. Either add the jar to the "
-                + "folder specified in the environment variable OPENCV_LOC or remove the following files: ${depFileNames}")
-        } else {
-            compile files("${System.env.OPENCV_LOC}/opencv-${opencvVersion}.jar")
-        }
-    }
+    // The following imports the Java OpenCV API * jar files representing the various JNI libraries (by platform)
+    compile "org.bytedeco:javacv-platform:${javaCvVersion}"
     
     // Used for uploading documents (images) to VANTIQ with VANTIQ SDK
     compile "io.vantiq:vantiq-sdk:${vantiqSDKVersion}"

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -517,7 +517,7 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
 
 
     /**
-     * Sets up the the communication method, one of timed notifications, continuous notifications, or Query responses
+     * Sets up the communication method, one of timed notifications, continuous notifications, or Query responses
      * @param general   The general portion of the configuration document
      * @return          true if the communication method could be setup, false otherwise
      */

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -528,7 +528,8 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
         int maxQueuedTasks = MAX_QUEUED_TASKS_DEFAULT;
 
         // First, we'll check the suppressNullValues option
-        if (general.get(SUPPRESS_EMPTY_NEURAL_NET_RESULTS) instanceof Boolean && (Boolean) general.get(SUPPRESS_EMPTY_NEURAL_NET_RESULTS)) {
+        if (general.get(SUPPRESS_EMPTY_NEURAL_NET_RESULTS) instanceof Boolean
+                && (Boolean) general.get(SUPPRESS_EMPTY_NEURAL_NET_RESULTS)) {
             source.suppressEmptyNeuralNetResults = (Boolean) general.get(SUPPRESS_EMPTY_NEURAL_NET_RESULTS);
         }
 

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -302,8 +302,8 @@ public class ObjectRecognitionCore {
     }
     
     /**
-     * Processes the image then sends the results to the Vantiq source. Calls {@code stop()} if a FatalImageException is
-     * received.
+     * Processes the image then sends the results to the Vantiq source. Calls {@code stop()} if a
+     * FatalImageException is received.
      * @param imageResults An {@link ImageRetrieverResults} containing the image to be translated
      */
     public void sendDataFromImage(ImageRetrieverResults imageResults) {
@@ -340,20 +340,24 @@ public class ObjectRecognitionCore {
             if (!localNeuralNet.getClass().toString().contains("NoProcessor")) {
                 // Translate the results from the neural net and image into a message to send back 
                 Map message = createMapFromResults(imageResults, results);
+                log.debug("Message from results: {}", message.get("results"));
+                log.debug("Suppress value: {}", suppressEmptyNeuralNetResults);
 
                 // If suppressNullValues is set to true, then skip sending message results list is empty
                 if (suppressEmptyNeuralNetResults) {
                     if (message.get("results") instanceof List && ((List) message.get("results")).size() == 0) {
+                        log.debug("Skipping notification");
                         return;
                     }
                 }
+                log.debug("Notifying client with: {}", message);
                 client.sendNotification(message);
             }
         } catch (ImageProcessingException e) {
             log.warn("Could not process image", e);
         } catch (FatalImageException e) {
-            log.error("Image processor of type '" + localNeuralNet.getClass().getCanonicalName() + "' failed unrecoverably"
-                    , e);
+            log.error("Image processor of type '" + localNeuralNet.getClass().getCanonicalName() +
+                            "' failed unrecoverably", e);
             log.error("Stopping");
             stop();
         } catch (RuntimeException e) {

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/CameraRetriever.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/CameraRetriever.java
@@ -12,6 +12,8 @@ package io.vantiq.extsrc.objectRecognition.imageRetriever;
 import java.util.Date;
 import java.util.Map;
 
+import org.bytedeco.javacpp.Loader;
+import org.bytedeco.opencv.opencv_java;
 import org.opencv.core.Core;
 import org.opencv.core.Mat;
 import org.opencv.core.MatOfByte;
@@ -43,7 +45,7 @@ public class CameraRetriever implements ImageRetrieverInterface {
     public void setupDataRetrieval(Map<String, ?> dataSourceConfig, ObjectRecognitionCore source) throws Exception {
         // Try to load OpenCV
         try {
-            System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
+            Loader.load(opencv_java.class);
         } catch (Throwable t) {
             throw new Exception(this.getClass().getCanonicalName() + ".opencvDependency" 
                     + ": Could not load OpenCv for CameraRetriever. "

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/FileRetriever.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/FileRetriever.java
@@ -17,6 +17,8 @@ import io.vantiq.extsrc.objectRecognition.ObjectRecognitionCore;
 import io.vantiq.extsrc.objectRecognition.exception.FatalImageException;
 import io.vantiq.extsrc.objectRecognition.exception.ImageAcquisitionException;
 
+import org.bytedeco.javacpp.Loader;
+import org.bytedeco.opencv.opencv_java;
 import org.opencv.core.Core;
 import org.opencv.core.Mat;
 import org.opencv.core.MatOfByte;
@@ -86,7 +88,7 @@ public class FileRetriever implements ImageRetrieverInterface {
 
         // Load OpenCV
         try {
-            System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
+            Loader.load(opencv_java.class);
         } catch (Throwable t) {
             throw new Exception(this.getClass().getCanonicalName() + ".opencvDependency" 
                     + ": Could not load OpenCv for FileRetriever."

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/ImageRetrieverInterface.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/ImageRetrieverInterface.java
@@ -16,7 +16,12 @@ import io.vantiq.extsrc.objectRecognition.exception.FatalImageException;
 import io.vantiq.extsrc.objectRecognition.exception.ImageAcquisitionException;
 
 public interface ImageRetrieverInterface {
+    // Constants for source configuration
     static final String TYPE_ENTRY = "type";
+    static final String CAMERA = "camera";
+    static final String RTSP_CONFIG = "rtspConfig";
+    static final String RTSP_TRANSPORT = "rtspTransport";
+    static final String RTSP_FLAGS = "rtspFlags";
     
     /**
      * Configures the data retriever.

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/NetworkStreamRetriever.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/NetworkStreamRetriever.java
@@ -17,6 +17,11 @@ import java.net.URL;
 import java.util.Date;
 import java.util.Map;
 
+import org.bytedeco.javacpp.Loader;
+import org.bytedeco.javacv.FFmpegFrameGrabber;
+import org.bytedeco.javacv.Frame;
+import org.bytedeco.javacv.OpenCVFrameConverter;
+import org.bytedeco.opencv.opencv_java;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,6 +34,9 @@ import org.opencv.videoio.VideoCapture;
 import io.vantiq.extsrc.objectRecognition.ObjectRecognitionCore;
 import io.vantiq.extsrc.objectRecognition.exception.FatalImageException;
 import io.vantiq.extsrc.objectRecognition.exception.ImageAcquisitionException;
+
+import static org.bytedeco.ffmpeg.global.avutil.AV_LOG_ERROR;
+import static org.bytedeco.ffmpeg.global.avutil.av_log_set_level;
 
 /**
  * Captures images from an IP camera.
@@ -44,27 +52,32 @@ import io.vantiq.extsrc.objectRecognition.exception.ImageAcquisitionException;
  * </ul>
  */
 public class NetworkStreamRetriever implements ImageRetrieverInterface {
-    VideoCapture   capture;
+    FFmpegFrameGrabber capture;
     String         camera;
+    String         rtspTransport = "tcp";
+    Boolean        isRTSP = false;
     Logger         log = LoggerFactory.getLogger(this.getClass().getCanonicalName());
     Boolean        isPushProtocol = false;
+
+    static boolean openCvLoaded = false;
     
     private String sourceName;
 
-    // Constants for source configuration
-    private static final String CAMERA = "camera";
-    
     @Override
+    @SuppressWarnings("unchecked")
     public void setupDataRetrieval(Map<String, ?> dataSourceConfig, ObjectRecognitionCore source) throws Exception {
         sourceName = source.getSourceName();
-        try {
-            System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
-        } catch (Throwable t) {
-            throw new Exception(this.getClass().getCanonicalName() + ".opencvDependency" 
-                    + ": Could not load OpenCv for NetworkStreamRetriever."
-                    + "This is most likely due to a missing .dll/.so/.dylib. Please ensure that the environment "
-                    + "variable 'OPENCV_LOC' is set to the directory containing '" + Core.NATIVE_LIBRARY_NAME
-                    + "' and any other library requested by the attached error", t);
+        if (!openCvLoaded) {
+            try {
+                Loader.load(opencv_java.class);
+                openCvLoaded = true;
+            } catch (Throwable t) {
+                throw new Exception(this.getClass().getCanonicalName() + ".opencvDependency"
+                        + ": Could not load OpenCv for NetworkStreamRetriever."
+                        + "This is most likely due to a missing .dll/.so/.dylib. Please ensure that the environment "
+                        + "variable 'OPENCV_LOC' is set to the directory containing '" + Core.NATIVE_LIBRARY_NAME
+                        + "' and any other library requested by the attached error", t);
+            }
         }
         if (dataSourceConfig.get(CAMERA) instanceof String){
             camera = (String) dataSourceConfig.get(CAMERA);
@@ -74,20 +87,103 @@ public class NetworkStreamRetriever implements ImageRetrieverInterface {
                         pushCheck.getPath().endsWith("m3u") || pushCheck.getPath().endsWith("m3u8")) {
                     isPushProtocol = true;
                 }
+                if (pushCheck.getScheme().equalsIgnoreCase("rtsp") ||
+                        pushCheck.getScheme().equalsIgnoreCase("rtsps")) {
+                    isRTSP = true;
+                    // If the camera is an rtsp URL, check for any options
+                    if (dataSourceConfig.get(RTSP_CONFIG) instanceof Map) {
+                        Map<String, String> rtspConf = (Map<String, String>) dataSourceConfig.get(RTSP_CONFIG);
+                        if (rtspConf.get(RTSP_TRANSPORT) instanceof String) {
+                            rtspTransport = (String) rtspConf.get(RTSP_TRANSPORT);
+                        }
+                        // rtsp_flags is for cases where the transport is acting as a server
+                        // It does not apply in our connector case.
+                    }
+                }
             } catch (URISyntaxException e) {
                 throw new IllegalArgumentException(this.getClass().getCanonicalName() + ".unknownProtocol: "
                         + "URL specifies unknown protocol, or protocol was improperly formatted. Error Message: ", e);
             }
             
-            capture = new VideoCapture(camera);
+            openCapture();
+
         } else {
             throw new IllegalArgumentException(this.getClass().getCanonicalName() + ".configMissingOptions: "  + 
                     "No camera specified in dataSourceConfig");
         }
-        if (!capture.isOpened()) {
-            diagnoseConnection();
-            throw new IllegalArgumentException(this.getClass().getCanonicalName() + ".notVideoStream: " 
-                    + "Stream at URL cannot be opened as a video stream");
+    }
+
+    protected void openCapture() throws ImageAcquisitionException {
+
+        // This av_log_set_level() call  turns off a boatload of warnings reading some types of cameras.
+        // Fix for the actual issue (which isn't a functional one) hasn't been found, apparently.]
+        // See https://github.com/bytedeco/javacv/issues/780 for more information.
+
+        av_log_set_level(AV_LOG_ERROR);
+
+        try {
+            if (capture != null) {
+                capture.close();
+                capture.release();
+                capture = null;
+            }
+            capture = new FFmpegFrameGrabber(camera);
+
+            if (isRTSP) {
+                // Depending upon where the caller is running, the UDP transport for the actual video often employed
+                // by RTSP sub-transports may or may not actually get through. In order to avoid this, we'll ask
+                // the underlying transport to use TCP for the transport. We have not (yet) encountered an environment
+                // where this is an issue.  Suggested by https://github.com/bytedeco/javacv/issues/1022.
+
+                // More information on other options (that may be available) can be found here:
+                // http://underpop.online.fr/f/ffmpeg/help/rtsp.htm.gz
+
+                capture.setOption("rtsp_transport", rtspTransport);
+
+                log.debug("Capture opened, Format: {}, codec: {}, Vid Options: {}",
+                        capture.getFormat(), capture.getVideoCodecName(), capture.getOptions().toString());
+            }
+            capture.start();
+            log.debug("Capture started, Format: {}, codec: {} ({}), Vid Meta: {}",
+                    capture.getFormat(), capture.getVideoCodecName(), capture.getVideoCodec(), capture.getVideoMetadata().toString());
+
+        } catch (Exception e) {
+            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".noGrabber: "
+                    + "Unable to create or start FrameGrabber for camera '" + camera + "'", e);
+        }
+    }
+
+    protected Mat grabFrameAsMat() throws ImageAcquisitionException {
+        if (isPushProtocol) {
+            log.debug("Camera is via push protocol -- restarting...");
+            try {
+                capture.restart();
+                log.debug("Capture restarted, Format: {}, codec: {} ({}), Vid Meta: {}",
+                        capture.getFormat(), capture.getVideoCodecName(), capture.getVideoCodec(), capture.getVideoMetadata().toString());
+            } catch (Exception e) {
+                throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".errorStopStart: "
+                        + "Could not stop/start '" + camera + "'", e);
+            }
+        }
+        try {
+            Frame frame = null;
+            int tryCount = 0;
+            while (frame == null && tryCount < 100) {
+                frame = capture.grabImage();
+                tryCount += 1;
+                if (frame != null) {
+                    if (!frame.getTypes().contains(Frame.Type.VIDEO)) {
+                        log.debug("Found non-video frame: {}", frame.getTypes());
+                        continue;
+                    }
+                }
+            }
+
+            OpenCVFrameConverter.ToMat converterToMat = new OpenCVFrameConverter.ToMat();
+            return converterToMat.convertToOrgOpenCvCoreMat(frame);
+        } catch (Exception e) {
+            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".badImageGrab: "
+                    + "Could not obtain frame from camera '" + camera + "': " + e.toString(), e);
         }
     }
     
@@ -105,33 +201,22 @@ public class NetworkStreamRetriever implements ImageRetrieverInterface {
         Mat matrix = new Mat();
         ImageRetrieverResults results = new ImageRetrieverResults();
         Date captureTime = new Date();
-        
-        if (isPushProtocol) {
-            capture.release();
-            capture = new VideoCapture(camera);
-        }
-        capture.read(matrix);
-        
-        if (matrix.empty()) {
-            matrix.release();
+
+        matrix = grabFrameAsMat();
+
+        if (matrix == null || matrix.empty()) {
+            if (matrix != null) {
+                matrix.release();
+            }
             // Check connection to URL first
             diagnoseConnection();
-            
-            // Try to recreate video capture once connection is reestablished 
-            capture = new VideoCapture(camera);
-            
-            // Otherwise, check to see if camera has closed
-            if (!capture.isOpened() ) {
-                capture.release();
-                throw new FatalImageException(this.getClass().getCanonicalName() + ".mainCameraClosed: " 
-                        + "Camera '" + camera + "' has closed");
-            } else {
-                capture.read(matrix);
-                if (matrix.empty()) {
-                    matrix.release();
-                    throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".mainCameraReadError2: " 
-                            + "Could not obtain frame from camera '" + camera + "'");
-                }
+
+            openCapture();
+            matrix = grabFrameAsMat();
+            if (matrix.empty()) {
+                matrix.release();
+                throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".mainCameraReadError2: "
+                        + "Could not obtain frame from camera '" + camera + "'");
             }
         }
       
@@ -174,50 +259,43 @@ public class NetworkStreamRetriever implements ImageRetrieverInterface {
         } else if (capture == null) {
             throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".noMainCamera: " 
                     + "No camera was requested and no main camera was specified at initialization.");
-        } else if (capture.isOpened()){
-            try {
-                return getImage();
-            } catch (FatalImageException e) {
-                throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".mainCameraFatalError: " 
-                        + "Main camera failed fatally. Other cameras are still Queryable.");
-            }
-        } else {
-            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".mainCameraClosed: " 
-                    + "No camera was requested and the main camera is no longer open. Most likely this is due to a "
-                    + "previous fatal error for the main camera.");
+        } else  {// if (capture.isOpened()){
+            return getImage();
         }
-        
-        if (!cap.isOpened()) {
-            cap.release();
-            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".queryCameraUnreadable: " 
-                    + "Could not open camera '" + camId + "'");
-        }
-        Mat mat = new Mat();
-        
-        captureTime = new Date();
-        cap.read(mat);
-        if (mat.empty()) {
-            cap.release();
-            mat.release();
-            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".queryCameraReadError: " 
-                    + "Could not obtain frame from camera '" + camId + "'");
-        }
-        MatOfByte matOfByte = new MatOfByte();
-        // Translate the image into jpeg, error out if it cannot
-        if (!Imgcodecs.imencode(".jpg", mat, matOfByte)) {
-            matOfByte.release();
-            mat.release();
-            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".queryCameraConversionError: " 
-                    + "Could not convert the frame from camera '" + camera + "' into a jpeg image");
-        }
-        byte [] imageByte = matOfByte.toArray();
-        matOfByte.release();
-        mat.release();
-        cap.release();
-        
-        results.setImage(imageByte);
-        results.setTimestamp(captureTime);
-        return results;
+
+        return getImage();
+        // FIXME -- sort this all out & fix it up with new structure
+//        if (!cap.isOpened()) {
+//            cap.release();
+//            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".queryCameraUnreadable: "
+//                    + "Could not open camera '" + camId + "'");
+//        }
+//        Mat mat = new Mat();
+//
+//        captureTime = new Date();
+//        cap.read(mat);
+//        if (mat.empty()) {
+//            cap.release();
+//            mat.release();
+//            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".queryCameraReadError: "
+//                    + "Could not obtain frame from camera '" + camId + "'");
+//        }
+//        MatOfByte matOfByte = new MatOfByte();
+//        // Translate the image into jpeg, error out if it cannot
+//        if (!Imgcodecs.imencode(".jpg", mat, matOfByte)) {
+//            matOfByte.release();
+//            mat.release();
+//            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".queryCameraConversionError: "
+//                    + "Could not convert the frame from camera '" + camera + "' into a jpeg image");
+//        }
+//        byte [] imageByte = matOfByte.toArray();
+//        matOfByte.release();
+//        mat.release();
+//        cap.release();
+//
+//        results.setImage(imageByte);
+//        results.setTimestamp(captureTime);
+//        return results;
     }
     
     public void diagnoseConnection() throws ImageAcquisitionException {
@@ -245,8 +323,14 @@ public class NetworkStreamRetriever implements ImageRetrieverInterface {
     }
     
     public void close() {
-        if (capture != null) {
-            capture.release();
+        try {
+            if (capture != null) {
+                capture.release();
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException(this.getClass().getCanonicalName() + ".badRelease: "
+                    + "Unable to release framegrabber for cammera : " + camera, e);
+
         }
     }
 }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -120,10 +120,12 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
     private static SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd--HH-mm-ss");
 
     @Override
-    public void setupImageProcessing(Map<String, ?> neuralNetConfig, String sourceName, String modelDirectory, String authToken, String server) throws Exception {
+    public void setupImageProcessing(Map<String, ?> neuralNetConfig, String sourceName, String modelDirectory,
+                                     String authToken, String server) throws Exception {
         setup(neuralNetConfig, sourceName, modelDirectory, authToken, server);
         try {
-            objectDetector = new ObjectDetector(threshold, pbFile, labelsFile, metaFile, anchorArray, imageUtil, outputDir, labelImage, saveRate, vantiq, sourceName);
+            objectDetector = new ObjectDetector(threshold, pbFile, labelsFile, metaFile, anchorArray,
+                    imageUtil, outputDir, labelImage, saveRate, vantiq, sourceName);
         } catch (Exception e) {
             throw new Exception(this.getClass().getCanonicalName() + ".yoloBackendSetupError: " 
                     + "Failed to create new ObjectDetector", e);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestNetworkStreamRetriever.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestNetworkStreamRetriever.java
@@ -19,8 +19,10 @@ public class TestNetworkStreamRetriever {
     NetworkStreamRetriever retriever;
     NoSendORCore source;
     
-    final String IP_CAMERA_URL = "http://153.142.207.158:80/-wvhttp-01-/GetOneShot?image_size=640x480&frame_count=1000000000";
-    
+//    final String IP_CAMERA_URL = "http://153.142.207.158:80/-wvhttp-01-/GetOneShot?image_size=640x480&frame_count=1000000000";
+    // Apparently new version of camera or camera software.  URL requires update...cd ../ve
+    final String IP_CAMERA_URL = "http://153.142.207.158:80/-wvhttp-01-/image.cgi?image_size=640x480&frame_count=1000000000";
+
     @Before
     public void setup() {
         source = new NoSendORCore("src", "token", "server", "dir");

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
@@ -58,12 +58,24 @@ public class TestNoProcessor extends NeuralNetTestBase {
         if (testAuthToken != null && testVantiqServer != null) {
             vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
             vantiq.setAccessToken(testAuthToken);
+
+            try {
+                createSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception creating source impl: " + e);
+            }
         }
     }
 
     @AfterClass
     public static void deleteFromVantiq() throws InterruptedException {
         if (vantiq != null && vantiq.isAuthenticated()) {
+
+            try {
+                deleteSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception deleting source impl: " + e);
+            }
             // Deleting files saved as documents
             for (String vantiqSavedFile : vantiqSavedFiles) {
                 Thread.sleep(1000);
@@ -114,7 +126,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
 
     @Test
     public void testInvalidConfig() {
-        Map config = new LinkedHashMap<>();
+        Map<String, Object> config = new LinkedHashMap<>();
         NoProcessor npProcessor = new NoProcessor();
         NoProcessor npProcessor2 = new NoProcessor();
 
@@ -131,7 +143,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
 
     @Test
     public void testValidConfig() {
-        Map config = new LinkedHashMap<>();
+        Map<String, Object> config = new LinkedHashMap<>();
         NoProcessor npProcessor = new NoProcessor();
         NoProcessor npProcessor2 = new NoProcessor();
         NoProcessor npProcessor3 = new NoProcessor();
@@ -158,7 +170,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
 
         String lastFilename;
-        Map config = new LinkedHashMap<>();
+        Map<String, Object> config = new LinkedHashMap<>();
         NoProcessor npProcessor = new NoProcessor();
 
         config.put("outputDir", OUTPUT_DIR);
@@ -181,8 +193,10 @@ public class TestNoProcessor extends NeuralNetTestBase {
             // Should save first image with timestamp
             assert d.exists();
             assert d.isDirectory();
-            assert d.listFiles().length == 1;
-            assert d.listFiles()[0].getName().matches(timestampPattern);
+            File[] lf = d.listFiles();
+            assert lf != null;
+            assert lf.length == 1;
+            assert lf[0].getName().matches(timestampPattern);
 
             // Check it didn't save to VANTIQ
             lastFilename = "objectRecognition/" + SOURCE_NAME + '/' + npProcessor.lastFilename;
@@ -195,19 +209,21 @@ public class TestNoProcessor extends NeuralNetTestBase {
             // Every other so second should not save
             assert d.exists();
             assert d.isDirectory();
-            assert d.listFiles().length == 1;
+            lf = d.listFiles();
+            assert lf != null;
+            assert lf.length == 1;
             
-            
-            results = null;
             results = npProcessor.processImage(getTestImage());
             assert results.getResults() == null;
 
             // Every other so third and first should be saved
             assert d.exists();
             assert d.isDirectory();
-            assert d.listFiles().length == 2;
-            assert d.listFiles()[0].getName().matches(timestampPattern) || d.listFiles()[0].getName().matches(sameTimestampPattern);
-            assert d.listFiles()[1].getName().matches(timestampPattern) || d.listFiles()[1].getName().matches(sameTimestampPattern);
+            lf = d.listFiles();
+            assert lf != null;
+            assert lf.length == 2;
+            assert lf[0].getName().matches(timestampPattern) || lf[0].getName().matches(sameTimestampPattern);
+            assert lf[1].getName().matches(timestampPattern) || lf[1].getName().matches(sameTimestampPattern);
 
             // Check it didn't save to VANTIQ
             lastFilename = "objectRecognition/" + SOURCE_NAME + '/' + npProcessor.lastFilename;
@@ -231,7 +247,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
 
         String lastFilename;
-        Map config = new LinkedHashMap<>();
+        Map<String, Object> config = new LinkedHashMap<>();
         NoProcessor npProcessor = new NoProcessor();
 
         config.put("outputDir", OUTPUT_DIR);
@@ -252,8 +268,10 @@ public class TestNoProcessor extends NeuralNetTestBase {
             // Should save first image with timestamp
             assert d.exists();
             assert d.isDirectory();
-            assert d.listFiles().length == 1;
-            assert d.listFiles()[0].getName().matches(timestampPattern);
+            File[] lf = d.listFiles();
+            assert lf != null;
+            assert lf.length == 1;
+            assert lf[0].getName().matches(timestampPattern);
 
             // Checking that image was saved to VANTIQ
             Thread.sleep(1000);
@@ -268,18 +286,21 @@ public class TestNoProcessor extends NeuralNetTestBase {
             // Every other so second should not save
             assert d.exists();
             assert d.isDirectory();
-            assert d.listFiles().length == 1;
+            lf = d.listFiles();
+            assert lf != null;
+            assert lf.length == 1;
 
-            results = null;
             results = npProcessor.processImage(getTestImage());
             assert results.getResults() == null;
 
             // Every other so third and first should be saved
             assert d.exists();
             assert d.isDirectory();
-            assert d.listFiles().length == 2;
-            assert d.listFiles()[0].getName().matches(timestampPattern);
-            assert d.listFiles()[1].getName().matches(timestampPattern);
+            lf = d.listFiles();
+            assert lf != null;
+            assert lf.length == 2;
+            assert lf[0].getName().matches(timestampPattern);
+            assert lf[1].getName().matches(timestampPattern);
 
             // Checking that image was saved to VANTIQ
             Thread.sleep(1000);
@@ -306,7 +327,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
 
         String lastFilename;
-        Map config = new LinkedHashMap<>();
+        Map<String, Object> config = new LinkedHashMap<>();
         NoProcessor npProcessor = new NoProcessor();
 
         config.put("outputDir", OUTPUT_DIR);
@@ -349,7 +370,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
 
         String lastFilename;
-        Map config = new LinkedHashMap<>();
+        Map<String, Object> config = new LinkedHashMap<>();
         NoProcessor npProcessor = new NoProcessor();
 
         config.put("outputDir", OUTPUT_DIR);
@@ -370,7 +391,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
                 deleteDirectory(queryOutputDir);
             }
 
-            Map request = new LinkedHashMap<>();
+            Map<String, String> request = new LinkedHashMap<>();
             NeuralNetResults results = npProcessor.processImage(getTestImage(), request);
             assert results.getResults().isEmpty();
 
@@ -391,7 +412,6 @@ public class TestNoProcessor extends NeuralNetTestBase {
             request.remove("NNsaveImage");
             request.put("NNsaveImage", "vantiq");
             request.put("NNfileName", queryOutputFileVantiq);
-            results = null;
             results = npProcessor.processImage(getTestImage(), request);
             assert results.getResults().isEmpty();
 
@@ -407,15 +427,16 @@ public class TestNoProcessor extends NeuralNetTestBase {
             request.put("NNsaveImage", "both");
             request.put("NNfileName", queryOutputFile);
             request.put("NNoutputDir", queryOutputDir);
-            results = null;
             results = npProcessor.processImage(getTestImage(), request);
             assert results.getResults().isEmpty();
 
             // Should have saved the image at queryOutputFile + ".jpg"
             assert dNew.exists();
             assert dNew.isDirectory();
-            assert dNew.listFiles().length == 1;
-            assert dNew.listFiles()[0].getName().equals(queryOutputFile + ".jpg");
+            File[] lf = dNew.listFiles();
+            assert lf != null;
+            assert lf.length == 1;
+            assert lf[0].getName().equals(queryOutputFile + ".jpg");
 
             // Checking that image was saved in VANTIQ
             Thread.sleep(1000);
@@ -427,7 +448,6 @@ public class TestNoProcessor extends NeuralNetTestBase {
             request.remove("NNfileName");
             request.remove("NNsaveImage");
             request.put("NNsaveImage", "local");
-            results = null;
             results = npProcessor.processImage(getTestImage(), request);
             assert results.getResults().isEmpty();
 
@@ -435,6 +455,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
             assert dNew.exists();
             assert dNew.isDirectory();
             File[] listOfFiles = dNew.listFiles();
+            assert listOfFiles != null;
             assert listOfFiles.length == 2;
 
             // listFiles() Returns data in no specific order, so we check to make sure we are grabbing correct file
@@ -451,11 +472,12 @@ public class TestNoProcessor extends NeuralNetTestBase {
 
             queryOutputFile += ".jpeg";
             request.put("NNfileName", queryOutputFile);
-            results = null;
             results = npProcessor.processImage(getTestImage(), request);
             assert results.getResults().isEmpty();
 
-            assert dNew.listFiles().length == 3;
+            listOfFiles = dNew.listFiles();
+            assert listOfFiles != null;
+            assert listOfFiles.length == 3;
 
         } finally {
             // delete the directory even if the test fails
@@ -476,7 +498,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
 
         String lastFilename;
-        Map config = new LinkedHashMap<>();
+        Map<String, Object> config = new LinkedHashMap<>();
         NoProcessor npProcessor = new NoProcessor();
 
         config.put("outputDir", OUTPUT_DIR);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
@@ -1,5 +1,6 @@
 package io.vantiq.extsrc.objectRecognition.neuralNet;
 
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
@@ -7,6 +8,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -25,7 +27,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
     static final int CORE_START_TIMEOUT = 10;
     static final String OUTPUT_DIR = System.getProperty("buildDir") + "/resources/out";
     static final String SOURCE_NAME = "UnlikelyToExistTestObjectRecognitionSource";
-    static final String IP_CAMERA_ADDRESS = "http://207.192.232.2:8000/mjpg/video.mjpg";
+    static final String IP_CAMERA_ADDRESS = "http://60.45.181.202:8080/mjpg/quad/video.mjpg";
     static final String QUERY_FILENAME = "testFile";
     static final Map<String,String> IMAGE = new LinkedHashMap<String,String>() {{
         put("filename", "objectRecognition/" + SOURCE_NAME + "/" + QUERY_FILENAME + ".jpg");
@@ -37,6 +39,13 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         if (testVantiqServer != null && testAuthToken != null) {
             vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
             vantiq.setAccessToken(testAuthToken);
+
+            try {
+                createServerConfig();
+                createSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception creating source impl: " + e);
+            }
 
             setupSource(createSourceDef());
         }
@@ -52,6 +61,11 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         if (vantiq != null && vantiq.isAuthenticated()) {
             deleteSource();
 
+            try {
+                deleteSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception deleting source impl: " + e);
+            }
             for (String vantiqUploadFile : vantiqUploadFiles) {
                 deleteFileFromVantiq(vantiqUploadFile);
             }
@@ -83,6 +97,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         File[] outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE.get("name") + ".jpg");
         
@@ -100,6 +115,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE.get("name") + ".jpg");
         
@@ -117,6 +133,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to the last saved file
         outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         
         int index = core.lastQueryFilename.lastIndexOf('/') + 1;
@@ -190,6 +207,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         File[] outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE.get("name") + ".jpg");
         
@@ -214,6 +232,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE.get("name") + ".jpg");
         
@@ -238,6 +257,8 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to the last saved file
         outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         
         int index = core.lastQueryFilename.lastIndexOf('/') + 1;

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
@@ -21,13 +22,22 @@ public class TestParallelProcessing extends NeuralNetTestBase {
 
     static final String FAKE_MODEL_DIR = "";
     static final int CORE_START_TIMEOUT = 10;
-    static final String IP_CAMERA_ADDRESS = "http://207.192.232.2:8000/mjpg/video.mjpg";
+    // Camera here not really used -- just need it to set up
+    static final String IP_CAMERA_ADDRESS = "http://60.45.181.202:8080/mjpg/video.mjpg";
+
 
     @BeforeClass
     public static void classSetup() {
         if (testVantiqServer != null && testAuthToken != null) {
             vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
             vantiq.setAccessToken(testAuthToken);
+
+            try {
+                createServerConfig();
+                createSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception creating source impl: " + e);
+            }
         }
     }
 
@@ -39,6 +49,12 @@ public class TestParallelProcessing extends NeuralNetTestBase {
             deleteSource(vantiq);
             deleteType(vantiq);
             deleteRule(vantiq);
+
+            try {
+                deleteSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception deleting source impl: " + e);
+            }
         }
     }
 

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
@@ -103,6 +103,12 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
             vantiqUploadFiles.add(IMAGE_5.get("filename"));
             vantiqUploadFiles.add(IMAGE_6.get("filename"));
             vantiqUploadFiles.add(IMAGE_7.get("filename"));
+
+            try {
+                createSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception creating source impl: " + e);
+            }
         }
     }
     
@@ -139,6 +145,14 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     @SuppressWarnings("PMD.JUnit4TestShouldUseAfterAnnotation")
     @AfterClass
     public static void tearDown() {
+
+        if (vantiq != null) {
+            try {
+                deleteSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception deleting source impl: " + e);
+            }
+        }
         core.stop();
     }
     

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -1176,7 +1176,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             // Should have saved the image at queryOutputFile + ".jpg"
             assert dNew.exists();
             assert dNew.isDirectory();
-            File[] lf = d.listFiles();
+            File[] lf = dNew.listFiles();
             assert lf != null;
             assert lf.length == 1;
             assert lf[0].getName().equals(queryOutputFile + ".jpg");

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -50,7 +50,11 @@ public class TestYoloQueries extends NeuralNetTestBase {
     static final String PB_FILE = "coco-" + COCO_MODEL_VERSION + ".pb";
     static final String META_FILE = "coco-" + COCO_MODEL_VERSION + ".meta";
     static final String OUTPUT_DIR = System.getProperty("buildDir") + "/resources/out";
-    static final String IP_CAMERA_ADDRESS = "http://207.192.232.2:8000/mjpg/video.mjpg";
+
+    // Used for pre-cropping tests
+    static final int IP_CAMERA_WIDTH = 704;
+    static final int IP_CAMERA_HEIGHT = 480;
+    static final String IP_CAMERA_ADDRESS = "http://60.45.181.202:8080/mjpg/quad/video.mjpg";
 
     static final String IMAGE_1_DATE = "2019-02-05--02-35-10";
     static final Map<String,String> IMAGE_1 = new LinkedHashMap<String,String>() {{
@@ -107,12 +111,10 @@ public class TestYoloQueries extends NeuralNetTestBase {
     static final int PRECROP_TOP_LEFT_Y_COORDINATE = 50;
     static final int CROPPED_WIDTH = 200;
     static final int CROPPED_HEIGHT = 150;
-    static final int IP_CAMERA_WIDTH = 800;
-    static final int IP_CAMERA_HEIGHT = 450;
 
     
     @BeforeClass
-    public static void setup() {
+    public static void setup() throws Exception {
         if (testAuthToken != null && testVantiqServer != null) {
 
             vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
@@ -128,6 +130,12 @@ public class TestYoloQueries extends NeuralNetTestBase {
             vantiqUploadFiles.add(IMAGE_7.get("filename"));
             vantiqUploadFiles.add(IMAGE_8.get("filename"));
 
+            try {
+                createSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception creating source impl: " + e);
+            }
+            createServerConfig();
             setupSource(createSourceDef());
         }
     }
@@ -141,6 +149,12 @@ public class TestYoloQueries extends NeuralNetTestBase {
         }
         if (vantiq != null && vantiq.isAuthenticated()) {
             deleteSource(vantiq);
+
+            try {
+                deleteSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception deleting source impl: " + e);
+            }
 
             for (String vantiqUploadFile : vantiqUploadFiles) {
                 deleteFileFromVantiq(vantiqUploadFile);
@@ -205,6 +219,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         File[] outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE_8.get("name") + ".jpg");
         
@@ -222,6 +237,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE_8.get("name") + ".jpg");
         
@@ -239,6 +255,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to the last saved file
         outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         
         int index = core.lastQueryFilename.lastIndexOf('/') + 1;
@@ -312,6 +329,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         File[] outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE_8.get("name") + ".jpg");
         
@@ -336,6 +354,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE_8.get("name") + ".jpg");
         
@@ -360,6 +379,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to the last saved file
         outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         
         int index = core.lastQueryFilename.lastIndexOf('/') + 1;
@@ -572,8 +592,8 @@ public class TestYoloQueries extends NeuralNetTestBase {
         vantiqResponse = vantiq.selectOne("system.documents", IMAGE_2.get("filename"));
         if (vantiqResponse.hasErrors()) {
             List<VantiqError> errors = vantiqResponse.getErrors();
-            for (int i = 0; i < errors.size(); i++) {
-                if (errors.get(i).getCode().equals(NOT_FOUND_CODE)) {
+            for (VantiqError error : errors) {
+                if (error.getCode().equals(NOT_FOUND_CODE)) {
                     fail();
                 }
             }
@@ -613,6 +633,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         File outputDir = new File(OUTPUT_DIR);
         assert outputDir.exists();
         File[] outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 7;
         
         for (File file : outputDirFiles) {
@@ -644,7 +665,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         File d = new File(OUTPUT_DIR);
         File[] dList = d.listFiles();
-        
+        assert dList != null;
         assert dList.length == 1;
         assert dList[0].getName().equals(IMAGE_8.get("name") + ".jpg");
     }
@@ -669,7 +690,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         File d = new File(OUTPUT_DIR);
         File[] dList = d.listFiles();
-        
+        assert dList != null;
         assert dList.length == 6;
         
         for (File imageFile: dList) {
@@ -699,7 +720,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         File d = new File(OUTPUT_DIR);
         File[] dList = d.listFiles();
-        
+        assert dList != null;
         assert dList.length == 2;
         for (File file : dList) {
             assert file.getName().equals(IMAGE_1.get("date") + ".jpg") || file.getName().equals(IMAGE_8.get("name") + ".jpg");
@@ -726,7 +747,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
 
         File d = new File(OUTPUT_DIR);
         File[] dList = d.listFiles();
-        
+        assert dList != null;
         assert dList.length == 5;
         
         for (File imageFile: dList) {
@@ -764,12 +785,14 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         File[] outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals("testInvalidPreCrop.jpg");
         
         File resizedImageFile = new File(OUTPUT_DIR + "/" + outputDirFiles[0].getName());
         BufferedImage resizedImage = ImageIO.read(resizedImageFile);
-        
+
+        System.out.println("New size: w: " + resizedImage.getWidth() + ", h: " +resizedImage.getHeight());
         assert resizedImage.getWidth() == IP_CAMERA_WIDTH;
         assert resizedImage.getHeight() == IP_CAMERA_HEIGHT;
     }
@@ -806,6 +829,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         File[] outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals("testPreCrop.jpg");
         
@@ -818,9 +842,6 @@ public class TestYoloQueries extends NeuralNetTestBase {
 
     @Test
     public void testUploadAsImage() throws IOException, InterruptedException {
-        // Only run test with intended vantiq availability
-        assumeTrue(testAuthToken != null && testVantiqServer != null);
-
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
 
@@ -992,9 +1013,10 @@ public class TestYoloQueries extends NeuralNetTestBase {
     }
     
     public void addLocalTestImages() throws IOException {
-        new File(OUTPUT_DIR).mkdirs();
+        assert new File(OUTPUT_DIR).mkdirs();
         
         byte[] testImageBytes = getTestImage();
+        assert testImageBytes != null;
         InputStream in = new ByteArrayInputStream(testImageBytes);
         BufferedImage testImageBuffer = ImageIO.read(in);
         

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,11 +4,9 @@ include 'extjsdk'
 include 'udpSource'
 include 'CSVSource'
 include 'testConnector'
+include 'objectRecognitionSource'
 if (System.env.EASY_MODBUS_LOC) {
     include 'EasyModbusSource' 
-}
-if (System.env.OPENCV_LOC) {
-    include 'objectRecognitionSource'
 }
 if (System.env.JDBC_DRIVER_LOC) {
     include 'jdbcSource'


### PR DESCRIPTION
Fixes #290 

When there were multiple threads (_e.g._, when different Vantiq events caused queries to run simultaneously) were running queries against tables containing dates (including cases where it was the same table), the date strings returned could be garbled or confused.  This was due to the use of Java's `SimpleDateFormat` in a multi-threaded manner. This class is not thread safe, so...

Moved date formatters into method that does the database `SELECT` statement;  consequently, each thread gets its own copy that it can serially reuse.

Added test that runs 150 queries simultaneously -- w/o fix, things died with only a few threads. With fix, the 150 threads run fine. I ramped it to 1500 without issue, but there's no reason to keep that level in the tests.