### PR TITLE
Update log4j Version

### DIFF
--- a/CSVSource/build.gradle
+++ b/CSVSource/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     compile project(':extjsdk')
     
     compile "org.slf4j:slf4j-api:1.7.25"
-    compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.0"
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4jVersion}"
 
     // Used in tests
     testCompile "io.vantiq:vantiq-sdk:${vantiqSDKVersion}"

--- a/EasyModbusSource/build.gradle
+++ b/EasyModbusSource/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     compile project(':extjsdk')
     
     compile "org.slf4j:slf4j-api:1.7.25"
-    compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.0"
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4jVersion}"
     
     compile files("${System.env.EASY_MODBUS_LOC}/EasyModbusJava.jar")
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ ext {
     slf4jApiVersion = '1.7.25'
     eclipseMiloVersion = '0.2.1'
     vantiqSDKVersion = '1.0.31'
+    log4jVersion = '2.15.0'
 }
 
 

--- a/extjsdk/build.gradle
+++ b/extjsdk/build.gradle
@@ -73,7 +73,7 @@ artifacts {
 
 dependencies {
     compile "org.slf4j:slf4j-api:1.7.25"
-    compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.0"
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4jVersion}"
 
     compile "org.apache.commons:commons-lang3:3.12.0"
 

--- a/jdbcSource/build.gradle
+++ b/jdbcSource/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     compile project(':extjsdk')
     
     compile "org.slf4j:slf4j-api:1.7.25"
-    compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.0"
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4jVersion}"
     
     //  Compiling relevant JDBC Driver .jar file
     runtime files("${System.env.JDBC_DRIVER_LOC}")

--- a/jmsSource/build.gradle
+++ b/jmsSource/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     compile project(':extjsdk')
 
     compile "org.slf4j:slf4j-api:1.7.25"
-    compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.0"
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4jVersion}"
     
     // Used for for standard JMS utility
     compile group: 'javax.jms', name: 'javax.jms-api', version: '2.0.1'

--- a/objectRecognitionSource/build.gradle
+++ b/objectRecognitionSource/build.gradle
@@ -189,7 +189,7 @@ dependencies {
     compile project(':extjsdk')
     
     compile "org.slf4j:slf4j-api:1.7.25"
-    compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.0"
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4jVersion}"
 
     compile "org.projectlombok:lombok:${lombokVersion}"
 

--- a/opcuaSource/build.gradle
+++ b/opcuaSource/build.gradle
@@ -27,7 +27,7 @@ ext {
     commonsCliVersion = '1.4'
     bouncyCastleVersion = '1.58'
     slf4jApiVersion = '1.7.25'
-    log4jSlfImplVersion = '2.11.0'
+    log4jSlfImplVersion = '2.15.0'
 }
 
 repositories {

--- a/opcuaSource/build.gradle
+++ b/opcuaSource/build.gradle
@@ -27,7 +27,6 @@ ext {
     commonsCliVersion = '1.4'
     bouncyCastleVersion = '1.58'
     slf4jApiVersion = '1.7.25'
-    log4jSlfImplVersion = '2.15.0'
 }
 
 repositories {
@@ -42,7 +41,7 @@ dependencies {
 
     compile "org.projectlombok:lombok:${lombokVersion}"
     compile "org.slf4j:slf4j-api:${slf4jApiVersion}"
-    compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4jSlfImplVersion}"
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4jVersion}"
 
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
     compile "commons-cli:commons-cli:${commonsCliVersion}"

--- a/testConnector/build.gradle
+++ b/testConnector/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     compile project(':extjsdk')
 
     compile "org.slf4j:slf4j-api:1.7.25"
-    compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.0"
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4jVersion}"
 
     // Use JUnit test framework
     testCompile 'junit:junit:4.12'

--- a/udpSource/build.gradle
+++ b/udpSource/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     compile project(":extjsdk")
     
     compile "org.slf4j:slf4j-api:1.7.25"
-    compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.0"
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:${log4jVersion}"
     
     compile "com.fasterxml.jackson.core:jackson-databind:2.9.3"
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.9.3"	//XML parsing


### PR DESCRIPTION
Fixes #293 

Update log4j imports to release 2.15.0.  This avoids the remote execution vulnerability discovered in release 2.0+ of that code.