### PR TITLE
Remove need to build Open CV to build/use the Object Rec Connector

### DIFF
--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -559,12 +559,12 @@ public class TestJDBC extends TestJDBCBase {
         setupSource(createSourceDef(false, false));
         
         // Publish to the source in order to create a table
-        Map<String,Object> createParams = new LinkedHashMap<>();
+        Map<String, Object> createParams = new LinkedHashMap<>();
         createParams.put("query", CREATE_TABLE_DATETIME);
         vantiq.publish("sources", testSourceName, createParams);
         
         // Publish to the source in order to insert data into the table
-        Map<String,Object> insertParams = new LinkedHashMap<>();
+        Map<String, Object> insertParams = new LinkedHashMap<>();
         insertParams.put("query", INSERT_VALUE_DATETIME);
         vantiq.publish("sources", testSourceName, insertParams);
         

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -559,30 +559,30 @@ public class TestJDBC extends TestJDBCBase {
         setupSource(createSourceDef(false, false));
         
         // Publish to the source in order to create a table
-        Map<String,Object> create_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> create_params = new LinkedHashMap<>();
         create_params.put("query", CREATE_TABLE_DATETIME);
         vantiq.publish("sources", testSourceName, create_params);
         
         // Publish to the source in order to insert data into the table
-        Map<String,Object> insert_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> insert_params = new LinkedHashMap<>();
         insert_params.put("query", INSERT_VALUE_DATETIME);
         vantiq.publish("sources", testSourceName, insert_params);
         
         // Query the Source, and get the returned date
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String,Object> params = new LinkedHashMap<>();
         params.put("query", QUERY_TABLE_DATETIME);
         VantiqResponse response = vantiq.query(testSourceName, params);
         JsonArray responseBody = (JsonArray) response.getBody();
         JsonObject responseMap = (JsonObject) responseBody.get(0);
-        String timestamp = (String) responseMap.get("ts").getAsString();
-        assertTrue("Expected " + FORMATTED_TIMESTAMP + ", but got " + timestamp,
-                timestamp.equals(FORMATTED_TIMESTAMP));
+        String timestamp = responseMap.get("ts").getAsString();
+        assertEquals("Expected " + FORMATTED_TIMESTAMP + ", but got " + timestamp,
+                FORMATTED_TIMESTAMP, timestamp);
 
         // Create a Type with DateTime property
         setupType();
         
         // Insert timestamp into Type
-        Map<String,String> insertObj = new LinkedHashMap<String,String>();
+        Map<String,String> insertObj = new LinkedHashMap<>();
         insertObj.put("timestamp", timestamp);
         vantiq.insert(testTypeName, insertObj);
         
@@ -590,7 +590,7 @@ public class TestJDBC extends TestJDBCBase {
         response = vantiq.select(testTypeName, null, null, null);
         ArrayList typeResponseBody = (ArrayList) response.getBody();
         responseMap = (JsonObject) typeResponseBody.get(0);
-        String vantiqTimestamp = (String) responseMap.get("timestamp").getAsString();
+        String vantiqTimestamp = responseMap.get("timestamp").getAsString();
         
         // Check that the date was offset by adding 7 hours (since original date ends in 0700)
         assert vantiqTimestamp.equals(VANTIQ_FORMATTED_TIMESTAMP);
@@ -651,14 +651,14 @@ public class TestJDBC extends TestJDBCBase {
             }
             
             // Create array of the values to be input
-            ArrayList<Object> nullValuesList = new ArrayList<Object>();
+            ArrayList<Object> nullValuesList = new ArrayList<>();
             nullValuesList.add("'" + TIMESTAMP + "'");
             nullValuesList.add("'" + DATE + "'");
             nullValuesList.add("'" + TIME + "'");
             nullValuesList.add(TEST_INT);
             nullValuesList.add("'" + TEST_STRING + "'");
             nullValuesList.add(TEST_DEC);
-            Object[] nullValues = nullValuesList.toArray(new Object[nullValuesList.size()]);
+            Object[] nullValues = nullValuesList.toArray(new Object[0]);
             
             // Make one value null
             nullValues[i] = null;
@@ -679,9 +679,7 @@ public class TestJDBC extends TestJDBCBase {
                 queryResult = jdbc.processQuery(QUERY_NULL_VALUES);
                 assert queryResult.length == 1;
                 assert queryResult[0].size() == 5;
-                if (i != 0) {
-                    assert queryResult[0].get("ts").equals(FORMATTED_TIMESTAMP);
-                }
+                assert i == 0 || queryResult[0].get("ts").equals(FORMATTED_TIMESTAMP);
                 if (i != 1) {
                     assertEquals("Expected " + DATE + ", but got " + queryResult[0].get("testDate"),
                             DATE, queryResult[0].get("testDate"));
@@ -690,15 +688,9 @@ public class TestJDBC extends TestJDBCBase {
                     assertEquals("Expected " + FORMATTED_TIME + ", but got " + queryResult[0].get("testTime"),
                          FORMATTED_TIME, queryResult[0].get("testTime"));
                 }
-                if (i != 3) {
-                    assert queryResult[0].get("testInt").toString().equals(TEST_INT);
-                }
-                if (i != 4) {
-                    assert queryResult[0].get("testString").equals(TEST_STRING);
-                }
-                if (i != 5) {
-                    assert queryResult[0].get("testDec").toString().equals(TEST_DEC);
-                }
+                assert i == 3 || queryResult[0].get("testInt").toString().equals(TEST_INT);
+                assert i == 4 || queryResult[0].get("testString").equals(TEST_STRING);
+                assert i == 5 || queryResult[0].get("testDec").toString().equals(TEST_DEC);
             } catch (Exception e) {
                 fail("No exception should be thrown when querying: " + e.getMessage());
             }
@@ -805,19 +797,19 @@ public class TestJDBC extends TestJDBCBase {
         int numRows = 2000;
 
         // Publish to the source in order to create a table
-        Map<String,Object> create_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> create_params = new LinkedHashMap<>();
         create_params.put("query", CREATE_TABLE_MAX_MESSAGE_SIZE);
         vantiq.publish("sources", testSourceName, create_params);
 
         // Insert 2000 rows into the the table
-        Map<String,Object> insert_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> insert_params = new LinkedHashMap<>();
         insert_params.put("query", INSERT_ROW_MAX_MESSAGE_SIZE);
         for (int i = 0; i < numRows; i ++) {
             vantiq.publish("sources", testSourceName, insert_params);
         }
 
         // Query the Source without bundleFactor and make sure there were no errors
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String,Object> params = new LinkedHashMap<>();
         params.put("query", QUERY_TABLE_MAX_MESSAGE_SIZE);
         VantiqResponse response = vantiq.query(testSourceName, params);
         JsonArray responseBody = (JsonArray) response.getBody();
@@ -855,7 +847,7 @@ public class TestJDBC extends TestJDBCBase {
         assert core.lastRowBundle.length == numRows % bundleFactor;
 
         // Drop table and then create it again
-        Map<String,Object> drop_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> drop_params = new LinkedHashMap<>();
         drop_params.put("query", DROP_TABLE_MAX_MESSAGE_SIZE);
         vantiq.publish("sources", testSourceName, drop_params);
         vantiq.publish("sources", testSourceName, create_params);
@@ -920,7 +912,7 @@ public class TestJDBC extends TestJDBCBase {
         setupRule();
 
         // Publish to the source in order to create a table
-        Map<String,Object> create_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> create_params = new LinkedHashMap<>();
         create_params.put("query", CREATE_TABLE_ASYNCH);
         vantiq.publish("sources", testSourceName, create_params);
 
@@ -928,8 +920,8 @@ public class TestJDBC extends TestJDBCBase {
         // Execute Procedure to trigger asynchronous publish/queries (assign to variable to ensure that procedure has finished before selecting from type)
         VantiqResponse response = vantiq.execute(testProcedureName, new LinkedHashMap<>());
 
-        // Sleep for 5 seconds to make sure all queries have finished
-        Thread.sleep(5000);
+        // Sleep for 6 seconds to allow all queries to finish
+        Thread.sleep(6000);
 
         // Select from the type and make sure all of our results are there as expected
         response = vantiq.select(testTypeName, null, null, null);
@@ -937,7 +929,7 @@ public class TestJDBC extends TestJDBCBase {
         assertEquals (500, responseBody.size());
 
         // Delete the table for next test
-        Map<String,Object> delete_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> delete_params = new LinkedHashMap<>();
         delete_params.put("query", DROP_TABLE_ASYNCH);
         vantiq.publish("sources", testSourceName, delete_params);
 
@@ -962,7 +954,7 @@ public class TestJDBC extends TestJDBCBase {
         setupSource(createSourceDef(false, false));
 
         // Create table
-        Map<String,Object> create_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> create_params = new LinkedHashMap<>();
         create_params.put("query", CREATE_TABLE_INVALID_BATCH);
         vantiq.publish("sources", testSourceName, create_params);
 
@@ -973,12 +965,12 @@ public class TestJDBC extends TestJDBCBase {
         }
 
         // Attempt to insert data into the table, which should fail
-        Map<String,Object> insert_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> insert_params = new LinkedHashMap<>();
         insert_params.put("query", invalidBatch);
         vantiq.publish("sources", testSourceName, insert_params);
 
         // Query the table and make sure it is empty
-        Map<String,Object> query_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> query_params = new LinkedHashMap<>();
         query_params.put("query", SELECT_TABLE_INVALID_BATCH);
         VantiqResponse response = vantiq.query(testSourceName, query_params);
         JsonArray responseBody = (JsonArray) response.getBody();
@@ -1015,24 +1007,24 @@ public class TestJDBC extends TestJDBCBase {
         setupSource(createSourceDef(false, false));
 
         // Create table
-        Map<String,Object> create_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> create_params = new LinkedHashMap<>();
         create_params.put("query", CREATE_TABLE_BATCH);
         vantiq.publish("sources", testSourceName, create_params);
 
         // Creating a list of strings to insert as a batch
-        ArrayList<String> batch = new ArrayList<String>();
+        ArrayList<String> batch = new ArrayList<>();
         for (int i = 0; i<50; i++) {
             batch.add(INSERT_TABLE_BATCH);
         }
 
         // Inserting data into the table as a batch
-        Map<String,Object> insert_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> insert_params = new LinkedHashMap<>();
         insert_params.put("query", batch);
         VantiqResponse response = vantiq.publish("sources", testSourceName, insert_params);
         assert !response.hasErrors();
 
         // Select the data from table and make sure the response is valid
-        Map<String,Object> query_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> query_params = new LinkedHashMap<>();
         query_params.put("query", SELECT_TABLE_BATCH);
         response = vantiq.query(testSourceName, query_params);
         JsonArray responseBody = (JsonArray) response.getBody();
@@ -1055,19 +1047,19 @@ public class TestJDBC extends TestJDBCBase {
         setupSource(createSourceDef(false, false));
 
         // Create table using query
-        Map<String,Object> create_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> create_params = new LinkedHashMap<>();
         create_params.put("query", CREATE_TABLE_QUERY);
         VantiqResponse response = vantiq.query(testSourceName, create_params);
         assert !response.hasErrors();
 
         // Inserting data into the table using query
-        Map<String,Object> insert_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> insert_params = new LinkedHashMap<>();
         insert_params.put("query", INSERT_TABLE_QUERY);
         response = vantiq.query(testSourceName, insert_params);
         assert !response.hasErrors();
 
         // Select the data from table and make sure the previous queries worked
-        Map<String,Object> query_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> query_params = new LinkedHashMap<>();
         query_params.put("query", SELECT_TABLE_QUERY);
         response = vantiq.query(testSourceName, query_params);
         JsonArray responseBody = (JsonArray) response.getBody();
@@ -1076,7 +1068,7 @@ public class TestJDBC extends TestJDBCBase {
         assert bodyObject.get("name").getAsString().equals("Name");
 
         // Delete data from table using query
-        Map<String,Object> delete_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> delete_params = new LinkedHashMap<>();
         delete_params.put("query", DELETE_ROWS_QUERY);
         response = vantiq.query(testSourceName, delete_params);
         assert !response.hasErrors();
@@ -1103,24 +1095,24 @@ public class TestJDBC extends TestJDBCBase {
         setupSource(createSourceDef(false, false));
 
         // Create table
-        Map<String,Object> create_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> create_params = new LinkedHashMap<>();
         create_params.put("query", CREATE_TABLE_BATCH_QUERY);
         vantiq.query(testSourceName, create_params);
 
         // Creating a list of strings to insert as a batch
-        ArrayList<String> batch = new ArrayList<String>();
+        ArrayList<String> batch = new ArrayList<>();
         for (int i = 0; i<50; i++) {
             batch.add(INSERT_TABLE_BATCH_QUERY);
         }
 
         // Inserting data into the table as a batch
-        Map<String,Object> insert_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> insert_params = new LinkedHashMap<>();
         insert_params.put("query", batch);
         VantiqResponse response = vantiq.query(testSourceName, insert_params);
         assert !response.hasErrors();
 
         // Select the data from table and make sure the response is valid
-        Map<String,Object> query_params = new LinkedHashMap<String,Object>();
+        Map<String,Object> query_params = new LinkedHashMap<>();
         query_params.put("query", SELECT_TABLE_BATCH_QUERY);
         response = vantiq.query(testSourceName, query_params);
         JsonArray responseBody = (JsonArray) response.getBody();
@@ -1159,7 +1151,7 @@ public class TestJDBC extends TestJDBCBase {
     }
 
     public static boolean checkSourceExists() {
-        Map<String,String> where = new LinkedHashMap<String,String>();
+        Map<String,String> where = new LinkedHashMap<>();
         where.put("name", testSourceName);
         VantiqResponse response = vantiq.select("system.sources", null, where, null);
         ArrayList responseBody = (ArrayList) response.getBody();
@@ -1168,7 +1160,7 @@ public class TestJDBC extends TestJDBCBase {
 
     public static void setupSource(Map<String,Object> sourceDef) {
 
-        Map<String,String> where = new LinkedHashMap<String,String>();
+        Map<String,String> where = new LinkedHashMap<>();
         where.put("name", "JDBC");
         VantiqResponse implResp = vantiq.select("system.sourceimpls", null, where, null);
 
@@ -1180,11 +1172,11 @@ public class TestJDBC extends TestJDBCBase {
     }
     
     public static Map<String,Object> createSourceDef(boolean isAsynch, boolean useCustomTaskConfig) {
-        Map<String,Object> sourceDef = new LinkedHashMap<String,Object>();
-        Map<String,Object> sourceConfig = new LinkedHashMap<String,Object>();
-        Map<String,Object> jdbcConfig = new LinkedHashMap<String,Object>();
-        Map<String,Object> vantiq = new LinkedHashMap<String,Object>();
-        Map<String,Object> general = new LinkedHashMap<String,Object>();
+        Map<String,Object> sourceDef = new LinkedHashMap<>();
+        Map<String,Object> sourceConfig = new LinkedHashMap<>();
+        Map<String,Object> jdbcConfig = new LinkedHashMap<>();
+        Map<String,Object> vantiq = new LinkedHashMap<>();
+        Map<String,Object> general = new LinkedHashMap<>();
         
         // Setting up vantiq config options
         vantiq.put("packageRows", "true");
@@ -1219,27 +1211,23 @@ public class TestJDBC extends TestJDBCBase {
     }
     
     public static void deleteSource() {
-        Map<String,Object> where = new LinkedHashMap<String,Object>();
+        Map<String,Object> where = new LinkedHashMap<>();
         where.put("name", testSourceName);
         VantiqResponse response = vantiq.delete("system.sources", where);
     }
 
     public static boolean checkTypeExists() {
-        Map<String,String> where = new LinkedHashMap<String,String>();
+        Map<String,String> where = new LinkedHashMap<>();
         where.put("name", testTypeName);
         VantiqResponse response = vantiq.select("system.types", null, where, null);
         ArrayList responseBody = (ArrayList) response.getBody();
-        if (responseBody.isEmpty()) {
-            return false;
-        } else {
-            return true;
-        }
+        return !responseBody.isEmpty();
     }
     
     public static void setupType() {
-        Map<String,Object> typeDef = new LinkedHashMap<String,Object>();
-        Map<String,Object> properties = new LinkedHashMap<String,Object>();
-        Map<String,Object> propertyDef = new LinkedHashMap<String,Object>();
+        Map<String,Object> typeDef = new LinkedHashMap<>();
+        Map<String,Object> properties = new LinkedHashMap<>();
+        Map<String,Object> propertyDef = new LinkedHashMap<>();
         propertyDef.put("type", "DateTime");
         propertyDef.put("required", true);
         properties.put("timestamp", propertyDef);
@@ -1249,11 +1237,11 @@ public class TestJDBC extends TestJDBCBase {
     }
 
     public static void setupAsynchType() {
-        Map<String,Object> typeDef = new LinkedHashMap<String,Object>();
-        Map<String,Object> properties = new LinkedHashMap<String,Object>();
-        Map<String,Object> id = new LinkedHashMap<String,Object>();
-        Map<String,Object> first = new LinkedHashMap<String,Object>();
-        Map<String,Object> last = new LinkedHashMap<String,Object>();
+        Map<String,Object> typeDef = new LinkedHashMap<>();
+        Map<String,Object> properties = new LinkedHashMap<>();
+        Map<String,Object> id = new LinkedHashMap<>();
+        Map<String,Object> first = new LinkedHashMap<>();
+        Map<String,Object> last = new LinkedHashMap<>();
         id.put("type", "Integer");
         id.put("required", false);
         first.put("type", "String");
@@ -1269,13 +1257,13 @@ public class TestJDBC extends TestJDBCBase {
     }
     
     public static void deleteType() {
-        Map<String,Object> where = new LinkedHashMap<String,Object>();
+        Map<String,Object> where = new LinkedHashMap<>();
         where.put("name", testTypeName);
         VantiqResponse response = vantiq.delete("system.types", where);
     }
 
     public static boolean checkTopicExists() {
-        Map<String,String> where = new LinkedHashMap<String,String>();
+        Map<String,String> where = new LinkedHashMap<>();
         where.put("name", testTopicName);
         VantiqResponse response = vantiq.select("system.topics", null, where, null);
         ArrayList responseBody = (ArrayList) response.getBody();
@@ -1283,20 +1271,20 @@ public class TestJDBC extends TestJDBCBase {
     }
 
     public static void setupTopic() {
-        Map<String,String> topicDef = new LinkedHashMap<String,String>();
+        Map<String,String> topicDef = new LinkedHashMap<>();
         topicDef.put("name", testTopicName);
         topicDef.put("description", "A description");
         vantiq.insert("system.topics", topicDef);
     }
 
     public static void deleteTopic() {
-        Map<String,Object> where = new LinkedHashMap<String,Object>();
+        Map<String,Object> where = new LinkedHashMap<>();
         where.put("name", testTopicName);
         VantiqResponse response = vantiq.delete("system.topics", where);
     }
 
     public static boolean checkProcedureExists() {
-        Map<String,String> where = new LinkedHashMap<String,String>();
+        Map<String,String> where = new LinkedHashMap<>();
         where.put("name", testProcedureName);
         VantiqResponse response = vantiq.select("system.procedures", null, where, null);
         ArrayList responseBody = (ArrayList) response.getBody();
@@ -1316,21 +1304,17 @@ public class TestJDBC extends TestJDBCBase {
     }
 
     public static void deleteProcedure() {
-        Map<String,Object> where = new LinkedHashMap<String,Object>();
+        Map<String,Object> where = new LinkedHashMap<>();
         where.put("name", testProcedureName);
         VantiqResponse response = vantiq.delete("system.procedures", where);
     }
 
     public static boolean checkRuleExists() {
-        Map<String,String> where = new LinkedHashMap<String,String>();
+        Map<String,String> where = new LinkedHashMap<>();
         where.put("name", testRuleName);
         VantiqResponse response = vantiq.select("system.rules", null, where, null);
         ArrayList responseBody = (ArrayList) response.getBody();
-        if (responseBody.isEmpty()) {
-            return false;
-        } else {
-            return true;
-        }
+        return !responseBody.isEmpty();
     }
 
     public static void setupRule() {
@@ -1355,7 +1339,7 @@ public class TestJDBC extends TestJDBCBase {
     }
 
     public static void deleteRule() {
-        Map<String,Object> where = new LinkedHashMap<String,Object>();
+        Map<String,Object> where = new LinkedHashMap<>();
         where.put("name", testRuleName);
         VantiqResponse response = vantiq.delete("system.rules", where);
     }

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -559,17 +559,17 @@ public class TestJDBC extends TestJDBCBase {
         setupSource(createSourceDef(false, false));
         
         // Publish to the source in order to create a table
-        Map<String,Object> create_params = new LinkedHashMap<>();
-        create_params.put("query", CREATE_TABLE_DATETIME);
-        vantiq.publish("sources", testSourceName, create_params);
+        Map<String,Object> createParams = new LinkedHashMap<>();
+        createParams.put("query", CREATE_TABLE_DATETIME);
+        vantiq.publish("sources", testSourceName, createParams);
         
         // Publish to the source in order to insert data into the table
-        Map<String,Object> insert_params = new LinkedHashMap<>();
-        insert_params.put("query", INSERT_VALUE_DATETIME);
-        vantiq.publish("sources", testSourceName, insert_params);
+        Map<String,Object> insertParams = new LinkedHashMap<>();
+        insertParams.put("query", INSERT_VALUE_DATETIME);
+        vantiq.publish("sources", testSourceName, insertParams);
         
         // Query the Source, and get the returned date
-        Map<String,Object> params = new LinkedHashMap<>();
+        Map<String, Object> params = new LinkedHashMap<>();
         params.put("query", QUERY_TABLE_DATETIME);
         VantiqResponse response = vantiq.query(testSourceName, params);
         JsonArray responseBody = (JsonArray) response.getBody();
@@ -582,7 +582,7 @@ public class TestJDBC extends TestJDBCBase {
         setupType();
         
         // Insert timestamp into Type
-        Map<String,String> insertObj = new LinkedHashMap<>();
+        Map<String, String> insertObj = new LinkedHashMap<>();
         insertObj.put("timestamp", timestamp);
         vantiq.insert(testTypeName, insertObj);
         
@@ -797,19 +797,19 @@ public class TestJDBC extends TestJDBCBase {
         int numRows = 2000;
 
         // Publish to the source in order to create a table
-        Map<String,Object> create_params = new LinkedHashMap<>();
-        create_params.put("query", CREATE_TABLE_MAX_MESSAGE_SIZE);
-        vantiq.publish("sources", testSourceName, create_params);
+        Map<String, Object> createParams = new LinkedHashMap<>();
+        createParams.put("query", CREATE_TABLE_MAX_MESSAGE_SIZE);
+        vantiq.publish("sources", testSourceName, createParams);
 
         // Insert 2000 rows into the the table
-        Map<String,Object> insert_params = new LinkedHashMap<>();
-        insert_params.put("query", INSERT_ROW_MAX_MESSAGE_SIZE);
+        Map<String, Object> insertParams = new LinkedHashMap<>();
+        insertParams.put("query", INSERT_ROW_MAX_MESSAGE_SIZE);
         for (int i = 0; i < numRows; i ++) {
-            vantiq.publish("sources", testSourceName, insert_params);
+            vantiq.publish("sources", testSourceName, insertParams);
         }
 
         // Query the Source without bundleFactor and make sure there were no errors
-        Map<String,Object> params = new LinkedHashMap<>();
+        Map<String, Object> params = new LinkedHashMap<>();
         params.put("query", QUERY_TABLE_MAX_MESSAGE_SIZE);
         VantiqResponse response = vantiq.query(testSourceName, params);
         JsonArray responseBody = (JsonArray) response.getBody();
@@ -847,10 +847,10 @@ public class TestJDBC extends TestJDBCBase {
         assert core.lastRowBundle.length == numRows % bundleFactor;
 
         // Drop table and then create it again
-        Map<String,Object> drop_params = new LinkedHashMap<>();
-        drop_params.put("query", DROP_TABLE_MAX_MESSAGE_SIZE);
-        vantiq.publish("sources", testSourceName, drop_params);
-        vantiq.publish("sources", testSourceName, create_params);
+        Map<String, Object> dropParams = new LinkedHashMap<>();
+        dropParams.put("query", DROP_TABLE_MAX_MESSAGE_SIZE);
+        vantiq.publish("sources", testSourceName, dropParams);
+        vantiq.publish("sources", testSourceName, createParams);
 
         // Check that lastRowBundle is null when the query returns no data
         params.remove("bundleFactor");
@@ -862,7 +862,7 @@ public class TestJDBC extends TestJDBCBase {
         // Insert fewer rows, and make sure that using bundleFactor of 0 works
         numRows = 100;
         for (int i = 0; i < numRows; i ++) {
-            vantiq.publish("sources", testSourceName, insert_params);
+            vantiq.publish("sources", testSourceName, insertParams);
         }
         params.put("bundleFactor", 0);
         response = vantiq.query(testSourceName, params);
@@ -912,9 +912,9 @@ public class TestJDBC extends TestJDBCBase {
         setupRule();
 
         // Publish to the source in order to create a table
-        Map<String,Object> create_params = new LinkedHashMap<>();
-        create_params.put("query", CREATE_TABLE_ASYNCH);
-        vantiq.publish("sources", testSourceName, create_params);
+        Map<String, Object> createParams = new LinkedHashMap<>();
+        createParams.put("query", CREATE_TABLE_ASYNCH);
+        vantiq.publish("sources", testSourceName, createParams);
 
 
         // Execute Procedure to trigger asynchronous publish/queries (assign to variable to ensure that procedure has finished before selecting from type)
@@ -929,9 +929,9 @@ public class TestJDBC extends TestJDBCBase {
         assertEquals (500, responseBody.size());
 
         // Delete the table for next test
-        Map<String,Object> delete_params = new LinkedHashMap<>();
-        delete_params.put("query", DROP_TABLE_ASYNCH);
-        vantiq.publish("sources", testSourceName, delete_params);
+        Map<String, Object> deleteParams = new LinkedHashMap<>();
+        deleteParams.put("query", DROP_TABLE_ASYNCH);
+        vantiq.publish("sources", testSourceName, deleteParams);
 
         // Delete the Source/Type/Topic/Procedure/Rule from VANTIQ
         deleteSource();
@@ -954,9 +954,9 @@ public class TestJDBC extends TestJDBCBase {
         setupSource(createSourceDef(false, false));
 
         // Create table
-        Map<String,Object> create_params = new LinkedHashMap<>();
-        create_params.put("query", CREATE_TABLE_INVALID_BATCH);
-        vantiq.publish("sources", testSourceName, create_params);
+        Map<String, Object> createParams = new LinkedHashMap<>();
+        createParams.put("query", CREATE_TABLE_INVALID_BATCH);
+        vantiq.publish("sources", testSourceName, createParams);
 
         // Creating a list of integers to insert as a batch
         ArrayList<Object> invalidBatch = new ArrayList<>();
@@ -965,14 +965,14 @@ public class TestJDBC extends TestJDBCBase {
         }
 
         // Attempt to insert data into the table, which should fail
-        Map<String,Object> insert_params = new LinkedHashMap<>();
-        insert_params.put("query", invalidBatch);
-        vantiq.publish("sources", testSourceName, insert_params);
+        Map<String, Object> insertParams = new LinkedHashMap<>();
+        insertParams.put("query", invalidBatch);
+        vantiq.publish("sources", testSourceName, insertParams);
 
         // Query the table and make sure it is empty
-        Map<String,Object> query_params = new LinkedHashMap<>();
-        query_params.put("query", SELECT_TABLE_INVALID_BATCH);
-        VantiqResponse response = vantiq.query(testSourceName, query_params);
+        Map<String, Object> queryParams = new LinkedHashMap<>();
+        queryParams.put("query", SELECT_TABLE_INVALID_BATCH);
+        VantiqResponse response = vantiq.query(testSourceName, queryParams);
         JsonArray responseBody = (JsonArray) response.getBody();
         assert responseBody.size() == 0;
 
@@ -982,11 +982,11 @@ public class TestJDBC extends TestJDBCBase {
         }
 
         // Attempt to insert data into the table, which should fail
-        insert_params.put("query", invalidBatch);
-        vantiq.publish("sources", testSourceName, insert_params);
+        insertParams.put("query", invalidBatch);
+        vantiq.publish("sources", testSourceName, insertParams);
 
         // Query the table and make sure it is empty
-        response = vantiq.query(testSourceName, query_params);
+        response = vantiq.query(testSourceName, queryParams);
         responseBody = (JsonArray) response.getBody();
         assert responseBody.size() == 0;
 
@@ -1007,9 +1007,9 @@ public class TestJDBC extends TestJDBCBase {
         setupSource(createSourceDef(false, false));
 
         // Create table
-        Map<String,Object> create_params = new LinkedHashMap<>();
-        create_params.put("query", CREATE_TABLE_BATCH);
-        vantiq.publish("sources", testSourceName, create_params);
+        Map<String, Object> createParams = new LinkedHashMap<>();
+        createParams.put("query", CREATE_TABLE_BATCH);
+        vantiq.publish("sources", testSourceName, createParams);
 
         // Creating a list of strings to insert as a batch
         ArrayList<String> batch = new ArrayList<>();
@@ -1018,15 +1018,15 @@ public class TestJDBC extends TestJDBCBase {
         }
 
         // Inserting data into the table as a batch
-        Map<String,Object> insert_params = new LinkedHashMap<>();
-        insert_params.put("query", batch);
-        VantiqResponse response = vantiq.publish("sources", testSourceName, insert_params);
+        Map<String, Object> insertParams = new LinkedHashMap<>();
+        insertParams.put("query", batch);
+        VantiqResponse response = vantiq.publish("sources", testSourceName, insertParams);
         assert !response.hasErrors();
 
         // Select the data from table and make sure the response is valid
-        Map<String,Object> query_params = new LinkedHashMap<>();
-        query_params.put("query", SELECT_TABLE_BATCH);
-        response = vantiq.query(testSourceName, query_params);
+        Map<String, Object> queryParams = new LinkedHashMap<>();
+        queryParams.put("query", SELECT_TABLE_BATCH);
+        response = vantiq.query(testSourceName, queryParams);
         JsonArray responseBody = (JsonArray) response.getBody();
         assert responseBody.size() == 50;
 
@@ -1047,34 +1047,34 @@ public class TestJDBC extends TestJDBCBase {
         setupSource(createSourceDef(false, false));
 
         // Create table using query
-        Map<String,Object> create_params = new LinkedHashMap<>();
-        create_params.put("query", CREATE_TABLE_QUERY);
-        VantiqResponse response = vantiq.query(testSourceName, create_params);
+        Map<String, Object> createParams = new LinkedHashMap<>();
+        createParams.put("query", CREATE_TABLE_QUERY);
+        VantiqResponse response = vantiq.query(testSourceName, createParams);
         assert !response.hasErrors();
 
         // Inserting data into the table using query
-        Map<String,Object> insert_params = new LinkedHashMap<>();
-        insert_params.put("query", INSERT_TABLE_QUERY);
-        response = vantiq.query(testSourceName, insert_params);
+        Map<String, Object> insertParams = new LinkedHashMap<>();
+        insertParams.put("query", INSERT_TABLE_QUERY);
+        response = vantiq.query(testSourceName, insertParams);
         assert !response.hasErrors();
 
         // Select the data from table and make sure the previous queries worked
-        Map<String,Object> query_params = new LinkedHashMap<>();
-        query_params.put("query", SELECT_TABLE_QUERY);
-        response = vantiq.query(testSourceName, query_params);
+        Map<String, Object> queryParams = new LinkedHashMap<>();
+        queryParams.put("query", SELECT_TABLE_QUERY);
+        response = vantiq.query(testSourceName, queryParams);
         JsonArray responseBody = (JsonArray) response.getBody();
         JsonObject bodyObject = responseBody.get(0).getAsJsonObject();
         assert bodyObject.get("id").getAsInt() == 1;
         assert bodyObject.get("name").getAsString().equals("Name");
 
         // Delete data from table using query
-        Map<String,Object> delete_params = new LinkedHashMap<>();
-        delete_params.put("query", DELETE_ROWS_QUERY);
-        response = vantiq.query(testSourceName, delete_params);
+        Map<String, Object> deleteParams = new LinkedHashMap<>();
+        deleteParams.put("query", DELETE_ROWS_QUERY);
+        response = vantiq.query(testSourceName, deleteParams);
         assert !response.hasErrors();
 
         // Double check that the delete worked
-        response = vantiq.query(testSourceName, query_params);
+        response = vantiq.query(testSourceName, queryParams);
         responseBody = (JsonArray) response.getBody();
         assert responseBody.size() == 0;
 
@@ -1095,9 +1095,9 @@ public class TestJDBC extends TestJDBCBase {
         setupSource(createSourceDef(false, false));
 
         // Create table
-        Map<String,Object> create_params = new LinkedHashMap<>();
-        create_params.put("query", CREATE_TABLE_BATCH_QUERY);
-        vantiq.query(testSourceName, create_params);
+        Map<String, Object> createParams = new LinkedHashMap<>();
+        createParams.put("query", CREATE_TABLE_BATCH_QUERY);
+        vantiq.query(testSourceName, createParams);
 
         // Creating a list of strings to insert as a batch
         ArrayList<String> batch = new ArrayList<>();
@@ -1106,22 +1106,22 @@ public class TestJDBC extends TestJDBCBase {
         }
 
         // Inserting data into the table as a batch
-        Map<String,Object> insert_params = new LinkedHashMap<>();
-        insert_params.put("query", batch);
-        VantiqResponse response = vantiq.query(testSourceName, insert_params);
+        Map<String, Object> insertParams = new LinkedHashMap<>();
+        insertParams.put("query", batch);
+        VantiqResponse response = vantiq.query(testSourceName, insertParams);
         assert !response.hasErrors();
 
         // Select the data from table and make sure the response is valid
-        Map<String,Object> query_params = new LinkedHashMap<>();
-        query_params.put("query", SELECT_TABLE_BATCH_QUERY);
-        response = vantiq.query(testSourceName, query_params);
+        Map<String, Object> queryParams = new LinkedHashMap<>();
+        queryParams.put("query", SELECT_TABLE_BATCH_QUERY);
+        response = vantiq.query(testSourceName, queryParams);
         JsonArray responseBody = (JsonArray) response.getBody();
         assert responseBody.size() == 50;
 
         // Adding a select statement to batch, to make sure it does not execute
         batch.add(SELECT_TABLE_BATCH_QUERY);
-        insert_params.put("query", batch);
-        response = vantiq.query(testSourceName, insert_params);
+        insertParams.put("query", batch);
+        response = vantiq.query(testSourceName, insertParams);
         assert response.hasErrors();
 
         // Delete the Source
@@ -1151,16 +1151,16 @@ public class TestJDBC extends TestJDBCBase {
     }
 
     public static boolean checkSourceExists() {
-        Map<String,String> where = new LinkedHashMap<>();
+        Map<String, String> where = new LinkedHashMap<>();
         where.put("name", testSourceName);
         VantiqResponse response = vantiq.select("system.sources", null, where, null);
         ArrayList responseBody = (ArrayList) response.getBody();
         return !responseBody.isEmpty();
     }
 
-    public static void setupSource(Map<String,Object> sourceDef) {
+    public static void setupSource(Map<String, Object> sourceDef) {
 
-        Map<String,String> where = new LinkedHashMap<>();
+        Map<String, String> where = new LinkedHashMap<>();
         where.put("name", "JDBC");
         VantiqResponse implResp = vantiq.select("system.sourceimpls", null, where, null);
 
@@ -1171,12 +1171,12 @@ public class TestJDBC extends TestJDBCBase {
         }
     }
     
-    public static Map<String,Object> createSourceDef(boolean isAsynch, boolean useCustomTaskConfig) {
-        Map<String,Object> sourceDef = new LinkedHashMap<>();
-        Map<String,Object> sourceConfig = new LinkedHashMap<>();
-        Map<String,Object> jdbcConfig = new LinkedHashMap<>();
-        Map<String,Object> vantiq = new LinkedHashMap<>();
-        Map<String,Object> general = new LinkedHashMap<>();
+    public static Map<String, Object> createSourceDef(boolean isAsynch, boolean useCustomTaskConfig) {
+        Map<String, Object> sourceDef = new LinkedHashMap<>();
+        Map<String, Object> sourceConfig = new LinkedHashMap<>();
+        Map<String, Object> jdbcConfig = new LinkedHashMap<>();
+        Map<String, Object> vantiq = new LinkedHashMap<>();
+        Map<String, Object> general = new LinkedHashMap<>();
         
         // Setting up vantiq config options
         vantiq.put("packageRows", "true");
@@ -1211,13 +1211,13 @@ public class TestJDBC extends TestJDBCBase {
     }
     
     public static void deleteSource() {
-        Map<String,Object> where = new LinkedHashMap<>();
+        Map<String, Object> where = new LinkedHashMap<>();
         where.put("name", testSourceName);
         VantiqResponse response = vantiq.delete("system.sources", where);
     }
 
     public static boolean checkTypeExists() {
-        Map<String,String> where = new LinkedHashMap<>();
+        Map<String, String> where = new LinkedHashMap<>();
         where.put("name", testTypeName);
         VantiqResponse response = vantiq.select("system.types", null, where, null);
         ArrayList responseBody = (ArrayList) response.getBody();
@@ -1225,9 +1225,9 @@ public class TestJDBC extends TestJDBCBase {
     }
     
     public static void setupType() {
-        Map<String,Object> typeDef = new LinkedHashMap<>();
-        Map<String,Object> properties = new LinkedHashMap<>();
-        Map<String,Object> propertyDef = new LinkedHashMap<>();
+        Map<String, Object> typeDef = new LinkedHashMap<>();
+        Map<String, Object> properties = new LinkedHashMap<>();
+        Map<String, Object> propertyDef = new LinkedHashMap<>();
         propertyDef.put("type", "DateTime");
         propertyDef.put("required", true);
         properties.put("timestamp", propertyDef);
@@ -1237,11 +1237,11 @@ public class TestJDBC extends TestJDBCBase {
     }
 
     public static void setupAsynchType() {
-        Map<String,Object> typeDef = new LinkedHashMap<>();
-        Map<String,Object> properties = new LinkedHashMap<>();
-        Map<String,Object> id = new LinkedHashMap<>();
-        Map<String,Object> first = new LinkedHashMap<>();
-        Map<String,Object> last = new LinkedHashMap<>();
+        Map<String, Object> typeDef = new LinkedHashMap<>();
+        Map<String, Object> properties = new LinkedHashMap<>();
+        Map<String, Object> id = new LinkedHashMap<>();
+        Map<String, Object> first = new LinkedHashMap<>();
+        Map<String, Object> last = new LinkedHashMap<>();
         id.put("type", "Integer");
         id.put("required", false);
         first.put("type", "String");
@@ -1257,13 +1257,13 @@ public class TestJDBC extends TestJDBCBase {
     }
     
     public static void deleteType() {
-        Map<String,Object> where = new LinkedHashMap<>();
+        Map<String, Object> where = new LinkedHashMap<>();
         where.put("name", testTypeName);
         VantiqResponse response = vantiq.delete("system.types", where);
     }
 
     public static boolean checkTopicExists() {
-        Map<String,String> where = new LinkedHashMap<>();
+        Map<String, String> where = new LinkedHashMap<>();
         where.put("name", testTopicName);
         VantiqResponse response = vantiq.select("system.topics", null, where, null);
         ArrayList responseBody = (ArrayList) response.getBody();
@@ -1271,20 +1271,20 @@ public class TestJDBC extends TestJDBCBase {
     }
 
     public static void setupTopic() {
-        Map<String,String> topicDef = new LinkedHashMap<>();
+        Map<String, String> topicDef = new LinkedHashMap<>();
         topicDef.put("name", testTopicName);
         topicDef.put("description", "A description");
         vantiq.insert("system.topics", topicDef);
     }
 
     public static void deleteTopic() {
-        Map<String,Object> where = new LinkedHashMap<>();
+        Map<String, Object> where = new LinkedHashMap<>();
         where.put("name", testTopicName);
         VantiqResponse response = vantiq.delete("system.topics", where);
     }
 
     public static boolean checkProcedureExists() {
-        Map<String,String> where = new LinkedHashMap<>();
+        Map<String, String> where = new LinkedHashMap<>();
         where.put("name", testProcedureName);
         VantiqResponse response = vantiq.select("system.procedures", null, where, null);
         ArrayList responseBody = (ArrayList) response.getBody();
@@ -1304,13 +1304,13 @@ public class TestJDBC extends TestJDBCBase {
     }
 
     public static void deleteProcedure() {
-        Map<String,Object> where = new LinkedHashMap<>();
+        Map<String, Object> where = new LinkedHashMap<>();
         where.put("name", testProcedureName);
         VantiqResponse response = vantiq.delete("system.procedures", where);
     }
 
     public static boolean checkRuleExists() {
-        Map<String,String> where = new LinkedHashMap<>();
+        Map<String, String> where = new LinkedHashMap<>();
         where.put("name", testRuleName);
         VantiqResponse response = vantiq.select("system.rules", null, where, null);
         ArrayList responseBody = (ArrayList) response.getBody();
@@ -1339,7 +1339,7 @@ public class TestJDBC extends TestJDBCBase {
     }
 
     public static void deleteRule() {
-        Map<String,Object> where = new LinkedHashMap<>();
+        Map<String, Object> where = new LinkedHashMap<>();
         where.put("name", testRuleName);
         VantiqResponse response = vantiq.delete("system.rules", where);
     }

--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -50,94 +50,16 @@ Additionally, an example VANTIQ project named *objRecExample.zip* can be found i
     *   [FtpRetriever](#ftpRet) -- Retrieves images through FTP, FTPS, and SFTP.
 
 ## How to Run the Program<a name="objRecMain" id="objRecMain"></a>
-
-### Building OpenCV <a name="building-opencv" id="building-openv"></a>
-
-The [official site](https://opencv.org/releases/) and [the somewhat dated tutorial](https://opencv-java-tutorials.readthedocs.io/en/latest/01-installing-opencv-for-java.html) describe how to install it. These are, we believe, sufficient in Windows and Linux environments.
-
-#### Building OpenCV for macOS
-
-Installation on macOS<sup>&reg;</sup> is a bit more complicated. The easiest way is to use [Homebrew](https://brew.sh). _Homebrew_ is a package manager for macOS.  It is also available for Linux.
-
-Once _Homebrew_ is installed, you can read the instructions in [this only slightly dated tutorial](https://medium.com/macoclock/setting-up-mac-for-opencv-java-development-with-intellij-idea-fd2153eb634f) for background information. However, recent changes in _Homebrew_ have made some changes necessary.
-
-Specfically, current versions of _Homebrew_ need a bit more information about the Java environment to build the Java code for OpenCV. If this information is not provided, the installation of OpenCV appears to succeed, but the Java implemenation is not available. No errors are apparent. 
-
-As a result, the following steps are necessary to install OpenCV with Java support on macOS. The following are expected to be run from the Terminal application.
-
-1. If not already installed, install _Homebrew_ (see the [installation instructions](https://brew.sh).) The _Homebrew_ command is `brew`, so you will see its use below.
-2. If not already installed, install _Ant_ (used by the build process).
-    * `brew install ant`
-    * Set the ANT_HOME environment variable to the installation location.  Due to some issues with the current versions of the _Ant_ installation, you may need to to set ANT_HOME to `/usr/local/Cellar/ant/1.10.11/libexec` where _1.10.11_ is the version of _Ant_ installed.
-3. If not already installed, install the XCode command-line tools.
-    * `xcode-select --install`
-4. Prepare to use `brew` to install OpenCV. To do this, you will configure the OpenCV installation to include the Java libraries.  This is done by editing the `brew` _formula_ (the instructions `brew` uses to do the installation).
-    * `brew edit opencv`
-    * In the text editor that opens, make the following changes.
-        * All of these are added to the build arguments, after the line beginning with `args = std_cmake_args`.
-        * Find the line `-DBUILD_JAVA=OFF` and change it to `-DBUILD_JAVA=ON`
-            * If this line is not in your formula, please add it.
-        * Find the line `-DBUILD_opencv_java=OFF` and change it to `-DBUILD_opencv_java=ON`
-            * If this line is not in your formula, please add it.
-        * Below this line, add the following lines
-        
-        ```
-            -DJAVA_INCLUDE_PATH=<JAVA_HOME>/include
-            -DJAVA_INCLUDE_PATH2=<JAVA_HOME>/include/darwin
-            -DJAVA_AWT_INCLUDE_PATH=<JAVA_HOME>/include
-            -DOPENCV_JAVA_TARGET_VERSION=<Java runtime version>
-        ```
-        * In these additions,
-            * Replace `<JAVA_HOME>` with the value of your `JAVA_HOME` environment variable, and
-            * Replace  `<Java runtime version>` with the version of the Java runtime you use (_e.g._, 1.8).
-            * For example, on this developer's machine, these lines are as follows:
-
-            ```
-            -DJAVA_INCLUDE_PATH=/Library/Java/JavaVirtualMachines/jdk1.8.0_192.jdk/Contents/Home/include
-            -DJAVA_INCLUDE_PATH2=/Library/Java/JavaVirtualMachines/jdk1.8.0_192.jdk/Contents/Home/include/darwin
-            -DJAVA_AWT_INCLUDE_PATH=/Library/Java/JavaVirtualMachines/jdk1.8.0_192.jdk/Contents/Home/include
-            -DOPENCV_JAVA_TARGET_VERSION=1.8
-            ```
-            but your system may be different.
-            
-            * Note that these are defined as 
-                * `JAVA_INCLUDE_PATH`: the include path to `jni.h`
-                * `JAVA_INCLUDE_PATH2`: the include path to `jni_md.h`
-                * `JAVA_AWT_INCLUDE_PATH`: the include path to `jawt.h`
-            * If these files are not found where indicated, the Java code will not be built (but you will not be notified).
-        * Once these changes are complete, save the file and exit the editor.
-5. Run the build.
-    * `brew install --build-from-source opencv`
-        * Depending upon your machine and environment, this build can take a few minutes to close to an hour. This command will download the source code & compile it.
-    * At the end, you should see no errors.  You can check that everything built correctly by looking at the folder/directory `/usr/local/opt/opencv/share/java/opencv4`.  This directory should exist, and contain one `.jar` file and one `.dylib` file. You can also look at  `/usr/local/Cellar/opencv/<opencv version>/share/java/opencv4/`, where `<opencv version>` is a representation of version of OpenCV installed. (On this developer's machine at the time of this writing, the current version is 4.5.3_2). The former directory is easier to find -- it is symlinked to the latter.
-        * If these directories do not exist or don't contain the expected files, your build did not build required Java files.  Check your edits to the formula.
-        * Note that if you need to rebuild, you will need to `brew uninstall opencv` before doing the install again.
-6. Set the environment variable OPENCV_LOC to the directory containing the OpenCV Java files.
-
-    * (using bash) `export OPENCV_LOC=/usr/local/opt/opencv/share/java/opencv4`
-    * (using csh) `setenv OPENCV_LOC /usr/local/opt/opencv/share/java/opencv4`
-
-Once these have completed, you have successfully installed OpenCV, and it is ready to use to build the Object Recognition Connector.
-            
+ 
  
 ### Building the ObjectRecognitionConnector
 
-1.  If you intend to use any of the implementations that require OpenCV, you must install OpenCV version 4 (any version 4 should be fine) for
-Java.  See the [Building OpenCV](#building-opencv) section. Once it's installed, copy 
-the jar and (lib)opencv_java410.dll/.so/.dylib to a single folder, then set the environment variable OPENCV_LOC to that 
-folder. Some features may depend on additional .dll/.so/.dylib files, such as FFmpeg for IP cameras.
-    *   **NOTE:** If you are using a Windows or Linux machine, you may need to add the `opencv_ffmpeg410_64.dll` or 
-    `opencv_ffmpeg410_64.so` file, respectively, to the OPENCV_LOC folder. This file is located in the same directory as the 
-    other OpenCV .jar/.dll/.so/.dylib files. (Use `opencv_ffmpeg410.dll` or `opencv_ffmpeg410.so` for 32 bit version.)
-        *   A typical indicator that you will need to add this file is if OpenCV cannot open video streams/files.
-        * Note that the version numbers (_e.g._, `410`) on these libraries will vary based on the versions installed.
-    *   The implementations dependent on OpenCV are FileRetriever, NetworkStreamRetriever, and CameraRetriever.
-2.  Clone this repository (vantiq-extension-sources) and navigate into `<repo location>/vantiq-extension-sources`.
-3.  Run `./gradlew objectRecognitionSource:assemble`.
-4.  Navigate to `<repo location>/vantiq-extension-sources/objectRecognitionSource/build/distributions`. The zip and tar
+1.  Clone this repository (vantiq-extension-sources) and navigate into `<repo location>/vantiq-extension-sources`.
+2.  Run `./gradlew objectRecognitionSource:assemble`.
+3.  Navigate to `<repo location>/vantiq-extension-sources/objectRecognitionSource/build/distributions`. The zip and tar
     files both contain the same files, so choose whichever you prefer.
-5.  Uncompress the file in the location that you would like to install the program.
-6.  Run `<install location>/objectRecognitionSource/bin/objectRecognitionSource` with a local server.config file or
+4.  Uncompress the file in the location that you would like to install the program.
+5.  Run `<install location>/objectRecognitionSource/bin/objectRecognitionSource` with a local server.config file or
 specifying the [server config file](#serverConfig) as the first argument. Note that the `server.config` file can be placed in the `<install location>/objectRecognitionSource/serverConfig/server.config` or `<install location>/objectRecognitionSource/server.config` locations.
 
 ## Logging
@@ -175,13 +97,7 @@ sources inside your own code, then it is what you will use.
 1.  Clone this repository (vantiq-extension-sources) and navigate into `<repo location>/vantiq-extension-sources`.
     *   If you know that you will not use specific classes in the *.neuralNet or *.imageRetriever packages you can
         remove them now.
-    *   FileRetriever, NetworkStreamRetriever, and CameraRetriever all use OpenCV, which is not in the gradle
-        dependencies. If they are not removed you must install OpenCV, set the environment variable
-        OPENCV_LOC to the folder containing the jar, and ensure that when running your code the jar is in the classpath
-        and (lib)opencv_javaXXX.dll/.so/.dylib is in a folder in `java.library.path` (where XXX is replaced by the version of OpenCV you've installed -- _e.g._, 453, 410, _etc_). You may see a warning about not 
-        having (lib)opencv_javaXXX.dll/.so/.dylib in the correct directory when compiling the objectRecognition jar,
-        but this can be safely ignored since you will be setting the path yourself. Instructions for installing
-        OpenCV can be found at the [official site](https://opencv.org/releases/). Please see [Building OpenCV](#building-opencv) for instructions on generating these libraries.
+    *   FileRetriever, NetworkStreamRetriever, and CameraRetriever.
 2.  Run `./gradlew objectRecognitionSource:assemble` or `.\gradlew objectRecognitionSource:assemble` depending on the
     OS.
 3.  Navigate to `<repo location>/vantiq-extension-sources/objectRecognitionSource/build/libs` and copy
@@ -190,8 +106,8 @@ sources inside your own code, then it is what you will use.
     your project.
     *   The gradle build file specifies every dependency that is used only in neural net or image retriever
         implementations. If you removed any classes in step 1, use the comments to identify which dependencies are
-        no longer needed. OpenCV is automatically ignored if all its dependents are removed, so it can be ignored.
-
+        no longer needed.
+        
 ### Using in Your Own Code
 
 The ObjectRecognitionCore class has four public functions. The constructor takes in the same arguments passed through
@@ -794,7 +710,7 @@ before running `./gradlew assemble` or by inserting the class as a jar into
 
 ### Camera Retriever<a name="camRet" id="camRet"></a>
 
-This implementation uses OpenCV to capture images from a camera connected directly to a computer. An error is thrown
+This implementation uses JavaCV/OpenCV to capture images from a camera connected directly to a computer. An error is thrown
 whenever an image cannot be read successfully. Fatal errors are thrown only when the camera is inaccessible in non-Query
 mode.  
 
@@ -807,7 +723,7 @@ The timestamp is captured immediately before the image is grabbed from the camer
     
 ### Network Stream Retriever<a name="netRet" id="netRet"></a>
 
-This implementation uses OpenCV to capture live frames from a camera connected to a network address. Errors are thrown
+This implementation uses JavaCV/OpenCV to capture live frames from a camera connected to a network address. Errors are thrown
 whenever an image cannot be read successfully, whenever the provided URL uses an unsupported protocol, whenever the URL
 was unable to be opened, or whenever the URL does not represent a video stream. Fatal errors are thrown only when the
 camera is inaccessible in non-Query mode, (i.e. if the video stream has ended).  
@@ -826,7 +742,7 @@ The timestamp is captured immediately before the image is grabbed from the camer
 
 ### File Retriever<a name="fileRet" id="fileRet"></a>
 
-This implementation reads files from the disk using OpenCV for the videos. `fileLocation` must be a valid file at
+This implementation reads files from the disk using JavaCV/OpenCV for the videos. `fileLocation` must be a valid file at
 initialization. The initial image file can be replaced while the source is running, but the video cannot. For Queries,
 new files can be specified using the `fileLocation` and `fileExtension` options, and defaults to the initial file
 if `fileLocation` is not set. Queried videos can specify which frame of the video to access using the `targetFrame`
@@ -1058,7 +974,7 @@ into the `CLASSPATH` variable found in `<install location>/objectRecognitionSour
 and `<install location>/objectRecognitionSource/bin/objectRecognitionSource.bat` and remove the `libtensorflow*` files
 in `<install location>/objectRecognitionSource/lib`.  
 
-OpenCV will also display errors that look like `warning: Error opening file
+JavaCV/OpenCV will also display errors that look like `warning: Error opening file
 (/build/opencv/modules/videoio/src/cap_ffmpeg_impl.hpp:856)` and `warning: invalidLocation
 (/build/opencv/modules/videoio/src/cap_ffmpeg_impl.hpp:857)`. These are expected, as the tests need to ensure correct
 behavior when the file cannot be found.
@@ -1084,7 +1000,10 @@ are documented, and most if not all are in ObjectDetector and IOUtil.
 
 JSch is licensed under a [BSD-style license](http://www.jcraft.com/jsch/LICENSE.txt).
 
-OpenCV is licensed under the [BSD 3-clause license](https://opencv.org/license.html) or the [Apache Version 2.0 License](http://www.apache.org/licenses/LICENSE-2.0), depending upon the version of OpenCV you've installed. OpenCV typically uses third party
+JavaCV is licensed under the [Apache Version 2.0 License](http://www.apache.org/licenses/LICENSE-2.0) with Classpath Exceptions. Alternatively, it can be licensed under the [GNU General Public License (GPLv2), version 2 or better](https://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+JavaCV incorporates OpenCV.
+
+OpenCV is licensed under the [BSD 3-clause license](https://opencv.org/license.html) or the [Apache Version 2.0 License](http://www.apache.org/licenses/LICENSE-2.0), depending upon the version of OpenCV included. OpenCV may use third party
 components that may have stricter licenses and other licenses in this project. It is the responsibility of the
 user of this library to ensure that they meet all licensing requirements of components in or used by their OpenCV build.
 

--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -814,8 +814,11 @@ camera is inaccessible in non-Query mode, (i.e. if the video stream has ended).
 
 The options are as follows. Remember to prepend "DS" when using an option in a Query.
 
-*   camera: Required for Config, optional for Query. The URL of the camera to read images from. For queries, defaults
+* camera: Required for Config, optional for Query. The URL of the camera to read images from. For queries, defaults
     to the camera specified in the Config.
+* rtspConfig:
+    * rtsp_transport: Protocol to use for lower rtsp transport.  This is ignored if the scheme for the camera is
+neither`rtsp` or `rtsps`. Default is `tcp`.
 
 The timestamp is captured immediately before the image is grabbed from the camera. The additional data is:
 

--- a/objectRecognitionSource/build.gradle
+++ b/objectRecognitionSource/build.gradle
@@ -70,8 +70,6 @@ applicationDistribution.from("src/main/resources") {
 
 test {
     // set heap size for the test JVM(s)
-    // Java CV seems to impart more memory requirements for getting the same test results
-    // with gradle that we do with the IDE (even though the IDE is running tests via gradle).
     minHeapSize = "2048m"
     maxHeapSize = "2048m"
 }
@@ -187,8 +185,7 @@ task copyModels(type: Copy, dependsOn: [configurations.testRuntimeClasspath, con
 
 task copyOldCocoModels(type: Copy, dependsOn: [configurations.testRuntimeClasspath, configurations.oldYoloNames]) {
     from configurations.oldYoloNames.find { it.name == 'coco-1.0.pb' },
-        configurations.oldYoloNames.find { it.name == 'coco-1.0.names' }
-        
+         configurations.oldYoloNames.find { it.name == 'coco-1.0.names' }
 
     into "$buildDir/models/"
 }
@@ -196,7 +193,7 @@ task copyOldCocoModels(type: Copy, dependsOn: [configurations.testRuntimeClasspa
 
 task copyOldYoloModels(type: Copy, dependsOn: [configurations.testRuntimeClasspath, configurations.oldYoloNames]) {
     from configurations.oldYoloNames.find { it.name == 'yolo-1.0.pb' },
-        configurations.oldYoloNames.find { it.name == 'coco-1.0.names' }
+         configurations.oldYoloNames.find { it.name == 'coco-1.0.names' }
 
     rename { filename ->
         if (filename.contains("-1.0")) {
@@ -212,7 +209,7 @@ task copyOldYoloModels(type: Copy, dependsOn: [configurations.testRuntimeClasspa
 task copyTestResources(type: Copy, dependsOn: [configurations.testRuntimeClasspath, configurations.oldYoloNames]) {
     from configurations.testRuntimeClasspath.find { it.name == 'sampleVideo-1.0.mov' },
          configurations.testRuntimeClasspath.find { it.name == 'nothingVideo-1.0.mov' },
-        sourceSets.test.resources.asList()
+         sourceSets.test.resources.asList()
 
     into "$buildDir/testResources/"
 }

--- a/objectRecognitionSource/build.gradle
+++ b/objectRecognitionSource/build.gradle
@@ -20,19 +20,6 @@ repositories {
 
 mainClassName = 'io.vantiq.extsrc.objectRecognition.ObjectRecognitionMain'
 
-// Used to check if OpenCV is needed, and compile with OpenCV or throw errors if needed
-// Should be "**/<source file name>.java" for every file that need openCV to run
-def opencvDependentSourceFilePatterns = new ArrayList<String>(
-    [
-        "**/CameraRetriever.java",
-        "**/FileRetriever.java",
-        "**/NetworkStreamRetriever.java"
-    ]
-)
-def opencvDependentFiles = sourceSets.main.java.matching(
-        { delegate.setIncludes(opencvDependentSourceFilePatterns) }
-)
-
 // Used to automatically ignore tests for implementations that have been removed.
 // The tests should be called "Test<source file name>.java"
 // And should be included in the list as "**/Test<source file name>.java"
@@ -46,24 +33,7 @@ def standardImplementationTestPatterns = new ArrayList<String>(
     ]
 )
 
-// This is the version of OpenCV that you will be using. Should be "XYZ" for version X.Y.Z
-
-def opencvVersion = "410"   // Default value.  We'll use the OPENCV_LOC env. variable to find the version present.
-
-if (System.env.OPENCV_LOC != null ) {
-    def ocv = new File(System.env.OPENCV_LOC)
-    ocv.eachFile { fname ->
-        if (fname.name.startsWith("opencv-") && fname.name.endsWith(".jar")) {
-            opencvVersion = fname.name.substring("opencv-".length(), fname.name.lastIndexOf(".jar"))
-            logger.warn("Detected OpenCV Version ${opencvVersion}")
-        }
-    }
-} else {
-    logger.warn("No OPENCV Located via OPENCV_LOC env. variable.  Defaulting to OpenCV Version ${opencvVersion}")
-}
 // Add the logConfig folder to the classpath so that changes to logConfig/log4j2.xml will be used for logging
-// and set java.library.path to the contents of the environment variable OPENCV_LOC so the OpenCV native libraries are
-// usable 
 startScripts{
     doLast{
         def windowsScriptFile = file getWindowsScript()
@@ -71,14 +41,6 @@ startScripts{
         // Add the log Config to the top of the classpath
         windowsScriptFile.text = windowsScriptFile.text.replace("CLASSPATH=", "CLASSPATH=%APP_HOME%\\logConfig;")
         unixScriptFile.text = unixScriptFile.text.replace('CLASSPATH=', 'CLASSPATH=$APP_HOME/logConfig:')
-        
-        if (!opencvDependentFiles.getFiles().isEmpty()) { // Only set java.library.path for OpenCV if we need it
-            // Set the path to the location of the native libraries
-            windowsScriptFile.text = windowsScriptFile.text.replace('DEFAULT_JVM_OPTS=',
-                    'DEFAULT_JVM_OPTS=-Djava.library.path=%OPENCV_LOC%;%TENSORFLOW_JNI%')
-            unixScriptFile.text = unixScriptFile.text.replace('DEFAULT_JVM_OPTS=',
-                    'DEFAULT_JVM_OPTS=-Djava.library.path=$OPENCV_LOC:$TENSORFLOW_JNI')
-        }
     }
 }
 
@@ -100,52 +62,24 @@ applicationDistribution.from("src/main/resources") {
 
 test {
     // set heap size for the test JVM(s)
+    // Java CV seems to impart more memory requirements for getting the same test results
+    // with gradle that we do with the IDE (even though the IDE is running tests via gradle).
     minHeapSize = "2048m"
     maxHeapSize = "2048m"
 }
 
 tasks.withType(Test) {
-    def os = org.gradle.internal.os.OperatingSystem.current()
-    if (os.isWindows()) {
-        systemProperty "java.library.path", "${System.env.OPENCV_LOC};${System.env.TENSORFLOW_JNI}"
-    } else {
-        systemProperty "java.library.path", "${System.env.OPENCV_LOC}:${System.env.TENSORFLOW_JNI}"
-    }
     if (rootProject.hasProperty("TestAuthToken")) {
+        println('Setting TestAuthToken')
         systemProperty "TestAuthToken", rootProject.findProperty("TestAuthToken") ?: "empty"
     }
     if (rootProject.hasProperty("TestVantiqServer")) {
+        println('Setting TestVantiqServer')
+
         systemProperty "TestVantiqServer", rootProject.findProperty("TestVantiqServer") ?: "empty"
     }
     // Use the build dir as a base to get our various test artifacts.
     systemProperty "buildDir", "${buildDir}"
-}
-
-// Logs a warning if the .dll/.so/.dylib cannot be found for OpenCV when OpenCV is needed
-assemble.doLast {
-    def os = org.gradle.internal.os.OperatingSystem.current()
-    // Only need to warn about missing libraries if there are files dependent on OpenCV
-    if (!opencvDependentFiles.getFiles().isEmpty()) {
-        if (os.isWindows()) {
-            if (!file("${System.env.OPENCV_LOC}\\opencv_java${opencvVersion}.dll").exists()) {
-                logger.warn("Cannot find opencv_java${opencvVersion}.dll in '${System.env.OPENCV_LOC}'. Ensure that the requested "
-                    + "file exists at the folder specified in the environment variable OPENCV_LOC")
-            }
-        } else if (os.isLinux()) {
-            if (!file("${System.env.OPENCV_LOC}/libopencv_java${opencvVersion}.so").exists()) {
-                logger.warn("Cannot find libopencv_java${opencvVersion}.so in '${System.env.OPENCV_LOC}'. Ensure that the requested "
-                    + "file exists at the folder specified in the environment variable OPENCV_LOC")
-            }
-        } else if (os.isMacOsX()) {
-            if (!file("${System.env.OPENCV_LOC}/libopencv_java${opencvVersion}.dylib").exists()) {
-                logger.warn("Cannot find libopencv_java${opencvVersion}.dylib in '${System.env.OPENCV_LOC}/'. Ensure that the "
-                    + "requested file exists at the folder specified in the environment variable OPENCV_LOC")
-            }
-        } else {
-            logger.warn("Compiling unknown file system. Please ensure that the compiled OpenCV C++ library is inside " 
-                + "'${System.env.OPENCV_LOC}' so that the program can function correctly")
-        }
-    }
 }
 
 compileJava.doFirst {
@@ -181,8 +115,9 @@ configurations {
 }
 
 ext {
-    currentCocoVersion = 1.2
-    lombokVersion = "1.16.18"
+    currentCocoVersion = '1.2'
+    lombokVersion = '1.16.18'
+    javaCvVersion = '1.5.6'
 }
 
 dependencies {
@@ -225,28 +160,8 @@ dependencies {
     metaTest "vantiq.models:coco:1.1@meta"
     metaTest "vantiq.models:coco:1.1@pb"
 
-
-    // This imports OpenCV if it is needed, and throws an error if OpenCV is needed but not properly setup
-    // The opencv
-    if (!opencvDependentFiles.getFiles().isEmpty()) { // Only look for OpenCV if we need it
-        if (System.env.OPENCV_LOC == null ) { // Fail out if OpenCV is not available 
-            // Setting depFileNames to the files still dependent on OpenCV
-            def depFileNames = "'"
-            opencvDependentFiles.getFiles().forEach {file -> depFileNames += file.getName() + "', '"}
-            depFileNames = depFileNames.substring(0, depFileNames.length() - 3) // Remove the last ", '"
-            throw new Exception("Environment variable 'OPENCV_LOC' is not set. Either set it to a location containing " + 
-            "opencv-${opencvVersion}.jar and the compiled OpenCV library, or remove the following files: ${depFileNames}")
-        } else if (!file("${System.env.OPENCV_LOC}/opencv-${opencvVersion}.jar").exists()) { // Fail out if the OpenCV jar is missing
-            // Setting depFileNames to the files still dependent on OpenCV
-            def depFileNames = "'"
-            opencvDependentFiles.getFiles().forEach {file -> depFileNames += file.getName() + "', '"}
-            depFileNames = depFileNames.substring(0, depFileNames.length() - 3) // Remove the last ", '"
-            throw new Exception("Could not find opencv-${opencvVersion}.jar in '${System.env.OPENCV_LOC}'. Either add the jar to the "
-                + "folder specified in the environment variable OPENCV_LOC or remove the following files: ${depFileNames}")
-        } else {
-            compile files("${System.env.OPENCV_LOC}/opencv-${opencvVersion}.jar")
-        }
-    }
+    // The following imports the Java OpenCV API * jar files representing the various JNI libraries (by platform)
+    compile "org.bytedeco:javacv-platform:${javaCvVersion}"
     
     // Used for uploading documents (images) to VANTIQ with VANTIQ SDK
     compile "io.vantiq:vantiq-sdk:${vantiqSDKVersion}"

--- a/objectRecognitionSource/build.gradle
+++ b/objectRecognitionSource/build.gradle
@@ -78,12 +78,9 @@ test {
 
 tasks.withType(Test) {
     if (rootProject.hasProperty("TestAuthToken")) {
-        println('Setting TestAuthToken')
         systemProperty "TestAuthToken", rootProject.findProperty("TestAuthToken") ?: "empty"
     }
     if (rootProject.hasProperty("TestVantiqServer")) {
-        println('Setting TestVantiqServer')
-
         systemProperty "TestVantiqServer", rootProject.findProperty("TestVantiqServer") ?: "empty"
     }
     // Use the build dir as a base to get our various test artifacts.

--- a/objectRecognitionSource/build.gradle
+++ b/objectRecognitionSource/build.gradle
@@ -214,7 +214,7 @@ task copyOldYoloModels(type: Copy, dependsOn: [configurations.testRuntimeClasspa
 
 task copyTestResources(type: Copy, dependsOn: [configurations.testRuntimeClasspath, configurations.oldYoloNames]) {
     from configurations.testRuntimeClasspath.find { it.name == 'sampleVideo-1.0.mov' },
-        configurations.testRuntimeClasspath.find { it.name == 'nothingVideo-1.0.mov' },
+         configurations.testRuntimeClasspath.find { it.name == 'nothingVideo-1.0.mov' },
         sourceSets.test.resources.asList()
 
     into "$buildDir/testResources/"

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -65,7 +65,7 @@ import io.vantiq.extsrc.objectRecognition.neuralNet.NeuralNetInterface;
  * CameraRetriever, {@code ftp} for FtpRetriever, and {@code network} for NetworkStreamRetriever for the dataSource
  * config; and {@code yolo} for YoloProcessor for the neuralNet config.
  */
-@SuppressWarnings({"WeakerAccess"})
+@SuppressWarnings({"WeakerAccess", "PMD.TooManyFields"})
 public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMessage> {
     
     Logger                  log;
@@ -521,6 +521,7 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
      * @param general   The general portion of the configuration document
      * @return          true if the communication method could be setup, false otherwise
      */
+    @SuppressWarnings({"PMD.CognitiveComplexity"})
     private boolean prepareCommunication(Map<String, ?> general) {
         int polling = -1; // initializing to an invalid input
         boolean queryable = false;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -517,7 +517,7 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
 
 
     /**
-     * Sets up the the communication method, one of timed notifications, continuous notifications, or Query responses
+     * Sets up the communication method, one of timed notifications, continuous notifications, or Query responses
      * @param general   The general portion of the configuration document
      * @return          true if the communication method could be setup, false otherwise
      */

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -528,7 +528,8 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
         int maxQueuedTasks = MAX_QUEUED_TASKS_DEFAULT;
 
         // First, we'll check the suppressNullValues option
-        if (general.get(SUPPRESS_EMPTY_NEURAL_NET_RESULTS) instanceof Boolean && (Boolean) general.get(SUPPRESS_EMPTY_NEURAL_NET_RESULTS)) {
+        if (general.get(SUPPRESS_EMPTY_NEURAL_NET_RESULTS) instanceof Boolean
+                && (Boolean) general.get(SUPPRESS_EMPTY_NEURAL_NET_RESULTS)) {
             source.suppressEmptyNeuralNetResults = (Boolean) general.get(SUPPRESS_EMPTY_NEURAL_NET_RESULTS);
         }
 

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -49,6 +49,7 @@ import io.vantiq.extsrc.objectRecognition.query.DateRangeFilter;
  * itself. start() will return a boolean describing whether or not it succeeded, and will wait up to 10 seconds if
  * necessary.
  */
+@SuppressWarnings({"PMD.TooManyFields"})
 public class ObjectRecognitionCore {
     String sourceName;
     String authToken;
@@ -306,6 +307,7 @@ public class ObjectRecognitionCore {
      * FatalImageException is received.
      * @param imageResults An {@link ImageRetrieverResults} containing the image to be translated
      */
+    @SuppressWarnings({"PMD.CognitiveComplexity"})
     public void sendDataFromImage(ImageRetrieverResults imageResults) {
         
         if (imageResults == null) {
@@ -340,8 +342,10 @@ public class ObjectRecognitionCore {
             if (!localNeuralNet.getClass().toString().contains("NoProcessor")) {
                 // Translate the results from the neural net and image into a message to send back 
                 Map message = createMapFromResults(imageResults, results);
-                log.debug("Message from results: {}", message.get("results"));
-                log.debug("Suppress value: {}", suppressEmptyNeuralNetResults);
+                if (log.isDebugEnabled()) {
+                    log.debug("Message from results: {}", message.get("results"));
+                    log.debug("Suppress value: {}", suppressEmptyNeuralNetResults);
+                }
 
                 // If suppressNullValues is set to true, then skip sending message results list is empty
                 if (suppressEmptyNeuralNetResults) {
@@ -360,9 +364,11 @@ public class ObjectRecognitionCore {
         } catch (ImageProcessingException e) {
             log.warn("Could not process image", e);
         } catch (FatalImageException e) {
-            log.error("Image processor of type '" + localNeuralNet.getClass().getCanonicalName() +
-                            "' failed unrecoverably", e);
-            log.error("Stopping");
+            if (log.isErrorEnabled()) {
+                log.error("Image processor of type '" + localNeuralNet.getClass().getCanonicalName() +
+                        "' failed unrecoverably", e);
+                log.error("Stopping");
+            }
             stop();
         } catch (RuntimeException e) {
             log.error("Neural net had an uncaught runtime exception", e);

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -351,7 +351,11 @@ public class ObjectRecognitionCore {
                     }
                 }
                 log.debug("Notifying client with: {}", message);
-                client.sendNotification(message);
+                if (client != null) {
+                    client.sendNotification(message);
+                } else {
+                    log.debug("Unable to notify client as client is null,");
+                }
             }
         } catch (ImageProcessingException e) {
             log.warn("Could not process image", e);

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -302,8 +302,8 @@ public class ObjectRecognitionCore {
     }
     
     /**
-     * Processes the image then sends the results to the Vantiq source. Calls {@code stop()} if a FatalImageException is
-     * received.
+     * Processes the image then sends the results to the Vantiq source. Calls {@code stop()} if a
+     * FatalImageException is received.
      * @param imageResults An {@link ImageRetrieverResults} containing the image to be translated
      */
     public void sendDataFromImage(ImageRetrieverResults imageResults) {
@@ -340,20 +340,24 @@ public class ObjectRecognitionCore {
             if (!localNeuralNet.getClass().toString().contains("NoProcessor")) {
                 // Translate the results from the neural net and image into a message to send back 
                 Map message = createMapFromResults(imageResults, results);
+                log.debug("Message from results: {}", message.get("results"));
+                log.debug("Suppress value: {}", suppressEmptyNeuralNetResults);
 
                 // If suppressNullValues is set to true, then skip sending message results list is empty
                 if (suppressEmptyNeuralNetResults) {
                     if (message.get("results") instanceof List && ((List) message.get("results")).size() == 0) {
+                        log.debug("Skipping notification");
                         return;
                     }
                 }
+                log.debug("Notifying client with: {}", message);
                 client.sendNotification(message);
             }
         } catch (ImageProcessingException e) {
             log.warn("Could not process image", e);
         } catch (FatalImageException e) {
-            log.error("Image processor of type '" + localNeuralNet.getClass().getCanonicalName() + "' failed unrecoverably"
-                    , e);
+            log.error("Image processor of type '" + localNeuralNet.getClass().getCanonicalName() +
+                            "' failed unrecoverably", e);
             log.error("Stopping");
             stop();
         } catch (RuntimeException e) {

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -358,7 +358,7 @@ public class ObjectRecognitionCore {
                 if (client != null) {
                     client.sendNotification(message);
                 } else {
-                    log.debug("Unable to notify client as client is null,");
+                    log.debug("Unable to notify client as client is null.");
                 }
             }
         } catch (ImageProcessingException e) {

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/CameraRetriever.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/CameraRetriever.java
@@ -12,6 +12,8 @@ package io.vantiq.extsrc.objectRecognition.imageRetriever;
 import java.util.Date;
 import java.util.Map;
 
+import org.bytedeco.javacpp.Loader;
+import org.bytedeco.opencv.opencv_java;
 import org.opencv.core.Core;
 import org.opencv.core.Mat;
 import org.opencv.core.MatOfByte;
@@ -43,7 +45,7 @@ public class CameraRetriever implements ImageRetrieverInterface {
     public void setupDataRetrieval(Map<String, ?> dataSourceConfig, ObjectRecognitionCore source) throws Exception {
         // Try to load OpenCV
         try {
-            System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
+            Loader.load(opencv_java.class);
         } catch (Throwable t) {
             throw new Exception(this.getClass().getCanonicalName() + ".opencvDependency" 
                     + ": Could not load OpenCv for CameraRetriever. "

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/CameraRetriever.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/CameraRetriever.java
@@ -62,7 +62,7 @@ public class CameraRetriever extends RetrieverBase implements ImageRetrieverInte
         long before = System.currentTimeMillis();
 
         // Reading the next video frame from the camera
-        org.bytedeco.opencv.opencv_core.Mat matrix;
+        Mat matrix;
         ImageRetrieverResults results = new ImageRetrieverResults();
         Date captureTime = new Date();
 

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/CameraRetriever.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/CameraRetriever.java
@@ -68,16 +68,17 @@ public class CameraRetriever extends RetrieverBase implements ImageRetrieverInte
 
         matrix = grabFrameAsMat();
 
-        byte [] imageByte = convertMatToJpeg(matrix);
+        byte[] imageByte = convertMatToJpeg(matrix);
         matrix.release();
 
         results.setImage(imageByte);
         results.setTimestamp(captureTime);
 
         after = System.currentTimeMillis();
-        log.debug("Image retrieving time for source " + sourceName + ": {}.{} seconds"
-                , (after - before) / 1000, String.format("%03d", (after - before) % 1000));
-
+        if (log.isDebugEnabled()) {
+            log.debug("Image retrieving time for source " + sourceName + ": {}.{} seconds",
+                    (after - before) / 1000, String.format("%03d", (after - before) % 1000));
+        }
         return results;
     }
     
@@ -116,16 +117,17 @@ public class CameraRetriever extends RetrieverBase implements ImageRetrieverInte
         // Reading the next video frame from the camera
         Mat matrix = grabFrameAsMat(cap);
 
-        byte [] imageByte = convertMatToJpeg(matrix);
+        byte[] imageByte = convertMatToJpeg(matrix);
         matrix.release();
 
         results.setImage(imageByte);
         results.setTimestamp(captureTime);
 
         after = System.currentTimeMillis();
-        log.debug("Image retrieving time for source " + sourceName + ": {}.{} seconds"
-                , (after - before) / 1000, String.format("%03d", (after - before) % 1000));
-
+        if (log.isDebugEnabled()) {
+            log.debug("Image retrieving time for source " + sourceName + ": {}.{} seconds",
+                    (after - before) / 1000, String.format("%03d", (after - before) % 1000));
+        }
         return results;
     }
     

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/CameraRetriever.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/CameraRetriever.java
@@ -12,13 +12,8 @@ package io.vantiq.extsrc.objectRecognition.imageRetriever;
 import java.util.Date;
 import java.util.Map;
 
-import org.bytedeco.javacpp.Loader;
-import org.bytedeco.opencv.opencv_java;
-import org.opencv.core.Core;
-import org.opencv.core.Mat;
-import org.opencv.core.MatOfByte;
-import org.opencv.imgcodecs.Imgcodecs;
-import org.opencv.videoio.VideoCapture;
+import org.bytedeco.javacv.FFmpegFrameGrabber;
+import org.bytedeco.opencv.opencv_core.Mat;
 
 import io.vantiq.extsrc.objectRecognition.ObjectRecognitionCore;
 import io.vantiq.extsrc.objectRecognition.exception.FatalImageException;
@@ -34,92 +29,55 @@ import io.vantiq.extsrc.objectRecognition.exception.ImageAcquisitionException;
  * 
  * The timestamp is captured immediately before the image is grabbed from the camera. No other data is included.
  */
-public class CameraRetriever implements ImageRetrieverInterface {
-    VideoCapture   capture;
-    int         camera;
+public class CameraRetriever extends RetrieverBase implements ImageRetrieverInterface {
+    int camera;
+    String sourceName;
     
     // Constants for source configuration
     private static final String CAMERA = "camera";
     
     @Override
     public void setupDataRetrieval(Map<String, ?> dataSourceConfig, ObjectRecognitionCore source) throws Exception {
-        // Try to load OpenCV
-        try {
-            Loader.load(opencv_java.class);
-        } catch (Throwable t) {
-            throw new Exception(this.getClass().getCanonicalName() + ".opencvDependency" 
-                    + ": Could not load OpenCv for CameraRetriever. "
-                    + "This is most likely due to a missing .dll/.so/.dylib. Please ensure that the environment "
-                    + "variable 'OPENCV_LOC' is set to the directory containing '" + Core.NATIVE_LIBRARY_NAME
-                    + "' and any other library requested by the attached error", t);
-        }
-        
+
+        sourceName = source.getSourceName();
+
         // Specify which camera to read
         if (dataSourceConfig.get(CAMERA) instanceof Integer) {
             camera = (Integer) dataSourceConfig.get(CAMERA);
-
-            capture = new VideoCapture(camera);
+            capture = FFmpegFrameGrabber.createDefault(camera);
         } else {
             throw new IllegalArgumentException(this.getClass().getCanonicalName() + ".configMissingOptions: "  + 
                     "No camera specified in dataSourceConfig");
         }
-        
-        // Error out if the camera could not be opened
-        if (!capture.isOpened()) {
-            throw new Exception(this.getClass().getCanonicalName() + ".cameraUnreadable: " 
-                    + "Could not open requested camera '" + camera + "'. Common reasons are: "
-                    + "The camera is not connected properly; "
-                    + "OpenCV is not compiled with the correct codecs to deal with the camera type or is missing a "
-                    + "specific .dll/.so/.dylib file (typically FFmpeg); "
-                    + "The program is not allowed access to the camera");
-        }
     }
-    
+
     /**
      * Obtain the most recent image from the camera
-     * @throws FatalImageException     If the camera is no longer open.
+     * @throws FatalImageException  If the IP camera is no longer open
      */
     @Override
     public ImageRetrieverResults getImage() throws ImageAcquisitionException {
-        // Read the next video frame from the camera
-        Mat matrix = new Mat();
+        // Used to check how long image retrieving takes
+        long after;
+        long before = System.currentTimeMillis();
+
+        // Reading the next video frame from the camera
+        org.bytedeco.opencv.opencv_core.Mat matrix;
         ImageRetrieverResults results = new ImageRetrieverResults();
         Date captureTime = new Date();
 
-        capture.read(matrix);
-        
-        // Exit if nothing was read
-        if (matrix.empty()) {
-            matrix.release();
-            // If the camera is no longer open, then nothing can be read in the future
-            if (!capture.isOpened() ) {
-                capture.release();
-                throw new FatalImageException(this.getClass().getCanonicalName() + ".mainCameraClosed: " 
-                        + "Camera '" + camera + "' has closed");
-            } else {
-                throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".mainCameraReadError: " 
-                        + "Could not obtain frame from camera '" + camera + "'");
-            }
-        }
-        
-        
-        MatOfByte matOfByte = new MatOfByte();
-        // Translate the image into jpeg, error out if it cannot
-        if (!Imgcodecs.imencode(".jpg", matrix, matOfByte)) {
-            matOfByte.release();
-            matrix.release();
-            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".mainCameraConversionError: " 
-                    + "Could not convert the frame from camera '" + camera + "' into a jpeg image");
-        }
-        
-        // Save the jpeg image into as a byte array
-        byte [] imageByte = matOfByte.toArray();
-        matOfByte.release();
+        matrix = grabFrameAsMat();
+
+        byte [] imageByte = convertMatToJpeg(matrix);
         matrix.release();
-        
+
         results.setImage(imageByte);
         results.setTimestamp(captureTime);
-        
+
+        after = System.currentTimeMillis();
+        log.debug("Image retrieving time for source " + sourceName + ": {}.{} seconds"
+                , (after - before) / 1000, String.format("%03d", (after - before) % 1000));
+
         return results;
     }
     
@@ -128,76 +86,57 @@ public class CameraRetriever implements ImageRetrieverInterface {
      */
     @Override
     public ImageRetrieverResults getImage(Map<String, ?> request) throws ImageAcquisitionException {
-        VideoCapture cap;
+        FFmpegFrameGrabber cap;
         Object camId;
         ImageRetrieverResults results = new ImageRetrieverResults();
-        Date captureTime;
-        
+
         // Specify which camera to read
         if (request.get("DScamera") instanceof Integer) {
             int cam = (Integer) request.get("DScamera");
             camId = cam;
-            cap = new VideoCapture(cam);
-        } else if (capture == null) {
-            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".noMainCamera: " 
-                    + "No camera was requested and no main camera was specified at initialization.");
-        } else if (capture.isOpened()){
-            // Try to use the main camera if none was specified
             try {
-                return getImage();
-            } catch (FatalImageException e) {
-                throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".mainCameraFatalError: " 
-                        + "Main camera failed fatally. Other cameras are still Queryable.");
+                cap = FFmpegFrameGrabber.createDefault(cam);
+            } catch (FFmpegFrameGrabber.Exception e) {
+                throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".cameraNotOpened: "
+                        + "The camera id: " + camId + " could not be opened for source: " + sourceName + ".", e);
             }
+        } else if (capture == null) {
+            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".noMainCamera: "
+                    + "No camera was requested and no main camera was specified at initialization.");
         } else {
-            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".mainCameraClosed: " 
-                    + "No camera was requested and the main camera is no longer open. Most likely this is due to a "
-                    + "previous fatal error for the main camera.");
+            return getImage();
         }
-        
-        // Error out if the camera could not be opened
-        if (!cap.isOpened()) {
-            cap.release();
-            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".queryCameraUnreadable: " 
-                    + "Could not open camera '" + camId + "'");
-        }
-        Mat mat = new Mat();
-        
-        captureTime = new Date();
-        cap.read(mat);
-        
-        // Exit if nothing was read
-        if (mat.empty()) {
-            cap.release();
-            mat.release();
-            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".queryCameraReadError: " 
-                    + "Could not obtain frame from camera '" + camId + "'");
-        }
-        MatOfByte matOfByte = new MatOfByte();
-        
-        // Translate the image into jpeg, error out if it cannot
-        if (!Imgcodecs.imencode(".jpg", mat, matOfByte)) {
-            matOfByte.release();
-            mat.release();
-            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".queryCameraConversionError: " 
-                    + "Could not convert the frame from camera '" + camera + "' into a jpeg image");
-        }
-        
-        // Save the jpeg image into as a byte array
-        byte [] imageByte = matOfByte.toArray();
-        matOfByte.release();
-        mat.release();
-        cap.release();
-                
+
+        // If we got here, then we need to process the image from the specified camera.
+
+        long after;
+        long before = System.currentTimeMillis();
+        Date captureTime = new Date();
+
+        // Reading the next video frame from the camera
+        Mat matrix = grabFrameAsMat(cap);
+
+        byte [] imageByte = convertMatToJpeg(matrix);
+        matrix.release();
+
         results.setImage(imageByte);
         results.setTimestamp(captureTime);
-        
+
+        after = System.currentTimeMillis();
+        log.debug("Image retrieving time for source " + sourceName + ": {}.{} seconds"
+                , (after - before) / 1000, String.format("%03d", (after - before) % 1000));
+
         return results;
     }
     
     public void close() {
         if (capture != null) {
-            capture.release();
+            try {
+                capture.release();
+            } catch (FFmpegFrameGrabber.Exception e) {
+                log.warn("Release exception: ", e);
+                // otherwise, ignore
+            }
         }
     }
 }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/FileRetriever.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/FileRetriever.java
@@ -17,6 +17,8 @@ import io.vantiq.extsrc.objectRecognition.ObjectRecognitionCore;
 import io.vantiq.extsrc.objectRecognition.exception.FatalImageException;
 import io.vantiq.extsrc.objectRecognition.exception.ImageAcquisitionException;
 
+import org.bytedeco.javacpp.Loader;
+import org.bytedeco.opencv.opencv_java;
 import org.opencv.core.Core;
 import org.opencv.core.Mat;
 import org.opencv.core.MatOfByte;
@@ -86,7 +88,7 @@ public class FileRetriever implements ImageRetrieverInterface {
 
         // Load OpenCV
         try {
-            System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
+            Loader.load(opencv_java.class);
         } catch (Throwable t) {
             throw new Exception(this.getClass().getCanonicalName() + ".opencvDependency" 
                     + ": Could not load OpenCv for FileRetriever."

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/FileRetriever.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/FileRetriever.java
@@ -144,7 +144,7 @@ public class FileRetriever extends RetrieverBase implements ImageRetrieverInterf
         if (isMov) {
             Mat matrix = new Mat();
             // Save the current position for later.
-            log.debug("Reading frame number {}", currentFrameNumber);
+            log.trace("Reading frame number {}", currentFrameNumber);
 
             matrix = grabFrameAsMat();
             // Exit if nothing could be read
@@ -165,7 +165,7 @@ public class FileRetriever extends RetrieverBase implements ImageRetrieverInterf
             // Move forward by the number of frames specified in the Configuration
             currentFrameNumber += frameInterval;
             try {
-                log.debug("Setting next frame number to {}", currentFrameNumber);
+                log.trace("Setting next frame number to {}", currentFrameNumber);
                 capture.setVideoFrameNumber(currentFrameNumber);
             } catch (FFmpegFrameGrabber.Exception e) {
                 throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".videoSeekError: "
@@ -382,8 +382,8 @@ public class FileRetriever extends RetrieverBase implements ImageRetrieverInterf
                 tryCount += 1;
                 if (frame != null) {
                     if (!frame.getTypes().contains(Frame.Type.VIDEO)) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Found non-video frame: {}", frame.getTypes());
+                        if (log.isTraceEnabled()) {
+                            log.trace("Found non-video frame: {}", frame.getTypes());
                         }
                         continue;
                     }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/FileRetriever.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/FileRetriever.java
@@ -25,7 +25,6 @@ import org.bytedeco.opencv.opencv_core.Mat;
 
 import static org.bytedeco.opencv.global.opencv_imgcodecs.imread;
 
-
 /**
  * This implementation reads files from the disk, using OpenCV for the videos. {@code fileLocation} must be a valid file
  * at initialization if specified for a video. The initial image file can be replaced while the source is running, but the video cannot. For
@@ -76,6 +75,7 @@ public class FileRetriever extends RetrieverBase implements ImageRetrieverInterf
     private static final String FPS = "fps";
 
     @Override
+    @SuppressWarnings({"PMD.CognitiveComplexity", "PMD.AvoidDeeplyNestedIfStmts"})
     public void setupDataRetrieval(Map<String, ?> dataSourceConfig, ObjectRecognitionCore source) throws Exception {
         // Check if the file is a video
         if (dataSourceConfig.get(FILE_EXTENSION) instanceof String) {
@@ -130,6 +130,7 @@ public class FileRetriever extends RetrieverBase implements ImageRetrieverInterf
      * @throws FatalImageException  If no file was specified at configuration, or if the video has completed
      */
     @Override
+    @SuppressWarnings({"PMD.CognitiveComplexity"})
     public ImageRetrieverResults getImage() throws ImageAcquisitionException {
         ImageRetrieverResults results = new ImageRetrieverResults();
         Map<String, Object> otherData = new LinkedHashMap<>();
@@ -175,7 +176,7 @@ public class FileRetriever extends RetrieverBase implements ImageRetrieverInterf
             results.setImage(imageBytes);
                     
             return results;
-        } else if (cameraOrFile != null){
+        } else if (cameraOrFile != null) {
             // Read the expected image
             otherData.put("file", cameraOrFile);
             Mat image = imread(cameraOrFile);
@@ -211,6 +212,7 @@ public class FileRetriever extends RetrieverBase implements ImageRetrieverInterf
      * Read the specified file, or the file specified at configuration
      */
     @Override
+    @SuppressWarnings({"PMD.CognitiveComplexity"})
     public ImageRetrieverResults getImage(Map<String, ?> request) throws ImageAcquisitionException {
         ImageRetrieverResults results = new ImageRetrieverResults();
         Map<String, Object> otherData = new LinkedHashMap<>();
@@ -380,7 +382,9 @@ public class FileRetriever extends RetrieverBase implements ImageRetrieverInterf
                 tryCount += 1;
                 if (frame != null) {
                     if (!frame.getTypes().contains(Frame.Type.VIDEO)) {
-                        log.error("Found non-video frame: {}", frame.getTypes());
+                        if (log.isDebugEnabled()) {
+                            log.error("Found non-video frame: {}", frame.getTypes());
+                        }
                         continue;
                     }
                 }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/FileRetriever.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/FileRetriever.java
@@ -383,7 +383,7 @@ public class FileRetriever extends RetrieverBase implements ImageRetrieverInterf
                 if (frame != null) {
                     if (!frame.getTypes().contains(Frame.Type.VIDEO)) {
                         if (log.isDebugEnabled()) {
-                            log.error("Found non-video frame: {}", frame.getTypes());
+                            log.debug("Found non-video frame: {}", frame.getTypes());
                         }
                         continue;
                     }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/ImageRetrieverInterface.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/ImageRetrieverInterface.java
@@ -16,7 +16,12 @@ import io.vantiq.extsrc.objectRecognition.exception.FatalImageException;
 import io.vantiq.extsrc.objectRecognition.exception.ImageAcquisitionException;
 
 public interface ImageRetrieverInterface {
+    // Constants for source configuration
     static final String TYPE_ENTRY = "type";
+    static final String CAMERA = "camera";
+    static final String RTSP_CONFIG = "rtspConfig";
+    static final String RTSP_TRANSPORT = "rtspTransport";
+    static final String RTSP_FLAGS = "rtspFlags";
     
     /**
      * Configures the data retriever.

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/NetworkStreamRetriever.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/NetworkStreamRetriever.java
@@ -104,14 +104,14 @@ public class NetworkStreamRetriever extends RetrieverBase implements ImageRetrie
 
                 capture.setOption("rtsp_transport", rtspTransport);
 
-                if (log.isDebugEnabled()) {
-                    log.debug("Capture opened, Format: {}, codec: {}, Vid Options: {}",
+                if (log.isTraceEnabled()) {
+                    log.trace("Capture opened, Format: {}, codec: {}, Vid Options: {}",
                             capture.getFormat(), capture.getVideoCodecName(), capture.getOptions().toString());
                 }
             }
             capture.start();
-            if (log.isDebugEnabled()) {
-                log.debug("Capture started, Format: {}, codec: {} ({}), Vid Meta: {}",
+            if (log.isTraceEnabled()) {
+                log.trace("Capture started, Format: {}, codec: {} ({}), Vid Meta: {}",
                         capture.getFormat(), capture.getVideoCodecName(),
                         capture.getVideoCodec(), capture.getVideoMetadata().toString());
             }
@@ -135,8 +135,8 @@ public class NetworkStreamRetriever extends RetrieverBase implements ImageRetrie
             log.debug("Camera is via push protocol -- restarting...");
             try {
                 cap.restart();
-                if (log.isDebugEnabled()) {
-                    log.debug("Capture restarted, Format: {}, codec: {} ({}), Vid Meta: {}",
+                if (log.isTraceEnabled()) {
+                    log.trace("Capture restarted, Format: {}, codec: {} ({}), Vid Meta: {}",
                             capture.getFormat(), capture.getVideoCodecName(),
                             capture.getVideoCodec(), capture.getVideoMetadata().toString());
                 }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/NetworkStreamRetriever.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/NetworkStreamRetriever.java
@@ -17,6 +17,11 @@ import java.net.URL;
 import java.util.Date;
 import java.util.Map;
 
+import org.bytedeco.javacpp.Loader;
+import org.bytedeco.javacv.FFmpegFrameGrabber;
+import org.bytedeco.javacv.Frame;
+import org.bytedeco.javacv.OpenCVFrameConverter;
+import org.bytedeco.opencv.opencv_java;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,6 +34,9 @@ import org.opencv.videoio.VideoCapture;
 import io.vantiq.extsrc.objectRecognition.ObjectRecognitionCore;
 import io.vantiq.extsrc.objectRecognition.exception.FatalImageException;
 import io.vantiq.extsrc.objectRecognition.exception.ImageAcquisitionException;
+
+import static org.bytedeco.ffmpeg.global.avutil.AV_LOG_ERROR;
+import static org.bytedeco.ffmpeg.global.avutil.av_log_set_level;
 
 /**
  * Captures images from an IP camera.
@@ -44,27 +52,32 @@ import io.vantiq.extsrc.objectRecognition.exception.ImageAcquisitionException;
  * </ul>
  */
 public class NetworkStreamRetriever implements ImageRetrieverInterface {
-    VideoCapture   capture;
+    FFmpegFrameGrabber capture;
     String         camera;
+    String         rtspTransport = "tcp";
+    Boolean        isRTSP = false;
     Logger         log = LoggerFactory.getLogger(this.getClass().getCanonicalName());
     Boolean        isPushProtocol = false;
+
+    static boolean openCvLoaded = false;
     
     private String sourceName;
 
-    // Constants for source configuration
-    private static final String CAMERA = "camera";
-    
     @Override
+    @SuppressWarnings("unchecked")
     public void setupDataRetrieval(Map<String, ?> dataSourceConfig, ObjectRecognitionCore source) throws Exception {
         sourceName = source.getSourceName();
-        try {
-            System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
-        } catch (Throwable t) {
-            throw new Exception(this.getClass().getCanonicalName() + ".opencvDependency" 
-                    + ": Could not load OpenCv for NetworkStreamRetriever."
-                    + "This is most likely due to a missing .dll/.so/.dylib. Please ensure that the environment "
-                    + "variable 'OPENCV_LOC' is set to the directory containing '" + Core.NATIVE_LIBRARY_NAME
-                    + "' and any other library requested by the attached error", t);
+        if (!openCvLoaded) {
+            try {
+                Loader.load(opencv_java.class);
+                openCvLoaded = true;
+            } catch (Throwable t) {
+                throw new Exception(this.getClass().getCanonicalName() + ".opencvDependency"
+                        + ": Could not load OpenCv for NetworkStreamRetriever."
+                        + "This is most likely due to a missing .dll/.so/.dylib. Please ensure that the environment "
+                        + "variable 'OPENCV_LOC' is set to the directory containing '" + Core.NATIVE_LIBRARY_NAME
+                        + "' and any other library requested by the attached error", t);
+            }
         }
         if (dataSourceConfig.get(CAMERA) instanceof String){
             camera = (String) dataSourceConfig.get(CAMERA);
@@ -74,20 +87,103 @@ public class NetworkStreamRetriever implements ImageRetrieverInterface {
                         pushCheck.getPath().endsWith("m3u") || pushCheck.getPath().endsWith("m3u8")) {
                     isPushProtocol = true;
                 }
+                if (pushCheck.getScheme().equalsIgnoreCase("rtsp") ||
+                        pushCheck.getScheme().equalsIgnoreCase("rtsps")) {
+                    isRTSP = true;
+                    // If the camera is an rtsp URL, check for any options
+                    if (dataSourceConfig.get(RTSP_CONFIG) instanceof Map) {
+                        Map<String, String> rtspConf = (Map<String, String>) dataSourceConfig.get(RTSP_CONFIG);
+                        if (rtspConf.get(RTSP_TRANSPORT) instanceof String) {
+                            rtspTransport = (String) rtspConf.get(RTSP_TRANSPORT);
+                        }
+                        // rtsp_flags is for cases where the transport is acting as a server
+                        // It does not apply in our connector case.
+                    }
+                }
             } catch (URISyntaxException e) {
                 throw new IllegalArgumentException(this.getClass().getCanonicalName() + ".unknownProtocol: "
                         + "URL specifies unknown protocol, or protocol was improperly formatted. Error Message: ", e);
             }
             
-            capture = new VideoCapture(camera);
+            openCapture();
+
         } else {
             throw new IllegalArgumentException(this.getClass().getCanonicalName() + ".configMissingOptions: "  + 
                     "No camera specified in dataSourceConfig");
         }
-        if (!capture.isOpened()) {
-            diagnoseConnection();
-            throw new IllegalArgumentException(this.getClass().getCanonicalName() + ".notVideoStream: " 
-                    + "Stream at URL cannot be opened as a video stream");
+    }
+
+    protected void openCapture() throws ImageAcquisitionException {
+
+        // This av_log_set_level() call  turns off a boatload of warnings reading some types of cameras.
+        // Fix for the actual issue (which isn't a functional one) hasn't been found, apparently.]
+        // See https://github.com/bytedeco/javacv/issues/780 for more information.
+
+        av_log_set_level(AV_LOG_ERROR);
+
+        try {
+            if (capture != null) {
+                capture.close();
+                capture.release();
+                capture = null;
+            }
+            capture = new FFmpegFrameGrabber(camera);
+
+            if (isRTSP) {
+                // Depending upon where the caller is running, the UDP transport for the actual video often employed
+                // by RTSP sub-transports may or may not actually get through. In order to avoid this, we'll ask
+                // the underlying transport to use TCP for the transport. We have not (yet) encountered an environment
+                // where this is an issue.  Suggested by https://github.com/bytedeco/javacv/issues/1022.
+
+                // More information on other options (that may be available) can be found here:
+                // http://underpop.online.fr/f/ffmpeg/help/rtsp.htm.gz
+
+                capture.setOption("rtsp_transport", rtspTransport);
+
+                log.debug("Capture opened, Format: {}, codec: {}, Vid Options: {}",
+                        capture.getFormat(), capture.getVideoCodecName(), capture.getOptions().toString());
+            }
+            capture.start();
+            log.debug("Capture started, Format: {}, codec: {} ({}), Vid Meta: {}",
+                    capture.getFormat(), capture.getVideoCodecName(), capture.getVideoCodec(), capture.getVideoMetadata().toString());
+
+        } catch (Exception e) {
+            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".noGrabber: "
+                    + "Unable to create or start FrameGrabber for camera '" + camera + "'", e);
+        }
+    }
+
+    protected Mat grabFrameAsMat() throws ImageAcquisitionException {
+        if (isPushProtocol) {
+            log.debug("Camera is via push protocol -- restarting...");
+            try {
+                capture.restart();
+                log.debug("Capture restarted, Format: {}, codec: {} ({}), Vid Meta: {}",
+                        capture.getFormat(), capture.getVideoCodecName(), capture.getVideoCodec(), capture.getVideoMetadata().toString());
+            } catch (Exception e) {
+                throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".errorStopStart: "
+                        + "Could not stop/start '" + camera + "'", e);
+            }
+        }
+        try {
+            Frame frame = null;
+            int tryCount = 0;
+            while (frame == null && tryCount < 100) {
+                frame = capture.grabImage();
+                tryCount += 1;
+                if (frame != null) {
+                    if (!frame.getTypes().contains(Frame.Type.VIDEO)) {
+                        log.debug("Found non-video frame: {}", frame.getTypes());
+                        continue;
+                    }
+                }
+            }
+
+            OpenCVFrameConverter.ToMat converterToMat = new OpenCVFrameConverter.ToMat();
+            return converterToMat.convertToOrgOpenCvCoreMat(frame);
+        } catch (Exception e) {
+            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".badImageGrab: "
+                    + "Could not obtain frame from camera '" + camera + "': " + e.toString(), e);
         }
     }
     
@@ -105,33 +201,22 @@ public class NetworkStreamRetriever implements ImageRetrieverInterface {
         Mat matrix = new Mat();
         ImageRetrieverResults results = new ImageRetrieverResults();
         Date captureTime = new Date();
-        
-        if (isPushProtocol) {
-            capture.release();
-            capture = new VideoCapture(camera);
-        }
-        capture.read(matrix);
-        
-        if (matrix.empty()) {
-            matrix.release();
+
+        matrix = grabFrameAsMat();
+
+        if (matrix == null || matrix.empty()) {
+            if (matrix != null) {
+                matrix.release();
+            }
             // Check connection to URL first
             diagnoseConnection();
-            
-            // Try to recreate video capture once connection is reestablished 
-            capture = new VideoCapture(camera);
-            
-            // Otherwise, check to see if camera has closed
-            if (!capture.isOpened() ) {
-                capture.release();
-                throw new FatalImageException(this.getClass().getCanonicalName() + ".mainCameraClosed: " 
-                        + "Camera '" + camera + "' has closed");
-            } else {
-                capture.read(matrix);
-                if (matrix.empty()) {
-                    matrix.release();
-                    throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".mainCameraReadError2: " 
-                            + "Could not obtain frame from camera '" + camera + "'");
-                }
+
+            openCapture();
+            matrix = grabFrameAsMat();
+            if (matrix.empty()) {
+                matrix.release();
+                throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".mainCameraReadError2: "
+                        + "Could not obtain frame from camera '" + camera + "'");
             }
         }
       
@@ -174,50 +259,43 @@ public class NetworkStreamRetriever implements ImageRetrieverInterface {
         } else if (capture == null) {
             throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".noMainCamera: " 
                     + "No camera was requested and no main camera was specified at initialization.");
-        } else if (capture.isOpened()){
-            try {
-                return getImage();
-            } catch (FatalImageException e) {
-                throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".mainCameraFatalError: " 
-                        + "Main camera failed fatally. Other cameras are still Queryable.");
-            }
-        } else {
-            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".mainCameraClosed: " 
-                    + "No camera was requested and the main camera is no longer open. Most likely this is due to a "
-                    + "previous fatal error for the main camera.");
+        } else  {// if (capture.isOpened()){
+            return getImage();
         }
-        
-        if (!cap.isOpened()) {
-            cap.release();
-            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".queryCameraUnreadable: " 
-                    + "Could not open camera '" + camId + "'");
-        }
-        Mat mat = new Mat();
-        
-        captureTime = new Date();
-        cap.read(mat);
-        if (mat.empty()) {
-            cap.release();
-            mat.release();
-            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".queryCameraReadError: " 
-                    + "Could not obtain frame from camera '" + camId + "'");
-        }
-        MatOfByte matOfByte = new MatOfByte();
-        // Translate the image into jpeg, error out if it cannot
-        if (!Imgcodecs.imencode(".jpg", mat, matOfByte)) {
-            matOfByte.release();
-            mat.release();
-            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".queryCameraConversionError: " 
-                    + "Could not convert the frame from camera '" + camera + "' into a jpeg image");
-        }
-        byte [] imageByte = matOfByte.toArray();
-        matOfByte.release();
-        mat.release();
-        cap.release();
-        
-        results.setImage(imageByte);
-        results.setTimestamp(captureTime);
-        return results;
+
+        return getImage();
+        // FIXME -- sort this all out & fix it up with new structure
+//        if (!cap.isOpened()) {
+//            cap.release();
+//            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".queryCameraUnreadable: "
+//                    + "Could not open camera '" + camId + "'");
+//        }
+//        Mat mat = new Mat();
+//
+//        captureTime = new Date();
+//        cap.read(mat);
+//        if (mat.empty()) {
+//            cap.release();
+//            mat.release();
+//            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".queryCameraReadError: "
+//                    + "Could not obtain frame from camera '" + camId + "'");
+//        }
+//        MatOfByte matOfByte = new MatOfByte();
+//        // Translate the image into jpeg, error out if it cannot
+//        if (!Imgcodecs.imencode(".jpg", mat, matOfByte)) {
+//            matOfByte.release();
+//            mat.release();
+//            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".queryCameraConversionError: "
+//                    + "Could not convert the frame from camera '" + camera + "' into a jpeg image");
+//        }
+//        byte [] imageByte = matOfByte.toArray();
+//        matOfByte.release();
+//        mat.release();
+//        cap.release();
+//
+//        results.setImage(imageByte);
+//        results.setTimestamp(captureTime);
+//        return results;
     }
     
     public void diagnoseConnection() throws ImageAcquisitionException {
@@ -245,8 +323,14 @@ public class NetworkStreamRetriever implements ImageRetrieverInterface {
     }
     
     public void close() {
-        if (capture != null) {
-            capture.release();
+        try {
+            if (capture != null) {
+                capture.release();
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException(this.getClass().getCanonicalName() + ".badRelease: "
+                    + "Unable to release framegrabber for cammera : " + camera, e);
+
         }
     }
 }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/NetworkStreamRetriever.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/NetworkStreamRetriever.java
@@ -144,7 +144,8 @@ public class NetworkStreamRetriever extends RetrieverBase implements ImageRetrie
                 throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".errorStopStart: "
                         + "Could not stop/start '" + cameraOrFile + "'", e);
             }
-        }    }
+        }
+    }
     
     /**
      * Obtain the most recent image from the camera
@@ -186,8 +187,10 @@ public class NetworkStreamRetriever extends RetrieverBase implements ImageRetrie
         results.setTimestamp(captureTime);
         
         after = System.currentTimeMillis();
-        log.debug("Image retrieving time for source " + sourceName + ": {}.{} seconds"
-                , (after - before) / 1000, String.format("%03d", (after - before) % 1000));
+        if (log.isDebugEnabled()) {
+            log.debug("Image retrieving time for source " + sourceName + ": {}.{} seconds",
+                    (after - before) / 1000, String.format("%03d", (after - before) % 1000));
+        }
         
         return results;
     }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/NetworkStreamRetriever.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/NetworkStreamRetriever.java
@@ -231,7 +231,8 @@ public class NetworkStreamRetriever implements ImageRetrieverInterface {
             cap = new FFmpegFrameGrabber(cam);
         }
 
-        if (cap == null) {
+        // FIXME:  This seems incorrect -- we get the camera from above but ignore it.
+        if (capture == null) {
             throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".noMainCamera: " 
                     + "No camera was requested and no main camera was specified at initialization.");
         }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/RetrieverBase.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/RetrieverBase.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2022 Vantiq, Inc.
+ *
+ * All rights reserved.
+ *
+ * SPDX: MIT
+ */
+
+
+package io.vantiq.extsrc.objectRecognition.imageRetriever;
+
+import io.vantiq.extsrc.objectRecognition.exception.ImageAcquisitionException;
+import org.bytedeco.javacpp.BytePointer;
+import org.bytedeco.javacv.FFmpegFrameGrabber;
+import org.bytedeco.javacv.Frame;
+import org.bytedeco.javacv.OpenCVFrameConverter;
+import org.bytedeco.opencv.opencv_core.Mat;
+import org.bytedeco.opencv.opencv_core.Size;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.bytedeco.ffmpeg.global.avutil.AV_LOG_ERROR;
+import static org.bytedeco.ffmpeg.global.avutil.av_log_set_level;
+import static org.bytedeco.opencv.global.opencv_imgcodecs.imencode;
+
+public class RetrieverBase {
+    FFmpegFrameGrabber capture;
+    String cameraOrFile;
+    Logger log = LoggerFactory.getLogger(this.getClass().getCanonicalName());
+
+    RetrieverBase() {
+        // This av_log_set_level() call  turns off a boatload of warnings reading some types of cameras.
+        // Fix for the actual issue (which isn't a functional one) hasn't been found, apparently.]
+        // See https://github.com/bytedeco/javacv/issues/780 for more information.
+
+        av_log_set_level(AV_LOG_ERROR);
+    }
+
+    /**
+     * Converts an image into jpeg format and releases the Mat that held the original image
+     * @param image The image to convert
+     * @return      The bytes of the image in jpeg format, or null if it could not be converted
+     */
+    byte[] convertMatToJpeg(Mat image) {
+        // JPG conversion requires a buffer into which we'll place the jpg.  However, we have to guess at the size
+        // beforehand.  To do this, we'll work out the size of the uncompressed image in the passed-in Mat,
+        // and use that as our buffer size.  JPG's are compressed, so the results should be smaller...
+        Size s = image.size();
+        int maxSize = s.height() * s.width();
+        byte[] buf = new byte[maxSize];
+        BytePointer bytes = new BytePointer(buf);
+        log.debug("Image facts: size: h:{}, w: {}, using buffer size (h*w): {}", s.height(), s.width(), maxSize);
+
+        // Translate the image into jpeg, return null if it cannot
+        byte[] imageBytes = null;
+        if (image.empty()) {
+            log.warn("Cannot convert empty image to jpg");
+        } else if (imencode(".jpg", image, bytes)) {
+            log.debug("bytes stuff: limit: {}, position: {}, capacity: {}", bytes.limit(),
+                    bytes.position(), bytes.capacity());
+            imageBytes = bytes.getStringBytes();
+            log.debug("JPG length is: {}", imageBytes.length);
+        } else {
+            log.error("Failed to convert image to jpeg");
+        }
+        image.release();
+        return imageBytes;
+    }
+
+    /**
+     * Using the standard frame grabber, grab a frame and return it as a Mat.
+     *
+     * @return Mat containing the next frame from the device in question
+     * @throws ImageAcquisitionException
+     */
+    protected Mat grabFrameAsMat() throws ImageAcquisitionException {
+        return grabFrameAsMat(capture);
+    }
+
+    /**
+     * Using the specified frame grabber, grab a frame and return it as a Mat.
+     *
+     * @return Mat containing the next frame from the device in question
+     * @throws ImageAcquisitionException
+     */
+    protected Mat grabFrameAsMat(FFmpegFrameGrabber cap) throws ImageAcquisitionException {
+        resetForPush(cap);
+
+        try {
+            Frame frame = null;
+            int tryCount = 0;
+            while (frame == null && tryCount < 100) {
+                frame = cap.grabImage();
+                tryCount += 1;
+                if (frame != null) {
+                    if (!frame.getTypes().contains(Frame.Type.VIDEO)) {
+                        log.debug("Found non-video frame: {}", frame.getTypes());
+                        continue;
+                    }
+                }
+            }
+
+            OpenCVFrameConverter.ToMat converterToMat = new OpenCVFrameConverter.ToMat();
+            return converterToMat.convertToMat(frame);
+        } catch (Exception e) {
+            throw new ImageAcquisitionException(this.getClass().getCanonicalName() + ".badImageGrab: "
+                    + "Could not obtain frame from camera '" + cameraOrFile + "': " + e.toString(), e);
+        }
+    }
+
+    /**
+     * Reset framegrabber stream when each read requires the camera to be reset.
+     * Overridden where required.
+     *
+     * @param cap FFMpegFrameGrabber to reset as required
+     */
+    protected void resetForPush(FFmpegFrameGrabber cap) throws ImageAcquisitionException {
+        // Base case is to do nothing.  This can be overridden for push protocol cases where a "rewind" is necessary.
+        // At the time of this writing, used only for the network retriever where to get the "latest" frame, one
+        // must often close & reopen the network camera.
+    }
+}

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/RetrieverBase.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/RetrieverBase.java
@@ -49,15 +49,19 @@ public class RetrieverBase {
         int maxSize = s.height() * s.width();
         byte[] buf = new byte[maxSize];
         BytePointer bytes = new BytePointer(buf);
-        log.debug("Image facts: size: h:{}, w: {}, using buffer size (h*w): {}", s.height(), s.width(), maxSize);
+        if (log.isDebugEnabled()) {
+            log.debug("Image facts: size: h:{}, w: {}, using buffer size (h*w): {}", s.height(), s.width(), maxSize);
+        }
 
         // Translate the image into jpeg, return null if it cannot
         byte[] imageBytes = null;
         if (image.empty()) {
             log.warn("Cannot convert empty image to jpg");
         } else if (imencode(".jpg", image, bytes)) {
-            log.debug("bytes stuff: limit: {}, position: {}, capacity: {}", bytes.limit(),
-                    bytes.position(), bytes.capacity());
+            if (log.isDebugEnabled()) {
+                log.debug("bytes stuff: limit: {}, position: {}, capacity: {}", bytes.limit(),
+                        bytes.position(), bytes.capacity());
+            }
             imageBytes = bytes.getStringBytes();
             log.debug("JPG length is: {}", imageBytes.length);
         } else {
@@ -94,7 +98,9 @@ public class RetrieverBase {
                 tryCount += 1;
                 if (frame != null) {
                     if (!frame.getTypes().contains(Frame.Type.VIDEO)) {
-                        log.debug("Found non-video frame: {}", frame.getTypes());
+                        if (log.isDebugEnabled()) {
+                            log.debug("Found non-video frame: {}", frame.getTypes());
+                        }
                         continue;
                     }
                 }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/RetrieverBase.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/RetrieverBase.java
@@ -31,7 +31,7 @@ public class RetrieverBase {
 
     RetrieverBase() {
         // This av_log_set_level() call  turns off a boatload of warnings reading some types of cameras.
-        // Fix for the actual issue (which isn't a functional one) hasn't been found, apparently.]
+        // Fix for the actual issue (which isn't a functional one) hasn't been found, apparently.
         // See https://github.com/bytedeco/javacv/issues/780 for more information.
 
         av_log_set_level(AV_LOG_ERROR);
@@ -64,7 +64,9 @@ public class RetrieverBase {
                         bytes.position(), bytes.capacity());
             }
             imageBytes = bytes.getStringBytes();
-            log.debug("JPG length is: {}", imageBytes.length);
+            if (log.isDebugEnabled()) {
+                log.debug("JPG length is: {}", imageBytes.length);
+            }
         } else {
             log.error("Failed to convert image to jpeg");
         }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/RetrieverBase.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/RetrieverBase.java
@@ -34,7 +34,10 @@ public class RetrieverBase {
         // Fix for the actual issue (which isn't a functional one) hasn't been found, apparently.
         // See https://github.com/bytedeco/javacv/issues/780 for more information.
 
-        av_log_set_level(AV_LOG_ERROR);
+        if (!log.isTraceEnabled()) {
+            // allow info dump when working at trace level
+            av_log_set_level(AV_LOG_ERROR);
+        }
     }
 
     /**
@@ -50,8 +53,8 @@ public class RetrieverBase {
         int maxSize = s.height() * s.width();
         byte[] buf = new byte[maxSize];
         BytePointer bytes = new BytePointer(buf);
-        if (log.isDebugEnabled()) {
-            log.debug("Image facts: size: h:{}, w: {}, using buffer size (h*w): {}", s.height(), s.width(), maxSize);
+        if (log.isTraceEnabled()) {
+            log.trace("Image facts: size: h:{}, w: {}, using buffer size (h*w): {}", s.height(), s.width(), maxSize);
         }
 
         // Translate the image into jpeg, return null if it cannot
@@ -59,13 +62,13 @@ public class RetrieverBase {
         if (image.empty()) {
             log.warn("Cannot convert empty image to jpg");
         } else if (imencode(".jpg", image, bytes)) {
-            if (log.isDebugEnabled()) {
-                log.debug("bytes stuff: limit: {}, position: {}, capacity: {}", bytes.limit(),
+            if (log.isTraceEnabled()) {
+                log.trace("BytePointer Info: limit: {}, position: {}, capacity: {}", bytes.limit(),
                         bytes.position(), bytes.capacity());
             }
             imageBytes = bytes.getStringBytes();
-            if (log.isDebugEnabled()) {
-                log.debug("JPG length is: {}", imageBytes.length);
+            if (log.isTraceEnabled()) {
+                log.trace("JPG length is: {}", imageBytes.length);
             }
         } else {
             log.error("Failed to convert image to jpeg");
@@ -101,8 +104,8 @@ public class RetrieverBase {
                 tryCount += 1;
                 if (frame != null) {
                     if (!frame.getTypes().contains(Frame.Type.VIDEO)) {
-                        if (log.isDebugEnabled()) {
-                            log.debug("Found non-video frame: {}", frame.getTypes());
+                        if (log.isTraceEnabled()) {
+                            log.trace("Found non-video frame: {}", frame.getTypes());
                         }
                         continue;
                     }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/RetrieverBase.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/imageRetriever/RetrieverBase.java
@@ -23,6 +23,7 @@ import static org.bytedeco.ffmpeg.global.avutil.AV_LOG_ERROR;
 import static org.bytedeco.ffmpeg.global.avutil.av_log_set_level;
 import static org.bytedeco.opencv.global.opencv_imgcodecs.imencode;
 
+@SuppressWarnings({"PMD.PackageCase"})
 public class RetrieverBase {
     FFmpegFrameGrabber capture;
     String cameraOrFile;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -60,7 +60,7 @@ import io.vantiq.client.Vantiq;
  * 
  * No additional data is given.
  */
-
+@SuppressWarnings({"PMD.TooManyFields"})
 public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2 {
 
     Logger log = LoggerFactory.getLogger(this.getClass());
@@ -120,6 +120,7 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
     private static SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd--HH-mm-ss");
 
     @Override
+    @SuppressWarnings({"PMD.UseObjectForClearerAPI"})
     public void setupImageProcessing(Map<String, ?> neuralNetConfig, String sourceName, String modelDirectory,
                                      String authToken, String server) throws Exception {
         setup(neuralNetConfig, sourceName, modelDirectory, authToken, server);

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -120,10 +120,12 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
     private static SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd--HH-mm-ss");
 
     @Override
-    public void setupImageProcessing(Map<String, ?> neuralNetConfig, String sourceName, String modelDirectory, String authToken, String server) throws Exception {
+    public void setupImageProcessing(Map<String, ?> neuralNetConfig, String sourceName, String modelDirectory,
+                                     String authToken, String server) throws Exception {
         setup(neuralNetConfig, sourceName, modelDirectory, authToken, server);
         try {
-            objectDetector = new ObjectDetector(threshold, pbFile, labelsFile, metaFile, anchorArray, imageUtil, outputDir, labelImage, saveRate, vantiq, sourceName);
+            objectDetector = new ObjectDetector(threshold, pbFile, labelsFile, metaFile, anchorArray,
+                    imageUtil, outputDir, labelImage, saveRate, vantiq, sourceName);
         } catch (Exception e) {
             throw new Exception(this.getClass().getCanonicalName() + ".yoloBackendSetupError: " 
                     + "Failed to create new ObjectDetector", e);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecConfig.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecConfig.java
@@ -10,6 +10,8 @@
 package io.vantiq.extsrc.objectRecognition;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
@@ -75,7 +77,7 @@ public class TestObjRecConfig {
         // Should return null when not a valid class
         className = "Not a class";
         ir = handler.getImageRetriever(className);
-        assertTrue(ir == null);
+        assertNull(ir);
         assertTrue("Should fail when not given a valid class name", configIsFailed());
     }
     @Test
@@ -85,7 +87,7 @@ public class TestObjRecConfig {
         // Should return null when not an ImageRetrieverInterface
         className = this.getClass().getCanonicalName();
         ir = handler.getImageRetriever(className);
-        assertTrue(ir == null);
+        assertNull(ir);
         assertTrue("Should fail when not given a class that's not an image retriever", configIsFailed());
     }
     @Test
@@ -96,7 +98,7 @@ public class TestObjRecConfig {
         className = BasicTestRetriever.class.getCanonicalName();
         ir = handler.getImageRetriever(className);
         assertFalse("Should succeed when given an image retriever", configIsFailed());
-        assertTrue(ir instanceof ImageRetrieverInterface);
+        assertNotNull(ir);
         assertTrue(ir instanceof BasicTestRetriever);
     }
     
@@ -107,7 +109,7 @@ public class TestObjRecConfig {
         // Should return null when not a valid class
         className = "Not a class";
         nn = handler.getNeuralNet(className);
-        assertTrue(nn == null);
+        assertNull(nn);
         assertTrue("Should fail when not given a valid class name", configIsFailed());
     }
     @Test
@@ -117,7 +119,7 @@ public class TestObjRecConfig {
         // Should return null when not a NeuralNetInterface
         className = this.getClass().getCanonicalName();
         nn = handler.getNeuralNet(className);
-        assertTrue(nn == null);
+        assertNull(nn);
         assertTrue("Should fail when not given a class that's not an image retriever", configIsFailed());
     }
     @Test
@@ -128,20 +130,20 @@ public class TestObjRecConfig {
         className = BasicTestNeuralNet.class.getCanonicalName();
         nn = handler.getNeuralNet(className);
         assertFalse("Should succeed when given an image retriever", configIsFailed());
-        assertTrue(nn instanceof NeuralNetInterface);
+        assertNotNull(nn);
         assertTrue(nn instanceof BasicTestNeuralNet);
     }
-    
+
     @Test
     public void testEmptyConfig() {
-        Map conf = new LinkedHashMap<>();
+        Map<String, Object> conf = new LinkedHashMap<>();
         sendConfig(conf);
         assertTrue("Should fail on empty configuration", configIsFailed());
     }
     
     @Test
     public void testMissingGeneral() {
-        Map conf = minimalConfig();
+        Map<String, Object> conf = minimalConfig();
         conf.remove("general");
         sendConfig(conf);
         assertTrue("Should fail when missing 'general' configuration", configIsFailed());
@@ -149,7 +151,7 @@ public class TestObjRecConfig {
     
     @Test
     public void testMissingDataSource() {
-        Map conf = minimalConfig();
+        Map<String, Object> conf = minimalConfig();
         conf.remove("dataSource");
         sendConfig(conf);
         assertTrue("Should fail when missing 'dataSource' configuration", configIsFailed());
@@ -157,7 +159,7 @@ public class TestObjRecConfig {
     
     @Test
     public void testMissingNeuralNet() {
-        Map conf = minimalConfig();
+        Map<String, Object> conf = minimalConfig();
         conf.remove("neuralNet");
         sendConfig(conf);
         assertTrue("Should fail when missing 'neuralNet' configuration", configIsFailed());
@@ -165,7 +167,7 @@ public class TestObjRecConfig {
     
     @Test
     public void testInvalidThreshold() {
-        Map conf = minimalConfig();
+        Map<String, Object> conf = minimalConfig();
         neuralNet.put("threshold", 1000);
         sendConfig(conf);
         assertFalse("Should not fail when threshold is large int.", configIsFailed());
@@ -178,7 +180,7 @@ public class TestObjRecConfig {
     
     @Test
     public void testValidThreshold() {
-        Map conf = minimalConfig();
+        Map<String, Object> conf = minimalConfig();
         neuralNet.put("threshold", 0);
         sendConfig(conf);
         assertFalse("Should not fail when threshold is 0.", configIsFailed());
@@ -196,9 +198,9 @@ public class TestObjRecConfig {
     
     @Test
     public void testInvalidThreadConfigs() {
-        Map conf = minimalConfig();
-        general.put("maxRunningThreads", "jibberish");
-        general.put("maxQueuedTasks", "moreJibberish");
+        Map<String, Object> conf = minimalConfig();
+        general.put("maxRunningThreads", "gibberish");
+        general.put("maxQueuedTasks", "moreGibberish");
         sendConfig(conf);
         assertFalse("Should not fail when thread config options are strings.", configIsFailed());
         
@@ -210,7 +212,7 @@ public class TestObjRecConfig {
     
     @Test
     public void testValidThreadConfigs() {
-        Map conf = minimalConfig();
+        Map<String, Object> conf = minimalConfig();
         general.put("maxRunningThreads", 5);
         general.put("maxQueuedTasks", 10);
         sendConfig(conf);
@@ -224,7 +226,7 @@ public class TestObjRecConfig {
 
     @Test
     public void testInvalidImageUploadConfig() {
-        Map conf = minimalConfig();
+        Map<String, Object> conf = minimalConfig();
         neuralNet.put("uploadAsImage", "jibberish");
         sendConfig(conf);
         assertFalse("Should not fail when image upload config is a string", configIsFailed());
@@ -236,7 +238,7 @@ public class TestObjRecConfig {
 
     @Test
     public void testValidImageUploadConfig() {
-        Map conf = minimalConfig();
+        Map<String, Object> conf = minimalConfig();
         neuralNet.put("uploadAsImage", true);
         sendConfig(conf);
         assertFalse("Should not fail when image upload config is true", configIsFailed());
@@ -250,7 +252,7 @@ public class TestObjRecConfig {
     public void testMinimalConfig() {
         nCore.start(5); // Need a client to avoid NPEs on sends
         
-        Map conf = minimalConfig();
+        Map<String, Object> conf = minimalConfig();
         sendConfig(conf);
         assertFalse("Should not fail with minimal configuration", configIsFailed());
         
@@ -258,14 +260,14 @@ public class TestObjRecConfig {
         general.put("pollTime", 300000);
         sendConfig(conf);
         assertFalse("Should not fail with minimal configuration", configIsFailed());
-        assertTrue("Timer should exist after pollTime set to positive number", nCore.pollTimer != null); 
+        assertNotNull("Timer should exist after pollTime set to positive number", nCore.pollTimer);
         
         // Making sure pollRate works (backwards compatibility)
         general.remove("pollTime");
         general.put("pollRate", 300000);
         sendConfig(conf);
         assertFalse("Should not fail with minimal configuration", configIsFailed());
-        assertTrue("Timer should exist after pollRate set to positive number", nCore.pollTimer != null); 
+        assertNotNull("Timer should exist after pollRate set to positive number", nCore.pollTimer);
         
         general.remove("pollRate");
         general.put("allowQueries", true);
@@ -276,7 +278,7 @@ public class TestObjRecConfig {
     @Test
     public void testEmptyPostProcessor() {
         postProcessor = new HashMap<>();
-        Map conf = minimalConfig();
+        Map<String, Object> conf = minimalConfig();
         sendConfig(conf);
         assertFalse("Should not fail with empty postProcessor", configIsFailed());
     }
@@ -285,11 +287,12 @@ public class TestObjRecConfig {
     public void testEmptyPPMapper() {
         postProcessor = new HashMap<>();
         postProcessor.put(ObjectRecognitionConfigHandler.LOCATION_MAPPER, new HashMap<String, Object>());
-        Map conf = minimalConfig();
+        Map<String, Object> conf = minimalConfig();
         sendConfig(conf);
         assertFalse("Should not fail with empty postProcessor", configIsFailed());
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testBadCoords() {
         postProcessor = new HashMap<>();
@@ -298,7 +301,7 @@ public class TestObjRecConfig {
         mapper.put(ObjectRecognitionConfigHandler.IMAGE_COORDINATES, imgCoords);
         postProcessor.put(ObjectRecognitionConfigHandler.LOCATION_MAPPER, mapper);
 
-        Map conf = minimalConfig();
+        Map<String, Object> conf = minimalConfig();
         sendConfig(conf);
         assertTrue("Should fail with missing mapping coordinate sets", configIsFailed());
 
@@ -372,6 +375,7 @@ public class TestObjRecConfig {
         assertTrue("Should fail with invalid coordinate lists (5)", configIsFailed());
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testInvalidResultSpec() {
         postProcessor = new HashMap<>();
@@ -403,16 +407,17 @@ public class TestObjRecConfig {
         }
 
         mapper.put(ObjectRecognitionConfigHandler.RESULTS_AS_GEOJSON, 37);
-        Map conf = minimalConfig();
+        Map<String, Object> conf = minimalConfig();
         sendConfig(conf);
         assertTrue("Should fail with non-boolean-ish " + ObjectRecognitionConfigHandler.RESULTS_AS_GEOJSON,
                 configIsFailed());
     }
 
+    @SuppressWarnings("rawtypes")
     @Test
     public void testValidPostProcessor() {
         postProcessor = new HashMap<>();
-        Map<String, Object> mapper = new HashMap<String,Object>();
+        Map<String, Object> mapper = new HashMap<>();
         List<Map> imgCoords = new ArrayList<>();
         List<Map> mappedCoords = new ArrayList<>();
 
@@ -439,25 +444,25 @@ public class TestObjRecConfig {
             imgCoords.add(aCoord);
         }
 
-        Map conf = minimalConfig();
+        Map<String, Object> conf = minimalConfig();
         sendConfig(conf);
         assertFalse("Should not fail with valid setup", configIsFailed());
 
-        mapper = new HashMap<String,Object>();
+        mapper = new HashMap<>();
         mapper.put(ObjectRecognitionConfigHandler.IMAGE_COORDINATES, imgCoords);
         mapper.put(ObjectRecognitionConfigHandler.MAPPED_COORDINATES, mappedCoords);
         mapper.put(ObjectRecognitionConfigHandler.RESULTS_AS_GEOJSON, true);
-        postProcessor = new HashMap<String, Object>();
+        postProcessor = new HashMap<>();
         postProcessor.put(ObjectRecognitionConfigHandler.LOCATION_MAPPER, mapper);
         conf = minimalConfig();
         sendConfig(conf);
         assertFalse("Should not fail with valid setup & resultsAsGeoJSON", configIsFailed());
 
-        mapper = new HashMap<String,Object>();
+        mapper = new HashMap<>();
         mapper.put(ObjectRecognitionConfigHandler.IMAGE_COORDINATES, imgCoords);
         mapper.put(ObjectRecognitionConfigHandler.MAPPED_COORDINATES, mappedCoords);
         mapper.put(ObjectRecognitionConfigHandler.RESULTS_AS_GEOJSON, "false");
-        postProcessor = new HashMap<String, Object>();
+        postProcessor = new HashMap<>();
         postProcessor.put(ObjectRecognitionConfigHandler.LOCATION_MAPPER, mapper);
         conf = minimalConfig();
         sendConfig(conf);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestFileRetriever.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestFileRetriever.java
@@ -211,7 +211,6 @@ public class TestFileRetriever extends ObjRecTestBase {
     
     @Test
     public void testVideoBasicRead() {
-        System.out.println("Reading & setting frame number");
         try {
             Map<String, String> config = new LinkedHashMap<>();
             config.put("fileLocation", VIDEO_LOCATION);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestFileRetriever.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestFileRetriever.java
@@ -244,7 +244,7 @@ public class TestFileRetriever extends ObjRecTestBase {
 
             int loopLimit = Math.min(50, frameCount);
             int loopCount = 0;
-            while (loopCount++ < loopLimit) {
+            while (loopCount < loopLimit) {
                 byte[] oldData = data2;
                 results = fr.getImage();
                 od = results.getOtherData();
@@ -257,6 +257,7 @@ public class TestFileRetriever extends ObjRecTestBase {
                 // So we'll expect it to be the two we started with (0 & 1 + another) == +2
                 assertEquals(loopCount + 2, nextFrameNumber);
                 assertNotEquals(oldData, data2);
+                loopCount += 1;
             }
         } catch (ImageAcquisitionException e) {
             fail("Exception occurred when obtaining image: " + e);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestFileRetriever.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestFileRetriever.java
@@ -245,6 +245,7 @@ public class TestFileRetriever extends ObjRecTestBase {
             int loopLimit = Math.min(50, frameCount);
             int loopCount = 0;
             while (loopCount < loopLimit) {
+                loopCount += 1;
                 byte[] oldData = data2;
                 results = fr.getImage();
                 od = results.getOtherData();
@@ -257,7 +258,6 @@ public class TestFileRetriever extends ObjRecTestBase {
                 // So we'll expect it to be the two we started with (0 & 1 + another) == +2
                 assertEquals(loopCount + 2, nextFrameNumber);
                 assertNotEquals(oldData, data2);
-                loopCount += 1;
             }
         } catch (ImageAcquisitionException e) {
             fail("Exception occurred when obtaining image: " + e);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestNetworkStreamRetriever.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestNetworkStreamRetriever.java
@@ -18,10 +18,9 @@ import io.vantiq.extsrc.objectRecognition.exception.ImageAcquisitionException;
 
 public class TestNetworkStreamRetriever extends ObjRecTestBase {
 
-    final static String RTSP_CAMERA_ADDRESS = "rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mp4";
+    static final String RTSP_CAMERA_ADDRESS = "rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mp4";
     // Alternate purportedly opened, but sometimes apparently broken...
     // "rtsp://demo:demo@ipvmdemo.dyndns.org:5541/onvif-media/media.amp?profile=profile_1_h264&sessiontimeout=60&streamtype=unicast";
-
 
     NetworkStreamRetriever retriever;
     NoSendORCore source;

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestNetworkStreamRetriever.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestNetworkStreamRetriever.java
@@ -19,8 +19,10 @@ public class TestNetworkStreamRetriever {
     NetworkStreamRetriever retriever;
     NoSendORCore source;
     
-    final String IP_CAMERA_URL = "http://153.142.207.158:80/-wvhttp-01-/GetOneShot?image_size=640x480&frame_count=1000000000";
-    
+//    final String IP_CAMERA_URL = "http://153.142.207.158:80/-wvhttp-01-/GetOneShot?image_size=640x480&frame_count=1000000000";
+    // Apparently new version of camera or camera software.  URL requires update...cd ../ve
+    final String IP_CAMERA_URL = "http://153.142.207.158:80/-wvhttp-01-/image.cgi?image_size=640x480&frame_count=1000000000";
+
     @Before
     public void setup() {
         source = new NoSendORCore("src", "token", "server", "dir");

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestNetworkStreamRetriever.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestNetworkStreamRetriever.java
@@ -18,7 +18,7 @@ import io.vantiq.extsrc.objectRecognition.exception.ImageAcquisitionException;
 
 public class TestNetworkStreamRetriever extends ObjRecTestBase {
 
-    final String RTSP_CAMERA_ADDRESS = "rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mp4";
+    final static String RTSP_CAMERA_ADDRESS = "rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mp4";
     // Alternate purportedly opened, but sometimes apparently broken...
     // "rtsp://demo:demo@ipvmdemo.dyndns.org:5541/onvif-media/media.amp?profile=profile_1_h264&sessiontimeout=60&streamtype=unicast";
 
@@ -63,7 +63,7 @@ public class TestNetworkStreamRetriever extends ObjRecTestBase {
     }
 
     @Test
-    public void testRTSPCamera() {
+    public void testRtspCamera() {
         // Don't fail if camera's offline...
         assumeTrue("Could not open requested url", isIpAccessible(IP_CAMERA_URL));
 
@@ -94,7 +94,7 @@ public class TestNetworkStreamRetriever extends ObjRecTestBase {
         // Override schema to make sure something exists at the other end.  The URL class doesn't necessarily
         // grok all the scheme's used by camera URLs, so we'll convert to a common version just so we can
         // test the connection.
-        String schemeFreeURL = url.substring(url.indexOf(":"));
+        String schemeFreeURL = url.substring(url.indexOf(':'));
         url = "http" + schemeFreeURL;
         try {
             img = new URL(url);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetTestBase.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetTestBase.java
@@ -28,6 +28,7 @@ import io.vantiq.extjsdk.Utils;
 import io.vantiq.extsrc.objectRecognition.ObjRecTestBase;
 import org.junit.BeforeClass;
 
+@SuppressWarnings({"PMD.MutableStaticState"})
 public class NeuralNetTestBase extends ObjRecTestBase {
     public static final String MODEL_DIRECTORY = System.getProperty("buildDir") + "/models";
     public static final String SOURCE_NAME = "testSourceName";

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
@@ -58,12 +58,24 @@ public class TestNoProcessor extends NeuralNetTestBase {
         if (testAuthToken != null && testVantiqServer != null) {
             vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
             vantiq.setAccessToken(testAuthToken);
+
+            try {
+                createSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception creating source impl: " + e);
+            }
         }
     }
 
     @AfterClass
     public static void deleteFromVantiq() throws InterruptedException {
         if (vantiq != null && vantiq.isAuthenticated()) {
+
+            try {
+                deleteSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception deleting source impl: " + e);
+            }
             // Deleting files saved as documents
             for (String vantiqSavedFile : vantiqSavedFiles) {
                 Thread.sleep(1000);
@@ -114,7 +126,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
 
     @Test
     public void testInvalidConfig() {
-        Map config = new LinkedHashMap<>();
+        Map<String, Object> config = new LinkedHashMap<>();
         NoProcessor npProcessor = new NoProcessor();
         NoProcessor npProcessor2 = new NoProcessor();
 
@@ -131,7 +143,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
 
     @Test
     public void testValidConfig() {
-        Map config = new LinkedHashMap<>();
+        Map<String, Object> config = new LinkedHashMap<>();
         NoProcessor npProcessor = new NoProcessor();
         NoProcessor npProcessor2 = new NoProcessor();
         NoProcessor npProcessor3 = new NoProcessor();
@@ -158,7 +170,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
 
         String lastFilename;
-        Map config = new LinkedHashMap<>();
+        Map<String, Object> config = new LinkedHashMap<>();
         NoProcessor npProcessor = new NoProcessor();
 
         config.put("outputDir", OUTPUT_DIR);
@@ -181,8 +193,10 @@ public class TestNoProcessor extends NeuralNetTestBase {
             // Should save first image with timestamp
             assert d.exists();
             assert d.isDirectory();
-            assert d.listFiles().length == 1;
-            assert d.listFiles()[0].getName().matches(timestampPattern);
+            File[] lf = d.listFiles();
+            assert lf != null;
+            assert lf.length == 1;
+            assert lf[0].getName().matches(timestampPattern);
 
             // Check it didn't save to VANTIQ
             lastFilename = "objectRecognition/" + SOURCE_NAME + '/' + npProcessor.lastFilename;
@@ -195,19 +209,21 @@ public class TestNoProcessor extends NeuralNetTestBase {
             // Every other so second should not save
             assert d.exists();
             assert d.isDirectory();
-            assert d.listFiles().length == 1;
+            lf = d.listFiles();
+            assert lf != null;
+            assert lf.length == 1;
             
-            
-            results = null;
             results = npProcessor.processImage(getTestImage());
             assert results.getResults() == null;
 
             // Every other so third and first should be saved
             assert d.exists();
             assert d.isDirectory();
-            assert d.listFiles().length == 2;
-            assert d.listFiles()[0].getName().matches(timestampPattern) || d.listFiles()[0].getName().matches(sameTimestampPattern);
-            assert d.listFiles()[1].getName().matches(timestampPattern) || d.listFiles()[1].getName().matches(sameTimestampPattern);
+            lf = d.listFiles();
+            assert lf != null;
+            assert lf.length == 2;
+            assert lf[0].getName().matches(timestampPattern) || lf[0].getName().matches(sameTimestampPattern);
+            assert lf[1].getName().matches(timestampPattern) || lf[1].getName().matches(sameTimestampPattern);
 
             // Check it didn't save to VANTIQ
             lastFilename = "objectRecognition/" + SOURCE_NAME + '/' + npProcessor.lastFilename;
@@ -231,7 +247,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
 
         String lastFilename;
-        Map config = new LinkedHashMap<>();
+        Map<String, Object> config = new LinkedHashMap<>();
         NoProcessor npProcessor = new NoProcessor();
 
         config.put("outputDir", OUTPUT_DIR);
@@ -252,8 +268,10 @@ public class TestNoProcessor extends NeuralNetTestBase {
             // Should save first image with timestamp
             assert d.exists();
             assert d.isDirectory();
-            assert d.listFiles().length == 1;
-            assert d.listFiles()[0].getName().matches(timestampPattern);
+            File[] lf = d.listFiles();
+            assert lf != null;
+            assert lf.length == 1;
+            assert lf[0].getName().matches(timestampPattern);
 
             // Checking that image was saved to VANTIQ
             Thread.sleep(1000);
@@ -268,18 +286,21 @@ public class TestNoProcessor extends NeuralNetTestBase {
             // Every other so second should not save
             assert d.exists();
             assert d.isDirectory();
-            assert d.listFiles().length == 1;
+            lf = d.listFiles();
+            assert lf != null;
+            assert lf.length == 1;
 
-            results = null;
             results = npProcessor.processImage(getTestImage());
             assert results.getResults() == null;
 
             // Every other so third and first should be saved
             assert d.exists();
             assert d.isDirectory();
-            assert d.listFiles().length == 2;
-            assert d.listFiles()[0].getName().matches(timestampPattern);
-            assert d.listFiles()[1].getName().matches(timestampPattern);
+            lf = d.listFiles();
+            assert lf != null;
+            assert lf.length == 2;
+            assert lf[0].getName().matches(timestampPattern);
+            assert lf[1].getName().matches(timestampPattern);
 
             // Checking that image was saved to VANTIQ
             Thread.sleep(1000);
@@ -306,7 +327,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
 
         String lastFilename;
-        Map config = new LinkedHashMap<>();
+        Map<String, Object> config = new LinkedHashMap<>();
         NoProcessor npProcessor = new NoProcessor();
 
         config.put("outputDir", OUTPUT_DIR);
@@ -349,7 +370,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
 
         String lastFilename;
-        Map config = new LinkedHashMap<>();
+        Map<String, Object> config = new LinkedHashMap<>();
         NoProcessor npProcessor = new NoProcessor();
 
         config.put("outputDir", OUTPUT_DIR);
@@ -370,7 +391,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
                 deleteDirectory(queryOutputDir);
             }
 
-            Map request = new LinkedHashMap<>();
+            Map<String, String> request = new LinkedHashMap<>();
             NeuralNetResults results = npProcessor.processImage(getTestImage(), request);
             assert results.getResults().isEmpty();
 
@@ -391,7 +412,6 @@ public class TestNoProcessor extends NeuralNetTestBase {
             request.remove("NNsaveImage");
             request.put("NNsaveImage", "vantiq");
             request.put("NNfileName", queryOutputFileVantiq);
-            results = null;
             results = npProcessor.processImage(getTestImage(), request);
             assert results.getResults().isEmpty();
 
@@ -407,15 +427,16 @@ public class TestNoProcessor extends NeuralNetTestBase {
             request.put("NNsaveImage", "both");
             request.put("NNfileName", queryOutputFile);
             request.put("NNoutputDir", queryOutputDir);
-            results = null;
             results = npProcessor.processImage(getTestImage(), request);
             assert results.getResults().isEmpty();
 
             // Should have saved the image at queryOutputFile + ".jpg"
             assert dNew.exists();
             assert dNew.isDirectory();
-            assert dNew.listFiles().length == 1;
-            assert dNew.listFiles()[0].getName().equals(queryOutputFile + ".jpg");
+            File[] lf = dNew.listFiles();
+            assert lf != null;
+            assert lf.length == 1;
+            assert lf[0].getName().equals(queryOutputFile + ".jpg");
 
             // Checking that image was saved in VANTIQ
             Thread.sleep(1000);
@@ -427,7 +448,6 @@ public class TestNoProcessor extends NeuralNetTestBase {
             request.remove("NNfileName");
             request.remove("NNsaveImage");
             request.put("NNsaveImage", "local");
-            results = null;
             results = npProcessor.processImage(getTestImage(), request);
             assert results.getResults().isEmpty();
 
@@ -435,6 +455,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
             assert dNew.exists();
             assert dNew.isDirectory();
             File[] listOfFiles = dNew.listFiles();
+            assert listOfFiles != null;
             assert listOfFiles.length == 2;
 
             // listFiles() Returns data in no specific order, so we check to make sure we are grabbing correct file
@@ -451,11 +472,12 @@ public class TestNoProcessor extends NeuralNetTestBase {
 
             queryOutputFile += ".jpeg";
             request.put("NNfileName", queryOutputFile);
-            results = null;
             results = npProcessor.processImage(getTestImage(), request);
             assert results.getResults().isEmpty();
 
-            assert dNew.listFiles().length == 3;
+            listOfFiles = dNew.listFiles();
+            assert listOfFiles != null;
+            assert listOfFiles.length == 3;
 
         } finally {
             // delete the directory even if the test fails
@@ -476,7 +498,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
 
         String lastFilename;
-        Map config = new LinkedHashMap<>();
+        Map<String, Object> config = new LinkedHashMap<>();
         NoProcessor npProcessor = new NoProcessor();
 
         config.put("outputDir", OUTPUT_DIR);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
@@ -1,5 +1,6 @@
 package io.vantiq.extsrc.objectRecognition.neuralNet;
 
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
@@ -7,6 +8,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -25,7 +27,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
     static final int CORE_START_TIMEOUT = 10;
     static final String OUTPUT_DIR = System.getProperty("buildDir") + "/resources/out";
     static final String SOURCE_NAME = "UnlikelyToExistTestObjectRecognitionSource";
-    static final String IP_CAMERA_ADDRESS = "http://207.192.232.2:8000/mjpg/video.mjpg";
+    static final String IP_CAMERA_ADDRESS = "http://60.45.181.202:8080/mjpg/quad/video.mjpg";
     static final String QUERY_FILENAME = "testFile";
     static final Map<String,String> IMAGE = new LinkedHashMap<String,String>() {{
         put("filename", "objectRecognition/" + SOURCE_NAME + "/" + QUERY_FILENAME + ".jpg");
@@ -37,6 +39,13 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         if (testVantiqServer != null && testAuthToken != null) {
             vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
             vantiq.setAccessToken(testAuthToken);
+
+            try {
+                createServerConfig();
+                createSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception creating source impl: " + e);
+            }
 
             setupSource(createSourceDef());
         }
@@ -52,6 +61,11 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         if (vantiq != null && vantiq.isAuthenticated()) {
             deleteSource();
 
+            try {
+                deleteSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception deleting source impl: " + e);
+            }
             for (String vantiqUploadFile : vantiqUploadFiles) {
                 deleteFileFromVantiq(vantiqUploadFile);
             }
@@ -83,6 +97,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         File[] outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE.get("name") + ".jpg");
         
@@ -100,6 +115,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE.get("name") + ".jpg");
         
@@ -117,6 +133,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to the last saved file
         outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         
         int index = core.lastQueryFilename.lastIndexOf('/') + 1;
@@ -190,6 +207,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         File[] outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE.get("name") + ".jpg");
         
@@ -214,6 +232,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE.get("name") + ".jpg");
         
@@ -238,6 +257,8 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to the last saved file
         outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         
         int index = core.lastQueryFilename.lastIndexOf('/') + 1;

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
@@ -256,7 +256,6 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         // Check there is only one file, and it's name is equivalent to the last saved file
         outputDirFiles = outputDir.listFiles();
         assert outputDirFiles != null;
-        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         
         int index = core.lastQueryFilename.lastIndexOf('/') + 1;

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
@@ -21,13 +22,22 @@ public class TestParallelProcessing extends NeuralNetTestBase {
 
     static final String FAKE_MODEL_DIR = "";
     static final int CORE_START_TIMEOUT = 10;
-    static final String IP_CAMERA_ADDRESS = "http://207.192.232.2:8000/mjpg/video.mjpg";
+    // Camera here not really used -- just need it to set up
+    static final String IP_CAMERA_ADDRESS = "http://60.45.181.202:8080/mjpg/video.mjpg";
+
 
     @BeforeClass
     public static void classSetup() {
         if (testVantiqServer != null && testAuthToken != null) {
             vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
             vantiq.setAccessToken(testAuthToken);
+
+            try {
+                createServerConfig();
+                createSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception creating source impl: " + e);
+            }
         }
     }
 
@@ -39,6 +49,12 @@ public class TestParallelProcessing extends NeuralNetTestBase {
             deleteSource(vantiq);
             deleteType(vantiq);
             deleteRule(vantiq);
+
+            try {
+                deleteSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception deleting source impl: " + e);
+            }
         }
     }
 

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
@@ -103,6 +103,12 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
             vantiqUploadFiles.add(IMAGE_5.get("filename"));
             vantiqUploadFiles.add(IMAGE_6.get("filename"));
             vantiqUploadFiles.add(IMAGE_7.get("filename"));
+
+            try {
+                createSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception creating source impl: " + e);
+            }
         }
     }
     
@@ -139,6 +145,14 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     @SuppressWarnings("PMD.JUnit4TestShouldUseAfterAnnotation")
     @AfterClass
     public static void tearDown() {
+
+        if (vantiq != null) {
+            try {
+                deleteSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception deleting source impl: " + e);
+            }
+        }
         core.stop();
     }
     

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -1154,7 +1154,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             assert !dNew.exists();
 
             // Checking that image was saved in VANTIQ
-            Thread.sleep(1000); //. FIXME was 1 sec
+            Thread.sleep(1000);
             checkUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_DOCUMENTS);
             vantiqSavedFiles.add(results.getLastFilename());
 

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -1176,7 +1176,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             // Should have saved the image at queryOutputFile + ".jpg"
             assert dNew.exists();
             assert dNew.isDirectory();
-            File[] lf = d.listFiles();
+            File[] lf = dNew.listFiles();
             assert lf != null;
             assert lf.length == 1;
             assert lf[0].getName().equals(queryOutputFile + ".jpg");

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -54,7 +54,7 @@ import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
 
-@SuppressWarnings("PMD.ExcessiveClassLength")
+@SuppressWarnings({"PMD.ExcessiveClassLength", "PMD.AbbreviationAsWordInNameCheck"})
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class TestYoloProcessor extends NeuralNetTestBase {
 
@@ -340,7 +340,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Test
-    public void testRealJSONConfig() throws IOException {
+    public void testRealJsonConfig() throws IOException {
         String expectedResults = imageResultsAsString; // imageResultsAsStringWithoutServer;
         if (testAuthToken != null && testVantiqServer != null) {
             expectedResults = imageResultsAsString;
@@ -1791,7 +1791,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
 
-        Map <String, Object> config = new LinkedHashMap<>();
+        Map<String, Object> config = new LinkedHashMap<>();
         YoloProcessor ypImageSaver = new YoloProcessor();
 
         config.put("pbFile", PB_FILE);
@@ -1946,7 +1946,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     void resultsEquals(List<Map<String, ?>> list, List<Map> expectedRes) {
-        assertEquals("list Size: " + list.size() + ", expected: "+ expectedRes.size() +" :: " + list,
+        assertEquals("list Size: " + list.size() + ", expected: " + expectedRes.size() + " :: " + list,
                 expectedRes.size(), list.size());
         for (int i = 0; i < list.size(); i++) {
             mapEquals(list.get(i), expectedRes.get(i));
@@ -1985,7 +1985,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         return new ExtensionServiceMessage("").fromMap(msg);
     }
 
-    public static void setupSource(Map<String,Object> sourceDef) {
+    public static void setupSource(Map<String, Object> sourceDef) {
         VantiqResponse insertResponse = vantiq.insert("system.sources", sourceDef);
         if (insertResponse.isSuccess()) {
             core = new ObjectRecognitionCore(testSourceName, testAuthToken, testVantiqServer, MODEL_DIRECTORY);
@@ -1993,13 +1993,13 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         }
     }
 
-    public static Map<String,Object> createSourceDef(boolean suppressNullValues) {
-        Map<String,Object> sourceDef = new LinkedHashMap<>();
-        Map<String,Object> sourceConfig = new LinkedHashMap<>();
-        Map<String,Object> objRecConfig = new LinkedHashMap<>();
-        Map<String,Object> general = new LinkedHashMap<>();
-        Map<String,Object> dataSource = new LinkedHashMap<>();
-        Map<String,Object> neuralNet = new LinkedHashMap<>();
+    public static Map<String, Object> createSourceDef(boolean suppressNullValues) {
+        Map<String, Object> sourceDef = new LinkedHashMap<>();
+        Map<String, Object> sourceConfig = new LinkedHashMap<>();
+        Map<String, Object> objRecConfig = new LinkedHashMap<>();
+        Map<String, Object> general = new LinkedHashMap<>();
+        Map<String, Object> dataSource = new LinkedHashMap<>();
+        Map<String, Object> neuralNet = new LinkedHashMap<>();
 
         // Setting up general config options
         general.put("pollTime", 1000);
@@ -2035,9 +2035,9 @@ public class TestYoloProcessor extends NeuralNetTestBase {
     }
 
     public static void setupType() {
-        Map<String,Object> typeDef = new LinkedHashMap<>();
-        Map<String,Object> properties = new LinkedHashMap<>();
-        Map<String,Object> propertyDef = new LinkedHashMap<>();
+        Map<String, Object> typeDef = new LinkedHashMap<>();
+        Map<String, Object> properties = new LinkedHashMap<>();
+        Map<String, Object> propertyDef = new LinkedHashMap<>();
         propertyDef.put("type", "Object");
         propertyDef.put("multi", true);
         propertyDef.put("required", true);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -1154,7 +1154,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             assert !dNew.exists();
 
             // Checking that image was saved in VANTIQ
-            Thread.sleep(10000); //. FIXME was 1 sec
+            Thread.sleep(1000); //. FIXME was 1 sec
             checkUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_DOCUMENTS);
             vantiqSavedFiles.add(results.getLastFilename());
 

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -1008,7 +1008,8 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         return sourceDef;
     }
-    
+
+    @SuppressWarnings({"PMD.DetachedTestCase"})
     public void addLocalTestImages() throws IOException {
         assert new File(OUTPUT_DIR).mkdirs();
         

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -50,7 +50,11 @@ public class TestYoloQueries extends NeuralNetTestBase {
     static final String PB_FILE = "coco-" + COCO_MODEL_VERSION + ".pb";
     static final String META_FILE = "coco-" + COCO_MODEL_VERSION + ".meta";
     static final String OUTPUT_DIR = System.getProperty("buildDir") + "/resources/out";
-    static final String IP_CAMERA_ADDRESS = "http://207.192.232.2:8000/mjpg/video.mjpg";
+
+    // Used for pre-cropping tests
+    static final int IP_CAMERA_WIDTH = 704;
+    static final int IP_CAMERA_HEIGHT = 480;
+    static final String IP_CAMERA_ADDRESS = "http://60.45.181.202:8080/mjpg/quad/video.mjpg";
 
     static final String IMAGE_1_DATE = "2019-02-05--02-35-10";
     static final Map<String,String> IMAGE_1 = new LinkedHashMap<String,String>() {{
@@ -107,12 +111,10 @@ public class TestYoloQueries extends NeuralNetTestBase {
     static final int PRECROP_TOP_LEFT_Y_COORDINATE = 50;
     static final int CROPPED_WIDTH = 200;
     static final int CROPPED_HEIGHT = 150;
-    static final int IP_CAMERA_WIDTH = 800;
-    static final int IP_CAMERA_HEIGHT = 450;
 
     
     @BeforeClass
-    public static void setup() {
+    public static void setup() throws Exception {
         if (testAuthToken != null && testVantiqServer != null) {
 
             vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
@@ -128,6 +130,12 @@ public class TestYoloQueries extends NeuralNetTestBase {
             vantiqUploadFiles.add(IMAGE_7.get("filename"));
             vantiqUploadFiles.add(IMAGE_8.get("filename"));
 
+            try {
+                createSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception creating source impl: " + e);
+            }
+            createServerConfig();
             setupSource(createSourceDef());
         }
     }
@@ -141,6 +149,12 @@ public class TestYoloQueries extends NeuralNetTestBase {
         }
         if (vantiq != null && vantiq.isAuthenticated()) {
             deleteSource(vantiq);
+
+            try {
+                deleteSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Trapped exception deleting source impl: " + e);
+            }
 
             for (String vantiqUploadFile : vantiqUploadFiles) {
                 deleteFileFromVantiq(vantiqUploadFile);
@@ -205,6 +219,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         File[] outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE_8.get("name") + ".jpg");
         
@@ -222,6 +237,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE_8.get("name") + ".jpg");
         
@@ -239,6 +255,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to the last saved file
         outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         
         int index = core.lastQueryFilename.lastIndexOf('/') + 1;
@@ -312,6 +329,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         File[] outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE_8.get("name") + ".jpg");
         
@@ -336,6 +354,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE_8.get("name") + ".jpg");
         
@@ -360,6 +379,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to the last saved file
         outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         
         int index = core.lastQueryFilename.lastIndexOf('/') + 1;
@@ -572,8 +592,8 @@ public class TestYoloQueries extends NeuralNetTestBase {
         vantiqResponse = vantiq.selectOne("system.documents", IMAGE_2.get("filename"));
         if (vantiqResponse.hasErrors()) {
             List<VantiqError> errors = vantiqResponse.getErrors();
-            for (int i = 0; i < errors.size(); i++) {
-                if (errors.get(i).getCode().equals(NOT_FOUND_CODE)) {
+            for (VantiqError error : errors) {
+                if (error.getCode().equals(NOT_FOUND_CODE)) {
                     fail();
                 }
             }
@@ -613,6 +633,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         File outputDir = new File(OUTPUT_DIR);
         assert outputDir.exists();
         File[] outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 7;
         
         for (File file : outputDirFiles) {
@@ -644,7 +665,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         File d = new File(OUTPUT_DIR);
         File[] dList = d.listFiles();
-        
+        assert dList != null;
         assert dList.length == 1;
         assert dList[0].getName().equals(IMAGE_8.get("name") + ".jpg");
     }
@@ -669,7 +690,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         File d = new File(OUTPUT_DIR);
         File[] dList = d.listFiles();
-        
+        assert dList != null;
         assert dList.length == 6;
         
         for (File imageFile: dList) {
@@ -699,7 +720,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         File d = new File(OUTPUT_DIR);
         File[] dList = d.listFiles();
-        
+        assert dList != null;
         assert dList.length == 2;
         for (File file : dList) {
             assert file.getName().equals(IMAGE_1.get("date") + ".jpg") || file.getName().equals(IMAGE_8.get("name") + ".jpg");
@@ -726,7 +747,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
 
         File d = new File(OUTPUT_DIR);
         File[] dList = d.listFiles();
-        
+        assert dList != null;
         assert dList.length == 5;
         
         for (File imageFile: dList) {
@@ -764,12 +785,14 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         File[] outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals("testInvalidPreCrop.jpg");
         
         File resizedImageFile = new File(OUTPUT_DIR + "/" + outputDirFiles[0].getName());
         BufferedImage resizedImage = ImageIO.read(resizedImageFile);
-        
+
+        System.out.println("New size: w: " + resizedImage.getWidth() + ", h: " +resizedImage.getHeight());
         assert resizedImage.getWidth() == IP_CAMERA_WIDTH;
         assert resizedImage.getHeight() == IP_CAMERA_HEIGHT;
     }
@@ -806,6 +829,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         File[] outputDirFiles = outputDir.listFiles();
+        assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals("testPreCrop.jpg");
         
@@ -818,9 +842,6 @@ public class TestYoloQueries extends NeuralNetTestBase {
 
     @Test
     public void testUploadAsImage() throws IOException, InterruptedException {
-        // Only run test with intended vantiq availability
-        assumeTrue(testAuthToken != null && testVantiqServer != null);
-
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
 
@@ -992,9 +1013,10 @@ public class TestYoloQueries extends NeuralNetTestBase {
     }
     
     public void addLocalTestImages() throws IOException {
-        new File(OUTPUT_DIR).mkdirs();
+        assert new File(OUTPUT_DIR).mkdirs();
         
         byte[] testImageBytes = getTestImage();
+        assert testImageBytes != null;
         InputStream in = new ByteArrayInputStream(testImageBytes);
         BufferedImage testImageBuffer = ImageIO.read(in);
         

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -37,6 +37,7 @@ import io.vantiq.client.VantiqResponse;
 import io.vantiq.extsrc.objectRecognition.ObjectRecognitionCore;
 import okio.BufferedSource;
 
+@SuppressWarnings({"PMD.ExcessiveClassLength"})
 public class TestYoloQueries extends NeuralNetTestBase {
     
     static Vantiq vantiq;

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueriesLocationMapper.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueriesLocationMapper.java
@@ -229,6 +229,14 @@ public class TestYoloQueriesLocationMapper extends NeuralNetTestBase {
         return mapper;
     }
 
+    /**
+     * Create basic source definition.  In this case, we'll define the source to read from our supplied
+     * file.  This allows a consistent set of results rather than depending upon some arbitrary camera
+     * feed to provide enough targets.
+     *
+     * @param imgConvSpec
+     * @return
+     */
     public static Map<String,Object> createSourceDef(Map<String, Object> imgConvSpec) {
         Map<String,Object> sourceDef = new LinkedHashMap<String,Object>();
         Map<String,Object> sourceConfig = new LinkedHashMap<String,Object>();
@@ -238,8 +246,9 @@ public class TestYoloQueriesLocationMapper extends NeuralNetTestBase {
         Map<String,Object> neuralNet = new LinkedHashMap<String,Object>();
 
         // Setting up dataSource config options
-        dataSource.put("camera", IP_CAMERA_URL);
-        dataSource.put("type", "network");
+        dataSource.put("fileLocation", VIDEO_LOCATION);
+        dataSource.put("fileExtension", "mov");
+        dataSource.put("type", "file");
 
         // Setting up general config options
         general.put("allowQueries", true);

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,11 +4,9 @@ include 'extjsdk'
 include 'udpSource'
 include 'CSVSource'
 include 'testConnector'
+include 'objectRecognitionSource'
 if (System.env.EASY_MODBUS_LOC) {
     include 'EasyModbusSource' 
-}
-if (System.env.OPENCV_LOC) {
-    include 'objectRecognitionSource'
 }
 if (System.env.JDBC_DRIVER_LOC) {
     include 'jdbcSource'


### PR DESCRIPTION
Fixes #287 

(Apologies for the size of the PR.  There's really no way to do this incrementally.)

This PR substantially changes the way the Object Recognition Connector is built.  Previously, builders needed to have downloaded & built OpenCV -- which was sometimes no mean feat.  This PR changes the base from OpenCV to JavaCV, a more packaged solution that includes all of OpenCV (the same underlying technology is used).  This should make it easier to build the OR connector.

Additionally, some tests have been added & others cleaned up.  A fair amount of code cleanup was performed as well.