### PR TITLE
Fix error from extjsdk:fatJar task

### DIFF
--- a/extjsdk/build.gradle
+++ b/extjsdk/build.gradle
@@ -93,6 +93,7 @@ dependencies {
 task fatJar(type: Jar) {
     appendix = 'fat'
     from sourceSets.main.output
+    duplicatesStrategy 'include'
     from(".") {
         include "README.md"
         include "LICENSE/*"


### PR DESCRIPTION
Fixes #302

Add `duplicatesStrategy` to `fatJar` task.

Numerous things include META-INF/LICENSE stuff & we don't want to fail as a result...