### PR TITLE
Update to recent Vantiq SDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ group 'io.vantiq'
 ext {
     slf4jApiVersion = '1.7.25'
     eclipseMiloVersion = '0.2.1'
-    vantiqSDKVersion = '1.0.31'
+    vantiqSDKVersion = '1.1.1'
     log4jVersion = '2.17.0'
     lombokVersion = '1.18.24'
 }

--- a/jdbcSource/build.gradle
+++ b/jdbcSource/build.gradle
@@ -74,6 +74,7 @@ dependencies {
     // Use JUnit test framework
     testImplementation 'junit:junit:4.12'
     testImplementation project(path:":extjsdk", configuration:"testArtifacts")
+    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.9.3"
 
     // Used to create a connection pool if asynchronous processing has been specified for publish/query handlers
     implementation group: 'com.zaxxer', name: 'HikariCP', version: '3.3.1'

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -306,11 +306,7 @@ public class TestJDBC extends TestJDBCBase {
             deleteProcedure();
             deleteRule();
 
-            try {
-                deleteSourceImpl(vantiq);
-            } catch (Exception e) {
-                // Not much we can do here...
-            }
+            deleteSourceImpl(vantiq);
         }
 
         // Close JDBCCore if still open

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCBase.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCBase.java
@@ -8,9 +8,29 @@
 
 package io.vantiq.extsrc.jdbcSource;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vantiq.client.Vantiq;
+import io.vantiq.client.VantiqError;
+import io.vantiq.client.VantiqResponse;
 import org.junit.BeforeClass;
 
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
 public class TestJDBCBase {
+
+    public static final String JDBC_SRC_TYPE = "JDBC";
+    public static final String JDBC_IMPL_DEF = "jdbcImpl.json";
+    private static final Integer JDBC_IMPL_MAX_SIZE = 1000;
+
+    static final String VANTIQ_SOURCE_IMPL = "system.sourceimpls";
     static String testDBUsername;
     static String testDBPassword;
     static String testDBURL;
@@ -36,5 +56,53 @@ public class TestJDBCBase {
         testProcedureName = System.getProperty("EntConTestProcedureName", "testProcedureName");
         testRuleName = System.getProperty("EntConTestRuleName", "testRuleName");
         testTopicName = System.getProperty("EntConTestTopicName", "/test/topic/name");
+    }
+
+    static boolean createdImpl = false;
+    @SuppressWarnings("unchecked")
+    protected static void createSourceImpl(Vantiq vantiq) throws Exception {
+        VantiqResponse resp = vantiq.selectOne(VANTIQ_SOURCE_IMPL, JDBC_SRC_TYPE);
+        if (!resp.isSuccess()) {
+            ClassLoader loader = Thread.currentThread().getContextClassLoader();
+            byte[] implDef = new byte[JDBC_IMPL_MAX_SIZE];
+            try (InputStream is = loader.getResourceAsStream(JDBC_IMPL_DEF))
+            {
+                assert is != null;
+                int implSize = is.read(implDef);
+                assert implSize > 0;
+                assert implSize < JDBC_IMPL_MAX_SIZE;
+            }
+
+            ObjectMapper mapper = new ObjectMapper();
+            Map<String, Object> implMap = new LinkedHashMap<>();
+            implMap = mapper.readValue(implDef, implMap.getClass());
+            resp = vantiq.insert(VANTIQ_SOURCE_IMPL, implMap);
+            assert resp.isSuccess();
+
+            Map<String, String> where = new LinkedHashMap<>();
+            where.put("name", "JDBC");
+            VantiqResponse implResp = vantiq.select(VANTIQ_SOURCE_IMPL, null, where, null);
+            assertFalse("Errors from fetching source impl", implResp.hasErrors());
+            ArrayList responseBody = (ArrayList) implResp.getBody();
+            assertEquals("Missing sourceimpl -- expected a count of 1", 1, responseBody.size());
+            createdImpl = true;
+        }
+    }
+
+    protected static void deleteSourceImpl(Vantiq vantiq) throws Exception {
+        if (createdImpl) {
+            vantiq.deleteOne(VANTIQ_SOURCE_IMPL, JDBC_SRC_TYPE);
+            createdImpl = false;
+        }
+
+        VantiqResponse resp = vantiq.selectOne(VANTIQ_SOURCE_IMPL, JDBC_SRC_TYPE);
+        if (resp.hasErrors()) {
+            List<VantiqError> errors = resp.getErrors();
+            if (errors.size() != 1 || !errors.get(0).getCode().equals("io.vantiq.resource.not.found")) {
+                fail("Error deleting source impl" + resp.getErrors());
+            }
+        } else {
+            fail(JDBC_SRC_TYPE + " source impl found after deletion.");
+        }
     }
 }

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCBase.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCBase.java
@@ -58,7 +58,7 @@ public class TestJDBCBase {
         testTopicName = System.getProperty("EntConTestTopicName", "/test/topic/name");
     }
 
-    static boolean createdImpl = false;
+    private static boolean createdImpl = false;
     @SuppressWarnings("unchecked")
     protected static void createSourceImpl(Vantiq vantiq) throws Exception {
         VantiqResponse resp = vantiq.selectOne(VANTIQ_SOURCE_IMPL, JDBC_SRC_TYPE);

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCBase.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCBase.java
@@ -83,13 +83,14 @@ public class TestJDBCBase {
             where.put("name", "JDBC");
             VantiqResponse implResp = vantiq.select(VANTIQ_SOURCE_IMPL, null, where, null);
             assertFalse("Errors from fetching source impl", implResp.hasErrors());
+            @SuppressWarnings({"rawtypes"})
             ArrayList responseBody = (ArrayList) implResp.getBody();
-            assertEquals("Missing sourceimpl -- expected a count of 1", 1, responseBody.size());
+            assertEquals("Missing sourceImpl -- expected a count of 1", 1, responseBody.size());
             createdImpl = true;
         }
     }
 
-    protected static void deleteSourceImpl(Vantiq vantiq) throws Exception {
+    protected static void deleteSourceImpl(Vantiq vantiq) {
         if (createdImpl) {
             vantiq.deleteOne(VANTIQ_SOURCE_IMPL, JDBC_SRC_TYPE);
             createdImpl = false;


### PR DESCRIPTION
Fixes #344 

Upgrade to use most recent Vantiq SDK (1.1.1).

Also, correct JDBC tests to create their sourceimpl in Vantiq as needed.  Simplifies test setup (since I always forget to set it up ahead of time).  Side effect -- verifies that the one we supply as a test resource works :-).