### PR TITLE
Move to common location to define camera URLs.

### DIFF
--- a/objectRecognitionSource/build.gradle
+++ b/objectRecognitionSource/build.gradle
@@ -213,15 +213,12 @@ dependencies {
     implementation "com.jcraft:jsch:0.1.54"
     
     // The following dependencies are used to download neural net model information (and test artifacts) used in our
-    // tests and by some customer applications.  Formerly, some of these were downloaded from the following locations,
-    //    def sampleVideoUrl = new URL("https://www.dropbox.com/s/h5yd00qr8sfgdlt/sampleVideo.mov?dl=1")
-    //    def yoloGraphUrl = new URL("https://www.dropbox.com/s/lhnygcd6o6275jb/yolo.pb?dl=1")
-    // but we have now standardized on this mechanism.  The endpoints immediately above are left here for a short
-    // period of time in the event they prove useful to someone in the short term.  They are, however, temporary,
-    // the data there may not be available for an extended period of time.
+    // tests and by some customer applications.
 
 
     testRuntimeOnly "vantiq.testArtifacts:sampleVideo:1.0@mov"
+    testRuntimeOnly "vantiq.testArtifacts:nothingVideo:1.0@mov"
+
     testRuntimeOnly "vantiq.models:coco:${currentCocoVersion}@meta"
     testRuntimeOnly "vantiq.models:coco:${currentCocoVersion}@names"
     testRuntimeOnly "vantiq.models:coco:${currentCocoVersion}@pb"
@@ -302,6 +299,7 @@ task copyOldYoloModels(type: Copy, dependsOn: [configurations.testRuntimeClasspa
 
 task copyTestResources(type: Copy, dependsOn: [configurations.testRuntimeClasspath, configurations.oldYoloNames]) {
     from configurations.testRuntimeClasspath.find { it.name == 'sampleVideo-1.0.mov' },
+        configurations.testRuntimeClasspath.find { it.name == 'nothingVideo-1.0.mov' },
         sourceSets.test.resources.asList()
 
     into "$buildDir/testResources/"

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/ObjRecTestBase.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/ObjRecTestBase.java
@@ -25,11 +25,23 @@ public class ObjRecTestBase {
     public static final String JPEG_IMAGE_LOCATION = System.getProperty("buildDir") + "/testResources/sampleImage.jpg";
     public static final String PNG_IMAGE_LOCATION = System.getProperty("buildDir") + "/testResources/sampleImage.png";
     public static final String VIDEO_LOCATION = System.getProperty("buildDir") + "/testResources/sampleVideo-1.0.mov";
+    // Used to test suppressNullValues. Finding online cameras with nothing on them is hard, so we'll
+    // simply include a video of a white wall.  This should be good enough to find nothing.
+    public static final String NOTHING_VIDEO_LOCATION =
+            System.getProperty("buildDir") + "/testResources/nothingVideo-1.0.mov";
     public static String testAuthToken = null;
     public static String testVantiqServer = null;
     public static String testSourceName = null;
     public static String testTypeName = null;
     public static String testRuleName = null;
+
+    // Few of these are truly "public services" on purpose, so they periodically drop
+    // offline & things need to be refreshed here.  We centralize these definitions to simplify things when we need to
+    // find & change them.
+
+    // Camera with some recognizable objects in it.
+    // Use camera "close to home" -- CalTrans camera close to the office...
+    public static final String IP_CAMERA_URL = "https://wzmedia.dot.ca.gov/D4/S680_at_N_Main_St.stream/playlist.m3u8";
 
     @BeforeClass
     public static void getProps() {

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestNetworkStreamRetriever.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestNetworkStreamRetriever.java
@@ -8,6 +8,7 @@ import java.net.URL;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import io.vantiq.extsrc.objectRecognition.ObjRecTestBase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,12 +16,10 @@ import org.junit.Test;
 import io.vantiq.extsrc.objectRecognition.NoSendORCore;
 import io.vantiq.extsrc.objectRecognition.exception.ImageAcquisitionException;
 
-public class TestNetworkStreamRetriever {
+public class TestNetworkStreamRetriever extends ObjRecTestBase {
     NetworkStreamRetriever retriever;
     NoSendORCore source;
     
-    static final String IP_CAMERA_URL = "http://60.45.181.202:8080/mjpg/quad/video.mjpg";
-
     @Before
     public void setup() {
         source = new NoSendORCore("src", "token", "server", "dir");

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
@@ -25,7 +25,6 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
     static final int CORE_START_TIMEOUT = 10;
     static final String OUTPUT_DIR = System.getProperty("buildDir") + "/resources/out";
     static final String SOURCE_NAME = "UnlikelyToExistTestObjectRecognitionSource";
-    static final String IP_CAMERA_ADDRESS = "http://49.229.157.154:8080/mjpg/video.mjpg";
     static final String QUERY_FILENAME = "testFile";
     static final Map<String,String> IMAGE = new LinkedHashMap<String,String>() {{
         put("filename", "objectRecognition/" + SOURCE_NAME + "/" + QUERY_FILENAME + ".jpg");
@@ -296,7 +295,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         Map<String,Object> neuralNet = new LinkedHashMap<String,Object>();
         
         // Setting up dataSource config options
-        dataSource.put("camera", IP_CAMERA_ADDRESS);
+        dataSource.put("camera", IP_CAMERA_URL);
         dataSource.put("type", "network");
         
         // Setting up general config options

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
@@ -21,7 +21,6 @@ public class TestParallelProcessing extends NeuralNetTestBase {
 
     static final String FAKE_MODEL_DIR = "";
     static final int CORE_START_TIMEOUT = 10;
-    static final String IP_CAMERA_ADDRESS = "http://49.229.157.154:8080/mjpg/video.mjpg";
 
     @BeforeClass
     public static void classSetup() {
@@ -125,7 +124,7 @@ public class TestParallelProcessing extends NeuralNetTestBase {
         }
 
         // Setting up dataSource config options
-        dataSource.put("camera", IP_CAMERA_ADDRESS);
+        dataSource.put("camera", IP_CAMERA_URL);
         dataSource.put("type", "network");
 
         // Setting up neuralNet config options

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -1737,7 +1737,6 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         try {
             // Make sure that appropriate number of entries are stored in type (this means discard policy works, and core is still alive)
             VantiqResponse response = vantiq.select(testTypeName, null, null, null);
-            Object ent = response.getBody();
             @SuppressWarnings("unchecked")
             ArrayList<JsonObject> responseBody = (ArrayList<JsonObject>) response.getBody();
 

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -85,8 +85,6 @@ public class TestYoloProcessor extends NeuralNetTestBase {
     static final int KEYBOARD_CROPPED_WIDTH = 230;
     static final int KEYBOARD_CROPPED_HEIGHT = 125;
 
-    // Used to test suppressNullValues
-    static final String NO_RECOGNIZED_OBJECTS_CAMERA_ADDRESS = "http://49.229.157.154:8080/mjpg/video.mjpg";
     static final int CORE_START_TIMEOUT = 10;
 
     static ObjectRecognitionCore core;
@@ -1725,6 +1723,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         assumeFalse(checkRuleExists(vantiq));
 
         // Setup a VANTIQ Obj Rec Source, and start running the core
+
         setupSource(createSourceDef(suppressNullValues));
 
         // Create Type to store results
@@ -1735,32 +1734,34 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
         // Wait for 15 seconds while the source polls for frames from the data source and stores data in type
         Thread.sleep(15000);
+        try {
+            // Make sure that appropriate number of entries are stored in type (this means discard policy works, and core is still alive)
+            VantiqResponse response = vantiq.select(testTypeName, null, null, null);
+            ArrayList responseBody = (ArrayList) response.getBody();
 
-        // Make sure that appropriate number of entries are stored in type (this means discard policy works, and core is still alive)
-        VantiqResponse response = vantiq.select(testTypeName, null, null, null);
-        ArrayList responseBody = (ArrayList) response.getBody();
+            // If suppressNullValues is set to true, we shouldn't have any results stored in our type
+            if (suppressNullValues) {
+                assertEquals("Get responseBody content when none expected: " + responseBody,
+                        0, responseBody.size());
+            } else {
+                System.out.println("Found response: " + responseBody);
+                // Otherwise, we should have some results and they should be empty arrays
+                assert responseBody.size() > 0;
 
-        // If suppressNullValues is set to true, we shouldn't have any results stored in our type
-        if (suppressNullValues) {
-            assertEquals("Get responseBody content when none expected: " + responseBody, 
-                    0, responseBody.size());
-        } else {
-            // Otherwise, we should have some results and they should be empty arrays
-            assert responseBody.size() > 0;
-
-            for (int i = 0; i < responseBody.size(); i++) {
-                JsonObject resultObject = (JsonObject) responseBody.get(i);
-                assert resultObject.get("results") instanceof JsonArray;
-                assertEquals("Get resultObject.results content when none expected: " + responseBody,
-                        0, ((JsonArray) resultObject.get("results")).size());
+                for (int i = 0; i < responseBody.size(); i++) {
+                    JsonObject resultObject = (JsonObject) responseBody.get(i);
+                    assert resultObject.get("results") instanceof JsonArray;
+                    assertEquals("Get resultObject.results content when none expected: " + responseBody,
+                            0, ((JsonArray) resultObject.get("results")).size());
+                }
             }
+        } finally {
+            // Delete the Source/Type/Rule from VANTIQ
+            core.close();
+            deleteSource(vantiq);
+            deleteType(vantiq);
+            deleteRule(vantiq);
         }
-
-        // Delete the Source/Type/Rule from VANTIQ
-        core.close();
-        deleteSource(vantiq);
-        deleteType(vantiq);
-        deleteRule(vantiq);
     }
 
     @Test
@@ -1983,8 +1984,11 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         general.put("suppressEmptyNeuralNetResults", suppressNullValues);
 
         // Setting up dataSource config options
-        dataSource.put("camera", NO_RECOGNIZED_OBJECTS_CAMERA_ADDRESS);
-        dataSource.put("type", "network");
+        dataSource.put("fileLocation", NOTHING_VIDEO_LOCATION);
+        dataSource.put("fileExtension", "mov");
+        dataSource.put("type", "file");
+//        dataSource.put("camera", NO_RECOGNIZED_OBJECTS_CAMERA_ADDRESS);
+//        dataSource.put("type", "network");
 
         // Setting up neuralNet config options
         neuralNet.put("type", "yolo");

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -1987,8 +1987,6 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         dataSource.put("fileLocation", NOTHING_VIDEO_LOCATION);
         dataSource.put("fileExtension", "mov");
         dataSource.put("type", "file");
-//        dataSource.put("camera", NO_RECOGNIZED_OBJECTS_CAMERA_ADDRESS);
-//        dataSource.put("type", "network");
 
         // Setting up neuralNet config options
         neuralNet.put("type", "yolo");

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -50,7 +50,6 @@ public class TestYoloQueries extends NeuralNetTestBase {
     static final String PB_FILE = "coco-" + COCO_MODEL_VERSION + ".pb";
     static final String META_FILE = "coco-" + COCO_MODEL_VERSION + ".meta";
     static final String OUTPUT_DIR = System.getProperty("buildDir") + "/resources/out";
-    static final String IP_CAMERA_ADDRESS = "http://49.229.157.154:8080/mjpg/video.mjpg";
 
     static final String IMAGE_1_DATE = "2019-02-05--02-35-10";
     static final Map<String,String> IMAGE_1 = new LinkedHashMap<String,String>() {{
@@ -955,7 +954,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         Map<String,Object> neuralNet = new LinkedHashMap<String,Object>();
         
         // Setting up dataSource config options
-        dataSource.put("camera", IP_CAMERA_ADDRESS);
+        dataSource.put("camera", IP_CAMERA_URL);
         dataSource.put("type", "network");
         
         // Setting up general config options

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueriesLocationMapper.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueriesLocationMapper.java
@@ -45,7 +45,6 @@ public class TestYoloQueriesLocationMapper extends NeuralNetTestBase {
     static final String PB_FILE = "coco-" + COCO_MODEL_VERSION + ".pb";
     static final String META_FILE = "coco-" + COCO_MODEL_VERSION + ".meta";
     static final String OUTPUT_DIR = System.getProperty("buildDir") + "/resources/out";
-    static final String IP_CAMERA_ADDRESS = "http://61.208.190.221:8001/cgi-bin/camera?resolution=640&quality=1&Language=0&1639432689";
     static final Double ACCEPTABLE_DELTA = 0.0001d;
     static final Long REQUIRED_IMAGES = 4L;
     static final int IMAGE_ATTEMPTS = 40;
@@ -227,7 +226,7 @@ public class TestYoloQueriesLocationMapper extends NeuralNetTestBase {
         Map<String,Object> neuralNet = new LinkedHashMap<String,Object>();
 
         // Setting up dataSource config options
-        dataSource.put("camera", IP_CAMERA_ADDRESS);
+        dataSource.put("camera", IP_CAMERA_URL);
         dataSource.put("type", "network");
 
         // Setting up general config options


### PR DESCRIPTION
Fixes #298 

Moved camera URL to common subclass so only one place to change.  

For or null suppression tests, use fixed "nothingVideo" (lovely video of the wall) rather that try & find
an uninterpretable online camera.  May move to this type of resolution for some other things as well -- the tests for fetching video & interpreting it should be orthogonal.