### PR TITLE
Correctly handle multi-threaded queries involving dates

### DIFF
--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
@@ -216,7 +216,7 @@ public class JDBC {
      *                       (or an empty HashMap Array if the ResultSet was empty).
      * @throws VantiqSQLException
      */
-    @SuppressWarnings({"rawtypes", "PMD.CognitiveComplexity","PMD.SimpleDateFormatNeedsLocale"})
+    @SuppressWarnings({"rawtypes", "PMD.CognitiveComplexity", "PMD.SimpleDateFormatNeedsLocale"})
     Map[] createMapFromResults(ResultSet queryResults) throws VantiqSQLException {
         ArrayList<HashMap<String, Object>> rows = new ArrayList<HashMap<String, Object>>();
         try {

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
@@ -22,6 +22,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,10 +52,6 @@ public class JDBC {
 
     // Used if asynchronous publish/query handling has been specified
     private HikariDataSource ds = null;
-
-    DateFormat dfTimestamp  = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-    DateFormat dfDate       = new SimpleDateFormat("yyyy-MM-dd");
-    DateFormat dfTime       = new SimpleDateFormat("HH:mm:ss.SSSZ");
     
     /**
      * The method used to setup the connection to the SQL Database, using the values retrieved from the source config.
@@ -105,8 +102,8 @@ public class JDBC {
      *                          Array if nothing was returned)
      * @throws VantiqSQLException
      */
-    public HashMap[] processQuery(String sqlQuery) throws VantiqSQLException {
-        HashMap[] rsArray = null;
+    public Map[] processQuery(String sqlQuery) throws VantiqSQLException {
+        Map[] rsArray = null;
 
         if (isAsync) {
             try (Connection conn = ds.getConnection();
@@ -123,7 +120,7 @@ public class JDBC {
 
             try (Statement stmt = conn.createStatement();
                  ResultSet rs = stmt.executeQuery(sqlQuery)) {
-                rsArray = createMapFromResults(rs);
+                 rsArray = createMapFromResults(rs);
             } catch (SQLException e) {
                 // Handle errors for JDBC
                 reportSQLError(e);
@@ -219,18 +216,24 @@ public class JDBC {
      *                       (or an empty HashMap Array if the ResultSet was empty).
      * @throws VantiqSQLException
      */
-    HashMap[] createMapFromResults(ResultSet queryResults) throws VantiqSQLException {
-        ArrayList<HashMap> rows = new ArrayList<HashMap>();
+    @SuppressWarnings({"rawtypes"})
+    Map[] createMapFromResults(ResultSet queryResults) throws VantiqSQLException {
+        ArrayList<HashMap<String, Object>> rows = new ArrayList<HashMap<String, Object>>();
         try {
             if (!queryResults.next()) { 
-                return rows.toArray(new HashMap[rows.size()]);
+                return rows.toArray(new HashMap[0]);
             } else {
                 ResultSetMetaData md = queryResults.getMetaData(); 
                 int columns = md.getColumnCount();
+
+                // These formatters need to be local as they are not threadsafe.  Issue #290
+                DateFormat dfTimestamp  = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+                DateFormat dfDate       = new SimpleDateFormat("yyyy-MM-dd");
+                DateFormat dfTime       = new SimpleDateFormat("HH:mm:ss.SSSZ");
                 
                 // Iterate over rows of Result Set and create a map for each row
                 do {
-                    HashMap row = new HashMap(columns);
+                    HashMap<String, Object> row = new HashMap<>(columns);
                     for (int i=1; i<=columns; ++i) {
                         // Check column type to retrieve data in appropriate manner
                         int columnType = md.getColumnType(i);
@@ -273,8 +276,7 @@ public class JDBC {
         } catch (SQLException e) {
             reportSQLError(e);
         }
-        HashMap[] rowsArray = rows.toArray(new HashMap[rows.size()]);
-        return rowsArray;
+        return rows.toArray(new HashMap[0]);
     }
     
     /**

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBC.java
@@ -216,7 +216,7 @@ public class JDBC {
      *                       (or an empty HashMap Array if the ResultSet was empty).
      * @throws VantiqSQLException
      */
-    @SuppressWarnings({"rawtypes"})
+    @SuppressWarnings({"rawtypes", "PMD.CognitiveComplexity","PMD.SimpleDateFormatNeedsLocale"})
     Map[] createMapFromResults(ResultSet queryResults) throws VantiqSQLException {
         ArrayList<HashMap<String, Object>> rows = new ArrayList<HashMap<String, Object>>();
         try {

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
@@ -10,12 +10,10 @@ package io.vantiq.extsrc.jdbcSource;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Timer;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.ExecutorService;
@@ -51,7 +49,7 @@ public class JDBCCore {
     final static String SELECT_STATEMENT_IDENTIFIER = "select";
     
     // Used to check row bundling in tests
-    public HashMap[] lastRowBundle = null;
+    public Map[] lastRowBundle = null;
 
     ExecutorService queryPool = null;
     ExecutorService publishPool = null;
@@ -193,7 +191,7 @@ public class JDBCCore {
                 String queryString = (String) request.get("query");
                 // Check if SQL Query is an update statement, or query statement
                 if (queryString.trim().toLowerCase().startsWith(SELECT_STATEMENT_IDENTIFIER)) {
-                    HashMap[] queryArray = localJDBC.processQuery(queryString);
+                    Map[] queryArray = localJDBC.processQuery(queryString);
                     sendDataFromQuery(queryArray, message);
                 } else {
                     int data = localJDBC.processPublish(queryString);
@@ -299,9 +297,9 @@ public class JDBCCore {
             return;
         }
         try {
-            HashMap[] queryMap = localJDBC.processQuery(pollQuery);
+            Map[] queryMap = localJDBC.processQuery(pollQuery);
             if (queryMap != null) {
-                for (HashMap h : queryMap) {
+                for (Map h : queryMap) {
                     if (client.isConnected()) {
                         client.sendNotification(h);
                     } else {
@@ -324,7 +322,7 @@ public class JDBCCore {
     * @param queryArray     A HashMap Array containing the retrieved data from processQuery().
     * @param message        The Query message
     */
-   public void sendDataFromQuery(HashMap[] queryArray, ExtensionServiceMessage message) {
+   public void sendDataFromQuery(Map[] queryArray, ExtensionServiceMessage message) {
        Map<String, ?> request = (Map<String, ?>) message.getObject();
        String replyAddress = ExtensionServiceMessage.extractReplyAddress(message);
        
@@ -346,7 +344,7 @@ public class JDBCCore {
            // Otherwise, send messages containing 'bundleFactor' number of rows
            int len = queryArray.length;
            for (int i = 0; i < len; i += bundleFactor) {
-               HashMap[] rowBundle = Arrays.copyOfRange(queryArray, i, Math.min(queryArray.length, i+bundleFactor));
+               Map[] rowBundle = Arrays.copyOfRange(queryArray, i, Math.min(queryArray.length, i+bundleFactor));
                
                // If we reached the last row, send with 200 code
                if  (i + bundleFactor >= len) {

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCCore.java
@@ -169,6 +169,7 @@ public class JDBCCore {
      * a query error using sendQueryError()
      * @param message   The Query message.
      */
+    @SuppressWarnings({"PMD.CognitiveComplexity"})
     public void executeQuery(ExtensionServiceMessage message) {
         Map<String, ?> request = (Map<String, ?>) message.getObject();
         String replyAddress = ExtensionServiceMessage.extractReplyAddress(message);
@@ -344,7 +345,7 @@ public class JDBCCore {
            // Otherwise, send messages containing 'bundleFactor' number of rows
            int len = queryArray.length;
            for (int i = 0; i < len; i += bundleFactor) {
-               Map[] rowBundle = Arrays.copyOfRange(queryArray, i, Math.min(queryArray.length, i+bundleFactor));
+               Map[] rowBundle = Arrays.copyOfRange(queryArray, i, Math.min(queryArray.length, i + bundleFactor));
                
                // If we reached the last row, send with 200 code
                if  (i + bundleFactor >= len) {

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -26,7 +26,6 @@ import io.vantiq.extsrc.jdbcSource.exception.VantiqSQLException;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.Integer;
 import java.math.BigDecimal;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -104,7 +103,7 @@ public class TestJDBC extends TestJDBCBase {
             "testTime TIME);";
 
     static final String INSERT_MANY_DATES_FRAG = "INSERT INTO TestManyDates VALUES (";
-    static final String SELECT_QUERY_MANY_DATES= "SELECT * FROM TestManyDates;";
+    static final String SELECT_QUERY_MANY_DATES = "SELECT * FROM TestManyDates;";
     static final String DELETE_ROW_MANY_DATES = "DELETE FROM TestManyDates;";
     static final String DROP_TABLE_MANY_DATES = "DROP TABLE TestManyDates;";
 
@@ -199,7 +198,7 @@ public class TestJDBC extends TestJDBCBase {
         Utils.obtainServerConfig();
     }
 
-    @SuppressWarnings("PMD.JUnit4TestShouldUseAfterAnnotation")
+    @SuppressWarnings({"PMD.JUnit4TestShouldUseAfterAnnotation", "PMD.CognitiveComplexity", "PMD.EmptyCatchBlock"})
     @AfterClass
     public static void tearDown() throws VantiqSQLException {
         if (testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null) {
@@ -445,6 +444,7 @@ public class TestJDBC extends TestJDBCBase {
         }
     }
 
+    @SuppressWarnings({"PMD.CognitiveComplexity", "PMD.SimpleDateFormatNeedsLocale"})
     @Test
     public void testParallelDates() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
@@ -705,7 +705,8 @@ public class TestJDBC extends TestJDBCBase {
         
         jdbc.close();
     }
-    
+
+    @SuppressWarnings({"PMD.CognitiveComplexity"})
     @Test
     public void testCorrectErrors() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
@@ -1136,6 +1137,7 @@ public class TestJDBC extends TestJDBCBase {
 
     // ================================================= Helper functions =================================================
 
+    @SuppressWarnings({"PMD.SimpleDateFormatNeedsLocale"})
     public static Map<String, Object> createManyDatesRows(int id, int rowCount) {
         Instant inst = Instant.now().plus(id, ChronoUnit.DAYS);
         String instString = new SimpleDateFormat("yyyy-MM-dd' 'HH:mm:ss").format(Date.from(inst));

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -1138,7 +1138,7 @@ public class TestJDBC extends TestJDBCBase {
 
     // ================================================= Helper functions =================================================
 
-    @SuppressWarnings({"PMD.SimpleDateFormatNeedsLocale"})
+    @SuppressWarnings({"PMD.SimpleDateFormatNeedsLocale", "PMD.IllegalTypeCheck"})
     public static Map<String, Object> createManyDatesRows(int id, int rowCount) {
         Instant inst = Instant.now().plus(id, ChronoUnit.DAYS);
         String instString = new SimpleDateFormat("yyyy-MM-dd' 'HH:mm:ss").format(Date.from(inst));

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -8,31 +8,41 @@
 
 package io.vantiq.extsrc.jdbcSource;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 import static org.junit.Assert.assertEquals;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Before;
-import org.junit.Test;
-
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 import io.vantiq.client.Vantiq;
 import io.vantiq.client.VantiqResponse;
+import io.vantiq.extjsdk.Utils;
 import io.vantiq.extsrc.jdbcSource.exception.VantiqSQLException;
 
-@SuppressWarnings("PMD.ExcessiveClassLength")
+import java.io.File;
+import java.io.IOException;
+import java.lang.Integer;
+import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+@SuppressWarnings({"PMD.ExcessiveClassLength", "rawtypes"})
 public class TestJDBC extends TestJDBCBase {
     
     // Queries to be tested
@@ -54,12 +64,50 @@ public class TestJDBC extends TestJDBCBase {
     // Queries to test oddball types
     static final String CREATE_TABLE_EXTENDED_TYPES = "create table TestTypes(id int, ts TIMESTAMP, testDate DATE, "
             + "testTime TIME, testDec decimal(5,2));";
+
     static final String PUBLISH_QUERY_EXTENDED_TYPES = "INSERT INTO TestTypes VALUES (1, '" + TIMESTAMP + "', '" + DATE + "',"
             + " '" + TIME + "', 145.86);";
     static final String SELECT_QUERY_EXTENDED_TYPES = "SELECT * FROM TestTypes;";
     static final String DELETE_ROW_EXTENDED_TYPES = "DELETE FROM TestTypes;";
     static final String DELETE_TABLE_EXTENDED_TYPES = "DROP TABLE TestTypes;";
-    
+
+    static final Integer TS_COUNT = 25;
+    static final Integer PARALLEL_DATE_INSTANCE_COUNT = 15;
+    static final Integer PARALLEL_DATE_THREAD_COUNT = 150;
+    static final String CREATE_TABLE_MANY_DATES = "create table TestManyDates(id int," +
+            "ts1  TIMESTAMP," +
+            "ts2  TIMESTAMP," +
+            "ts3  TIMESTAMP," +
+            "ts4  TIMESTAMP," +
+            "ts5  TIMESTAMP," +
+            "ts6  TIMESTAMP," +
+            "ts7  TIMESTAMP," +
+            "ts8  TIMESTAMP," +
+            "ts9  TIMESTAMP," +
+            "ts10 TIMESTAMP," +
+            "ts11 TIMESTAMP," +
+            "ts12 TIMESTAMP," +
+            "ts13 TIMESTAMP," +
+            "ts14 TIMESTAMP," +
+            "ts15 TIMESTAMP," +
+            "ts16 TIMESTAMP," +
+            "ts17 TIMESTAMP," +
+            "ts18 TIMESTAMP," +
+            "ts19 TIMESTAMP," +
+            "ts20 TIMESTAMP," +
+            "ts21 TIMESTAMP," +
+            "ts22 TIMESTAMP," +
+            "ts23 TIMESTAMP," +
+            "ts24 TIMESTAMP," +
+            "ts25 TIMESTAMP," +
+            "testDate DATE, " +
+            "testTime TIME);";
+
+    static final String INSERT_MANY_DATES_FRAG = "INSERT INTO TestManyDates VALUES (";
+    static final String SELECT_QUERY_MANY_DATES= "SELECT * FROM TestManyDates;";
+    static final String DELETE_ROW_MANY_DATES = "DELETE FROM TestManyDates;";
+    static final String DROP_TABLE_MANY_DATES = "DROP TABLE TestManyDates;";
+
     // Queries to test errors
     static final String NO_TABLE = "SELECT * FROM jibberish";
     static final String NO_FIELD = "SELECT jibberish FROM Test";
@@ -141,15 +189,15 @@ public class TestJDBC extends TestJDBCBase {
         vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
         vantiq.setAccessToken(testAuthToken);
     }
-    
-    /* Uncomment this BeforeClass when debugging to ensure tables have been properly deleted.
-    
+
     @BeforeClass
-    public static void debugSetup() throws VantiqSQLException {
-        tearDown();
+    public static void setupEnv() throws IOException {
+        // Make initial Utils.obtainServerConfig() call so that we don't get errors later on
+        File serverConfigFile = new File("server.config");
+        serverConfigFile.createNewFile();
+        serverConfigFile.deleteOnExit();
+        Utils.obtainServerConfig();
     }
-    
-    */
 
     @SuppressWarnings("PMD.JUnit4TestShouldUseAfterAnnotation")
     @AfterClass
@@ -163,14 +211,14 @@ public class TestJDBC extends TestJDBCBase {
             try {
                 dropTablesJDBC.processPublish(DELETE_TABLE);
             } catch (VantiqSQLException e) {
-                // Shoudn't throw Exception
+                // Shouldn't throw Exception
             }
             
             // Delete second table
             try {
                 dropTablesJDBC.processPublish(DELETE_TABLE_EXTENDED_TYPES);
             } catch (VantiqSQLException e) {
-                // Shoudn't throw Exception
+                // Shouldn't throw Exception
             }
             
             // Delete third table
@@ -235,6 +283,13 @@ public class TestJDBC extends TestJDBCBase {
             } catch (VantiqSQLException e) {
                 // Shouldn't throw Exception
             }
+
+            // Delete parallel Dates table
+            try {
+                dropTablesJDBC.processPublish(DROP_TABLE_MANY_DATES);
+            } catch (VantiqSQLException e) {
+                // Shouldn't throw Exception
+            }
             
             // Close the new JDBC Instance
             dropTablesJDBC.close();
@@ -246,11 +301,13 @@ public class TestJDBC extends TestJDBCBase {
             deleteProcedure();
             deleteRule();
         }
+
         // Close JDBCCore if still open
         if (core != null) {
             core.close();
             core = null;
         }
+
         // Close JDBC if still open
         if (jdbc != null) {
             jdbc.close();
@@ -267,7 +324,7 @@ public class TestJDBC extends TestJDBCBase {
         
         // Try processPublish with a nonsense query
         try {
-            queryResult = jdbc.processPublish("jibberish");
+            jdbc.processPublish("jibberish");
             fail("Should have thrown an exception");
         } catch (VantiqSQLException e) {
             // Expected behavior
@@ -297,12 +354,12 @@ public class TestJDBC extends TestJDBCBase {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
         jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
         
-        HashMap[] queryResult;
+        Map[] queryResult;
         int deleteResult;
         
         // Try processQuery with a nonsense query
         try {
-            queryResult = jdbc.processQuery("jibberish");
+            jdbc.processQuery("jibberish");
             fail("Should have thrown exception.");
         } catch (VantiqSQLException e) {
             // Expected behavior
@@ -342,7 +399,7 @@ public class TestJDBC extends TestJDBCBase {
     public void testExtendedTypes() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
         jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
-        HashMap[] queryResult;
+        Map[] queryResult;
         int publishResult;
         
         // Create table with odd types including timestamps, dates, times, and decimals
@@ -366,7 +423,8 @@ public class TestJDBC extends TestJDBCBase {
             queryResult = jdbc.processQuery(SELECT_QUERY_EXTENDED_TYPES);
             String timestampTest = (String) queryResult[0].get("ts");
             assert timestampTest.matches(timestampPattern);
-            assertTrue("Expected " + FORMATTED_TIMESTAMP + ", but got " + timestampTest,timestampTest.equals(FORMATTED_TIMESTAMP));
+            assertEquals("Expected " + FORMATTED_TIMESTAMP + ", but got " + timestampTest,
+                    FORMATTED_TIMESTAMP, timestampTest);
             String dateTest = (String) queryResult[0].get("testDate");
             assert dateTest.matches(datePattern);
             assert dateTest.equals(DATE);
@@ -384,6 +442,104 @@ public class TestJDBC extends TestJDBCBase {
             assert publishResult > 0;
         } catch (VantiqSQLException e) {
             fail("Should not have thrown exception.");
+        }
+    }
+
+    @Test
+    public void testParallelDates() throws VantiqSQLException {
+        assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
+        jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
+        int publishResult;
+
+
+        // Create table with odd types including timestamps, dates, times, and decimals
+        try {
+            publishResult = jdbc.processPublish(CREATE_TABLE_MANY_DATES);
+            assert publishResult == 0;
+        } catch (VantiqSQLException e) {
+            e.printStackTrace();
+            fail("Should not have thrown exception." + e);
+        }
+
+        // Insert values into the newly created table
+        // Here, we will set up a bunch of sets of 25 rows, where each row has a bunch of dates in it.
+
+        ArrayList<Map<String, Object>> dataMap = new ArrayList<>();
+        try {
+            for (int i = 0; i < 25; i++) {
+                Map<String, Object> toPub = createManyDatesRows(i, PARALLEL_DATE_INSTANCE_COUNT);
+                dataMap.add(toPub);
+                for (String row : (String[]) toPub.get("batch")) {
+                    publishResult = jdbc.processPublish(row);
+                    assert publishResult > 0;
+                }
+            }
+        } catch (VantiqSQLException e) {
+            e.printStackTrace();
+            fail("Should not have thrown exception on insert: " + e);
+        }
+
+        // Now, to verify our parallel operations, we'll fire off a bunch of threads all doing the same
+        // query across this table full of dates.  We should get everything with correct results,
+        // but we had had the date results scrambled due to use of non-threadsafe methods.
+
+        AtomicReference<Exception> threadFailed = new AtomicReference<>();
+        Runnable querier = () -> {
+            // Select the values from the table and make sure the data is retrieved correctly
+            try {
+                Map[] qres = jdbc.processQuery(SELECT_QUERY_MANY_DATES);
+                for (Map row : qres) {
+                    int id = (int) row.get("id");
+                    for (int i = 1; i <= TS_COUNT; i++ ) {
+                        String timestampTest = (String) row.get("ts" + i);
+                        assertNotNull(timestampTest);
+                        assert timestampTest.matches(timestampPattern);
+                        Date found = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").parse(timestampTest);
+                        assert dataMap.size() > id;
+                        Date expected = new SimpleDateFormat("yyyy-MM-dd' 'HH:mm:ss")
+                                .parse(dataMap.get(id).get("expected").toString());
+                        assertNotNull(found);
+                        assertNotNull(expected);
+                        assertEquals("Expected " + expected + ", but got " + found, expected, found);
+                        String dateTest = (String) row.get("testDate");
+                        assert dateTest.matches(datePattern);
+                        assert dateTest.equals(DATE);
+                        String timeTest = (String) row.get("testTime");
+                        assert timeTest.matches(timePattern);
+                        assert timeTest.equals(FORMATTED_TIME);
+                    }
+                }
+            } catch (Exception e) {
+                threadFailed.set(e);
+            }
+        };
+
+        ArrayList<Thread> threads = new ArrayList<>();
+        for (int i = 0; i < PARALLEL_DATE_THREAD_COUNT; i++) {
+            Thread t = new Thread(querier);
+            threads.add(t);
+            t.start();
+        }
+
+        // Now, wait for all the threads to complete, checking that they all ran exception free.
+        Exception trapped = null;
+        for (Thread t: threads) {
+            try {
+                t.join();
+            } catch (Exception e) {
+                trapped = e;
+            }
+        }
+
+        assertNull(trapped);
+        assertNull("Trapped exception during thread processing: " + threadFailed.get(), threadFailed.get());
+
+        // Delete the row of data
+        try {
+            publishResult = jdbc.processPublish(DELETE_ROW_MANY_DATES);
+            assert publishResult > 0;
+        } catch (VantiqSQLException e) {
+            fail("Should not have thrown exception on drop.");
         }
     }
     
@@ -452,7 +608,7 @@ public class TestJDBC extends TestJDBCBase {
         jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
         
         int publishResult;
-        HashMap[] queryResult;
+        Map[] queryResult;
         
         // Create table with all supported data type values
         try {
@@ -526,12 +682,12 @@ public class TestJDBC extends TestJDBCBase {
                     assert queryResult[0].get("ts").equals(FORMATTED_TIMESTAMP);
                 }
                 if (i != 1) {
-                    assertTrue("Expected " + DATE + ", but got " + queryResult[0].get("testDate"),
-                            queryResult[0].get("testDate").equals(DATE));
+                    assertEquals("Expected " + DATE + ", but got " + queryResult[0].get("testDate"),
+                            DATE, queryResult[0].get("testDate"));
                 }
                 if (i != 2) {
-                    assertTrue("Expected " + FORMATTED_TIME + ", but got " + queryResult[0].get("testTime"),
-                         queryResult[0].get("testTime").equals(FORMATTED_TIME));
+                    assertEquals("Expected " + FORMATTED_TIME + ", but got " + queryResult[0].get("testTime"),
+                         FORMATTED_TIME, queryResult[0].get("testTime"));
                 }
                 if (i != 3) {
                     assert queryResult[0].get("testInt").toString().equals(TEST_INT);
@@ -555,12 +711,10 @@ public class TestJDBC extends TestJDBCBase {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
         assumeTrue(testDBURL.contains("mysql"));
         jdbc.setupJDBC(testDBURL, testDBUsername, testDBPassword, false, 0);
-        HashMap[] queryResult;
-        int publishResult;
-        
+
         // Check error code for selecting from non-existent table
         try {
-            queryResult = jdbc.processQuery(NO_TABLE);
+            jdbc.processQuery(NO_TABLE);
             fail("Should have thrown an exception.");
         } catch (VantiqSQLException e) {
             String message = e.getMessage();
@@ -569,7 +723,7 @@ public class TestJDBC extends TestJDBCBase {
         
         // Check error code for selecting non-existent field
         try {
-            queryResult = jdbc.processQuery(NO_FIELD);
+            jdbc.processQuery(NO_FIELD);
             fail("Should have thrown an exception.");
         } catch (VantiqSQLException e) {
             String message = e.getMessage();
@@ -578,7 +732,7 @@ public class TestJDBC extends TestJDBCBase {
         
         // Check error code for syntax error
         try {
-            queryResult = jdbc.processQuery(SYNTAX_ERROR);
+            jdbc.processQuery(SYNTAX_ERROR);
             fail("Should have thrown an exception.");
         } catch (VantiqSQLException e) {
             String message = e.getMessage();
@@ -587,7 +741,7 @@ public class TestJDBC extends TestJDBCBase {
         
         // Check error code for using INSERT with executeQuery() method
         try {
-            queryResult = jdbc.processQuery(PUBLISH_QUERY);
+            jdbc.processQuery(PUBLISH_QUERY);
             fail("Should have thrown an exception.");
         } catch (VantiqSQLException e) {
             String message = e.getMessage();
@@ -596,7 +750,7 @@ public class TestJDBC extends TestJDBCBase {
         
         // Check error code for INSERT not matching columns
         try {
-            publishResult = jdbc.processPublish(INSERT_NO_FIELD);
+            jdbc.processPublish(INSERT_NO_FIELD);
             fail("Should have thrown an exception.");
         } catch (VantiqSQLException e) {
             String message = e.getMessage();
@@ -605,13 +759,12 @@ public class TestJDBC extends TestJDBCBase {
         
         // Check error code for inserting wrong types
         try {
-            publishResult = jdbc.processPublish(INSERT_WRONG_TYPE);
+            jdbc.processPublish(INSERT_WRONG_TYPE);
             fail("Should have thrown an exception.");
         } catch (VantiqSQLException e) {
             String message = e.getMessage();
             assert message.contains("1366");
         }
-        
     }
     
     @Test
@@ -983,16 +1136,31 @@ public class TestJDBC extends TestJDBCBase {
 
     // ================================================= Helper functions =================================================
 
+    public static Map<String, Object> createManyDatesRows(int id, int rowCount) {
+        Instant inst = Instant.now().plus(id, ChronoUnit.DAYS);
+        String instString = new SimpleDateFormat("yyyy-MM-dd' 'HH:mm:ss").format(Date.from(inst));
+        LinkedHashMap<String, Object> resSet = new LinkedHashMap<>();
+        String[] insertList = new String[rowCount];
+        for (int i = 1; i <= rowCount; i++) {
+            StringBuilder result = new StringBuilder(INSERT_MANY_DATES_FRAG + id + ", '");
+            for (int j = 0; j < TS_COUNT; j++) {
+                result.append(instString).append("', '");
+            }
+            result.append(" " + DATE + "', '" + TIME + "');");
+            insertList[i -1] = result.toString();
+        }
+        resSet.put("id", id);
+        resSet.put("expected", instString);
+        resSet.put("batch", insertList);
+        return resSet;
+    }
+
     public static boolean checkSourceExists() {
         Map<String,String> where = new LinkedHashMap<String,String>();
         where.put("name", testSourceName);
         VantiqResponse response = vantiq.select("system.sources", null, where, null);
         ArrayList responseBody = (ArrayList) response.getBody();
-        if (responseBody.isEmpty()) {
-            return false;
-        } else {
-            return true;
-        }
+        return !responseBody.isEmpty();
     }
 
     public static void setupSource(Map<String,Object> sourceDef) {
@@ -1108,11 +1276,7 @@ public class TestJDBC extends TestJDBCBase {
         where.put("name", testTopicName);
         VantiqResponse response = vantiq.select("system.topics", null, where, null);
         ArrayList responseBody = (ArrayList) response.getBody();
-        if (responseBody.isEmpty()) {
-            return false;
-        } else {
-            return true;
-        }
+        return !responseBody.isEmpty();
     }
 
     public static void setupTopic() {
@@ -1133,11 +1297,7 @@ public class TestJDBC extends TestJDBCBase {
         where.put("name", testProcedureName);
         VantiqResponse response = vantiq.select("system.procedures", null, where, null);
         ArrayList responseBody = (ArrayList) response.getBody();
-        if (responseBody.isEmpty()) {
-            return false;
-        } else {
-            return true;
-        }
+        return !responseBody.isEmpty();
     }
 
     public static void setupProcedure() {

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -41,7 +41,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-@SuppressWarnings({"PMD.ExcessiveClassLength", "rawtypes"})
+@SuppressWarnings({"PMD.ExcessiveClassLength", "rawtypes", "PMD.IllegalTypeCheck"})
 public class TestJDBC extends TestJDBCBase {
     
     // Queries to be tested
@@ -601,7 +601,8 @@ public class TestJDBC extends TestJDBCBase {
         // Delete the Source from VANTIQ
         deleteSource();
     }
-    
+
+    @SuppressWarnings({"PMD.CognitiveComplexity"})
     @Test
     public void testNullValues() throws VantiqSQLException {
         assumeTrue(testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null);
@@ -1149,7 +1150,7 @@ public class TestJDBC extends TestJDBCBase {
                 result.append(instString).append("', '");
             }
             result.append(" " + DATE + "', '" + TIME + "');");
-            insertList[i -1] = result.toString();
+            insertList[i - 1] = result.toString();
         }
         resSet.put("id", id);
         resSet.put("expected", instString);


### PR DESCRIPTION
Fixes #290 

Code was using `SimpleDateFormat` in an unsafe manner.  This has been corrected.

Added new test to verify things.  Runs 150 simultaneous threads.  Ramped manually up higher, no change, but no reason to keep that in.  Failure without fix happened with only a few threads.

Did other code hygiene whilst there.
