### PR TITLE
Handle occasional status message

### DIFF
--- a/extpsdk/build.gradle
+++ b/extpsdk/build.gradle
@@ -11,7 +11,7 @@ ext {
         pypi_repo = 'testpypi'
     }
     if (!project.rootProject.hasProperty('vantiqConnectorSdkVersion')) {
-        vantiqConnectorSdkVersion = '1.1.9'
+        vantiqConnectorSdkVersion = '1.1.10'
     }
 }
 

--- a/extpsdk/src/main/python/vantiqconnectorsdk.py
+++ b/extpsdk/src/main/python/vantiqconnectorsdk.py
@@ -434,6 +434,9 @@ class VantiqSourceConnection:
                     status = resp[_STATUS]
                     if status >= 300:
                         return _CONNECTION_FAILED
+                    # Sometimes we get a status message back.  If so & it's OK, wait for the config message
+                    raw_resp = await websocket.recv()
+                    resp = json.loads(raw_resp)
 
                 # Otherwise, we should have a configExtension message
                 if _OPERATION in resp.keys():


### PR DESCRIPTION
Fixes #328

Vantiq server _sometimes_ sends a status message after a connect, sometimes not.  It appears to be more prevalent with https connections, but not exclusive.

Add code so that when a status message is received there (and is successful), we read again to get the connect extension message.  Otherwise, the protocol is out of sync and the connection never completes.