### PR TITLE
A variety of minor fixes to PythonExecConnector

### DIFF
--- a/pythonExecSource/README.md
+++ b/pythonExecSource/README.md
@@ -104,4 +104,5 @@ VANTIQ_PASSWORD <Password for that Vantiq user>
 
 ## Copyright and License
 
-Copyright &copy; 2022 Vantiq, Inc.  Code released under the [MIT license](./LICENSE.txt).
+Copyright &copy; 2022 Vantiq, Inc.  Code released under the
+[MIT license](https://github.com/Vantiq/vantiq-extension-sources/blob/master/pythonExecSource/LICENSE.txt).

--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -12,7 +12,7 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('pyExecSrcVersion')) {
-        pyExecSrcVersion = '1.1.9'
+        pyExecSrcVersion = '1.1.10'
     }
     vantiqSdkVersion = '1.1.1'
     vantiqConnectorSdkVersion = '1.1.10'

--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -15,7 +15,7 @@ ext {
         pyExecSrcVersion = '1.1.10'
     }
     vantiqSdkVersion = '1.1.2'
-    vantiqConnectorSdkVersion = '1.1.11'
+    vantiqConnectorSdkVersion = '1.1.12'
 }
 
 python {

--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -14,8 +14,8 @@ ext {
     if (!project.rootProject.hasProperty('pyExecSrcVersion')) {
         pyExecSrcVersion = '1.1.10'
     }
-    vantiqSdkVersion = '1.1.1'
-    vantiqConnectorSdkVersion = '1.1.10'
+    vantiqSdkVersion = '1.1.2'
+    vantiqConnectorSdkVersion = '1.1.11'
 }
 
 python {

--- a/pythonExecSource/docs/Usage.md
+++ b/pythonExecSource/docs/Usage.md
@@ -32,6 +32,14 @@ Note: The term _extension source_ is an older term, but it is still evident in t
 
 ## Python Execution Connector Operation
 
+### Warning
+
+This connector provides the ability to execute arbitrary Python code. That code will run in the same context in which the connector runs. That is, it will start in the same working directory and run with the same privileges at the connector itself.
+
+This means that _malicious_ code could be executed, and it could do anything that any other Python script could do. While this is generally the goal, it is important to recognize this and take appropriate precautions to control developer access to the namespace in which the Python Execution Connector is defined.
+
+Note that this is no different than any other connector (JDBC, JMS, etc.) where the connector can affect the state of the system to which it is connected. The execution of Python code just makes the possibilities more obvious.
+
 ### Defining the Source in Vantiq
 
 #### Creating the Source
@@ -98,6 +106,8 @@ here we will provide a few examples.
 
 #### Query from Vantiq
 
+(See the [Warning](#warning) section.)
+
 To execute some Python code,
 you can run a query using the SELECT statement.
 
@@ -159,9 +169,6 @@ def main():
     loop = asyncio.get_event_loop()
     tasks = []
     tasks.append(loop.create_task(looper(loop_count)))
-    print('Looper -- about to wait for the loop')
-    asyncio.gather(*tasks)
-    print('Looper -- done with wait')
 
     
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #336 -- after timeout, connector sometimes becomes unresponsive
Fixes #335 -- better reportage of compile errors in query-provided code
Fixes #334 -- better reportage of errors in query-provided code
Fixes #332 -- print message that connector is up
(no issue) -- Fix README.md links to be full links so that the readme on pypi will work correctly.
(no issue) -- Update dependency versions based on their updates (to their readme's)

Fixes for a variety of minor issues.  Added tests for these where applicable