### PR TITLE
Enable including of Base64-encoded image in results

### DIFF
--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCBase.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCBase.java
@@ -93,7 +93,6 @@ public class TestJDBCBase {
     protected static void deleteSourceImpl(Vantiq vantiq) {
         if (createdImpl) {
             vantiq.deleteOne(VANTIQ_SOURCE_IMPL, JDBC_SRC_TYPE);
-            createdImpl = false;
         }
 
         VantiqResponse resp = vantiq.selectOne(VANTIQ_SOURCE_IMPL, JDBC_SRC_TYPE);
@@ -102,7 +101,7 @@ public class TestJDBCBase {
             if (errors.size() != 1 || !errors.get(0).getCode().equals("io.vantiq.resource.not.found")) {
                 fail("Error deleting source impl" + resp.getErrors());
             }
-        } else {
+        } else if (createdImpl) {
             fail(JDBC_SRC_TYPE + " source impl found after deletion.");
         }
     }

--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -165,21 +165,21 @@ The Configuration document may look similar to the following example:
 ### Options Available for General
 At least one of these options must be set for the source to function
 
-*   pollTime: This indicates how often an image should be captured. A positive number represents the number of
+*   `pollTime`: This indicates how often an image should be captured. A positive number represents the number of
 milliseconds between captures. If the specified time is less than the amount of time it takes to process the image then
 images will be taken as soon as the previous finishes. If this is set to 0, the next image will be captured as soon as
 the previous is sent. 
     *   (**NOTE:** Previously named "pollRate". For a limited amount of time, both "pollTime" and "pollRate"
     will be valid General Config options, but in the future only "pollTime" will be supported.)
-*   allowQueries: This option allows Queries to be received when set to `true'
-*   maxRunningThreads: Optional. Only used if `pollTime` has been specified. The maximum number of threads running at any 
+*   `allowQueries`: This option allows Queries to be received when set to `true'
+*   `maxRunningThreads`: Optional. Only used if `pollTime` has been specified. The maximum number of threads running at any 
 given point for polling requests from the specific VANTIQ source. Must be a positive integer. Default value is 10.
-*   maxQueuedTask: Optional. Only used if `pollTime` has been specified. The maximum number of queued tasks at any given point 
+*   `maxQueuedTask`: Optional. Only used if `pollTime` has been specified. The maximum number of queued tasks at any given point 
 for polling requests from the specific VANTIQ source. Must be a positive integer. Default value is 20.
     *   **NOTE:** The default behavior of the Object Recognition Source is to process up to 10 captured frames in parallel at 
     a time. If you would like the source to only process one frame at a time, then `maxRunningThreads` and `maxQueuedTasks` 
     must both be set to 1.
-*   suppressEmptyNeuralNetResults: Optional. Only used if `pollTime` has been specified. Must be a boolean value. If set to 
+*   `suppressEmptyNeuralNetResults`: Optional. Only used if `pollTime` has been specified. Must be a boolean value. If set to 
 `true`, only the neural net results containing recognitions, (from polled frames), will be sent back to the VANTIQ Source as a 
 Notificiation.
 
@@ -189,7 +189,7 @@ Most of the options required for dataSource are dependent on the specific implem
 [ImageRetrieverInterface](#retrieveInterface). The ones that are the same across all implementations
 are:
 
-*   type: Optional. Can be one of three situations
+*   `type`: Optional. Can be one of three situations
     1.  The fully qualified class name of an implementation of ImageRetrieverInterface, e.g.
         "io.vantiq.extsrc.objectRecognition.imageRetriever.CameraRetriever".
     2.  The short name of one of the standard implementations, i.e. one of "[file](#fileRet)", "[camera](#camRet)",
@@ -203,7 +203,8 @@ are:
 Most of the options required for neuralNet are dependent on the specific implementation of
 [NeuralNetInterface](#netInterface). For an example of neural net specific configurations, please look at the [YOLO Processor 
 configuration options](#yoloNet). The ones that are the same across all implementations are:
-*   type: Optional. Can be one of three situations
+
+*   `type`: Optional. Can be one of three situations
     1.  The fully qualified class name of an implementation of NeuralNetInterface, e.g.
         "io.vantiq.extsrc.objectRecognition.neuralNet.YoloProcessor".
     2.  The short name of one of the standard implementations, i.e. one of "[yolo](#yoloNet)", "[none](#noNet)" or
@@ -211,34 +212,35 @@ configuration options](#yoloNet). The ones that are the same across all implemen
     3.  Empty, in which case the program will try to find an implementation with the name "DefaultProcessor" in
         the `io.vantiq.objectRecognition.neuralNet` package. This implementation is not provided, and must be written by
         the user.
-*   threshold: Optional. Threshold is used to decide if the Neural Net's result is a valid one, by comparing the resulting confidence of the recognition against the threshold value. A high threshold will lead to fewer results, all with a higher confidence. A low threshold will lead to more results, some of which having a lower confidence. Threshold defaults to 0.5 if not specified, or if invalid. There are two ways to specify this value:
+*   `threshold`: Optional. Threshold is used to decide if the Neural Net's result is a valid one, by comparing the resulting confidence of the recognition against the threshold value. A high threshold will lead to fewer results, all with a higher confidence. A low threshold will lead to more results, some of which having a lower confidence. Threshold defaults to 0.5 if not specified, or if invalid. There are two ways to specify this value:
     1.  The value can be a number between 0 and 1 (i.e. 0.4, or 0.2, etc...)
     2.  The value can be a number between 0 and 100 (i.e. 40, or 20, etc...)
-*   cropBeforeAnalysis: Optional. Used to crop the retrieved images before they are processed by the Neural Net. This option 
+*   `cropBeforeAnalysis`: Optional. Used to crop the retrieved images before they are processed by the Neural Net. This option 
 *must* contain the following values:
     *   **x**: The top left x-coordinate used to crop the image.
     *   **y**: The top left y-coordinate used to crop the image.
     *   **width**: The width of the cropped image, (starting at the x-coordinate specified above).
     *   **height**: The height of the cropped image, (starting at the y-coordinate specified above).
-*   saveImage: Optional. The value can be one of the following three options:
+*   `saveImage`: Optional. The value can be one of the following three options:
     1.  "local"     - This will save images to the disk (outputDir must be specified in order for this to work).
     2.  "vantiq"    - This will save images as documents in VANTIQ. No images will be saved locally even if outputDir is specified.
     3.  "both"      - This will save the images both to the disk and as documents in VANTIQ. (outputDir must be specified in order to save locally)
+* `includeEncodedImage`: Optional.  If set, the Base64-encoded image will be included in the results. The image encoded and included is the same one that would be saved if `saveImage` is/was set. _E.g._, if `labelImage` (see below) is set, the encoded image will contain the labeling.  Note that `includeEncodedImage` and `saveImage` are independent of one another;  either or both can be set.
     
-**NOTE:** All of the following options are relevant only if the "saveImage" option has been set.
+**NOTE:** All of the following options are relevant only if the `saveImage` or `includedEncodedImage` (for `labelImage` and `savedResolution`) options are set.
 
-*   outputDir: Optional. The directory in which images will be saved locally. Images will only be saved locally if saveImage 
+*   `outputDir`: Optional. The directory in which images will be saved locally. Images will only be saved locally if saveImage 
 is set to be either "local" or "both".
-*   saveRate: Optional. The rate at which images will be saved (i.e. "saveRate": 3 - This will save every 3rd image that is 
+*   `saveRate`: Optional. The rate at which images will be saved (i.e. "saveRate": 3 - This will save every 3rd image that is 
 captured). If not specified, the value will default to 1 which saves every captured image.
-*   labelImage: Optional. If set to "true", images will be saved with bounding boxes and labels. If set to "false", or if not 
+*   `labelImage`: Optional. If set to "true", images will be saved with bounding boxes and labels. If set to "false", or if not 
 set at all, the images will be saved with no bounding boxes or labels.
-*   uploadAsImage: Optional. If set to "true", images will be uploaded to VANTIQ as VANTIQ Images, (the default behavior 
+*   `uploadAsImage`: Optional. If set to "true", images will be uploaded to VANTIQ as VANTIQ Images, (the default behavior 
 uploads images as VANTIQ Documents).
     *   **NOTE**: This option is only relevant if "saveImage" has been set to either "vantiq" or "both".
-*   savedResolution: Optional. A map containing options for adjusting the resolution of the saved images.
+*   `savedResolution`: Optional. A map containing options for adjusting the resolution of the saved images.
     * *Options for savedResolution:*
-    1. longEdge: Optional. This sets the maximum long edge dimension for saved images. Must be a non-negative integer that is 
+    1. `longEdge`: Optional. This sets the maximum long edge dimension for saved images. Must be a non-negative integer that is 
     smaller than the long edge of the image to be saved. This value will become the new long edge dimension, and the short 
     edge will be scaled down to maintain the same aspect ratio as the original image.
         *   **NOTE:** We do not support enlarging images. This feature can be used *only* to resize images to smaller 
@@ -535,7 +537,7 @@ identified, in the format used by the neural [net implementation](#netInterface)
 
 Options available for all Queries (not prepended by anything) are:
 
-*   sendFullResponse: Optional. Specifies that this request should send back data in the same format as a notification
+*   `sendFullResponse`: Optional. Specifies that this request should send back data in the same format as a notification
     instead of only the objects recognized. Note that the data will be the sole occupant of a 1-element array when
     received, instead of being immediately available as a JSON object. This is because Query results are mandated
     to be arrays. Default is false.
@@ -597,12 +599,14 @@ it will be set to the default value, "processNextFrame".
         *   "cropBeforeAnalysis": Optional. This value can be set exactly like the "cropBeforeAnalysis" value in the source 
         configuration. If no cropBeforeAnalysis value is set as a query parameter, the source configuration's 
         cropBeforeAnalysis value will be used.
-        *   uploadAsImage: Optional. If set to "true", images will be uploaded to VANTIQ as VANTIQ Images, (the default 
+        *   "uploadAsImage": Optional. If set to "true", images will be uploaded to VANTIQ as VANTIQ Images, (the default 
         behavior uploads images as VANTIQ Documents).
+        *   "includeEncodedImage": Optional.  If set to "true", a Base64-encoded image will be included in the results when `sendFullResponse` is set.
     
 **EXAMPLE QUERIES**:
 
 *   Upload Query using imageName:
+
 ```
 SELECT * FROM SOURCE Camera1 AS results WITH
     	operation:"upload",
@@ -611,14 +615,16 @@ SELECT * FROM SOURCE Camera1 AS results WITH
 ```
 
 *   Upload Query using imageDate, uploading as VANTIQ Images:
+
 ```
 SELECT * FROM SOURCE Camera1 AS results WITH
-    	operation:"upload",
-    	imageDate:["2019-02-08--10-33-36", "2019-02-08--12-45-18"],
+        operation:"upload",
+        imageDate:["2019-02-08--10-33-36", "2019-02-08--12-45-18"],
         uploadAsImage: true
 ```
 
 *   Delete Query using imageName:
+
 ```
 SELECT * FROM SOURCE Camera1 AS results WITH
     	operation:"delete",
@@ -626,6 +632,7 @@ SELECT * FROM SOURCE Camera1 AS results WITH
 ```
 
 *   Delete Query using imageDate to delete everything after a certain date:
+
 ```
 SELECT * FROM SOURCE Camera1 AS results WITH
     	operation:"delete",
@@ -633,6 +640,7 @@ SELECT * FROM SOURCE Camera1 AS results WITH
 ```
 
 *   Delete Query using imageDate to delete all images:
+
 ```
 SELECT * FROM SOURCE Camera1 AS results WITH
     	operation:"delete",
@@ -640,21 +648,23 @@ SELECT * FROM SOURCE Camera1 AS results WITH
 ```
 
 *   Process Next Frame Query:
+
 ```
 SELECT * FROM SOURCE Camera1 AS results WITH
         operation:"processNextFrame",
-    	NNsaveImage:"local",
-    	NNoutputDir:"testDir",
-    	NNfileName:"testFile"
+        NNsaveImage:"local",
+        NNoutputDir:"testDir",
+        NNfileName:"testFile"
 ```
 
 *   Process Next Frame Query, with preCrop set:
+
 ```
 SELECT * FROM SOURCE Camera1 AS results WITH
         operation:"processNextFrame",
-    	NNsaveImage:"local",
-    	NNoutputDir:"testDir",
-    	NNfileName:"testFile",
+        NNsaveImage:"local",
+        NNoutputDir:"testDir",
+        NNfileName:"testFile",
         cropBeforeAnalysis: {
             x: 50,
             y: 100,
@@ -664,20 +674,22 @@ SELECT * FROM SOURCE Camera1 AS results WITH
 ```
 
 * Process Next Frame Query, uploading as VANTIQ Image:
+
 ```
 SELECT * FROM SOURCE Camera1 AS results WITH
         operation:"processNextFrame",
-    	NNsaveImage:"vantiq",
-    	NNfileName:"testFile",
+        NNsaveImage:"vantiq",
+        NNfileName:"testFile",
         uploadAsImage: true
 ```
 
 *   Process Next Frame Query without specifying operation *(not recommended)*:
+
 ```
 SELECT * FROM SOURCE Camera1 AS results WITH
-    	NNsaveImage:"local",
-    	NNoutputDir:"testDir",
-    	NNfileName:"testFile"
+        NNsaveImage:"local",
+        NNoutputDir:"testDir",
+        NNfileName:"testFile"
 ```
 
 ### Error Messages

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
@@ -43,7 +43,7 @@ public class ObjectDetector {
 
     // This will be used to create
     // "year-month-date-hour-minute-seconds"
-    private static SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd--HH-mm-ss");
+    private static final  SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd--HH-mm-ss");
     
     // Getting meta config options for YOLO Processor
     public MetaBasedConfig metaConfigOptions = new MetaBasedConfig();
@@ -92,7 +92,7 @@ public class ObjectDetector {
      * @param vantiq        The Vantiq variable used to connect to the VANTIQ SDK. Either authenticated, or set to null.
      * @param sourceName    The name of the VANTIQ Source
      */
-    @SuppressWarnings({"PMD.ParamNumberCheck", "PMD.CognitiveComplexity", "PMD.ExcessiveParameterList"})
+    @SuppressWarnings({"PMD.ParameterNumberCheck", "PMD.CognitiveComplexity", "PMD.ExcessiveParameterList"})
     public ObjectDetector(float thresh, String graphFile, String labelFile, String metaFile, double[] anchorArray,
                           ImageUtil imageUtil, Boolean labelImage, int saveRate,
                           Vantiq vantiq, String sourceName) {

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
@@ -94,7 +94,7 @@ public class ObjectDetector {
      * @param vantiq        The Vantiq variable used to connect to the VANTIQ SDK. Either authenticated, or set to null.
      * @param sourceName    The name of the VANTIQ Source
      */
-    @SuppressWarnings({"CheckStyle.ParameterNumberCheck", "PMD.CognitiveComplexity", "PMD.ExcessiveParameterList"})
+    @SuppressWarnings({"Checkstyle.ParameterNumberCheck", "PMD.CognitiveComplexity", "PMD.ExcessiveParameterList"})
     public ObjectDetector(float thresh, String graphFile, String labelFile, String metaFile, double[] anchorArray,
                           ImageUtil imageUtil, Boolean labelImage, int saveRate,
                           Vantiq vantiq, String sourceName) {

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
@@ -228,7 +228,7 @@ public class ObjectDetector {
         try (Tensor<Float> normalizedImage = normalizeImage(image)) {
             List<Recognition> recognitions = YOLOClassifier.getInstance(threshold, anchorArray, frameSize).classifyImage(executeYOLOGraph(normalizedImage), labels);
             BufferedImage buffImage = ImageUtil.createImageFromBytes(image);
-
+            
             // Saves an image if requested
             if (outputDir != null || vantiq != null || this.imageUtil.saveImage) {
                 ImageUtil imageUtil = new ImageUtil();

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
@@ -35,6 +35,7 @@ import static edu.ml.tensorflow.Config.MEAN;
 /**
  * ObjectDetector class to detect objects using pre-trained models with TensorFlow Java API.
  */
+@SuppressWarnings("PMD.TooManyFields")
 public class ObjectDetector {
     private final static Logger LOGGER = LoggerFactory.getLogger(ObjectDetector.class);
     private byte[] graph_def;
@@ -57,7 +58,7 @@ public class ObjectDetector {
     private Vantiq vantiq = null;
     private String sourceName = null;
     private double[] anchorArray;
-    private Map<String,Object> metaFileMap;    
+    private Map<String, Object> metaFileMap;
     
     private Graph yoloGraph;
     private Session yoloSession;
@@ -84,7 +85,6 @@ public class ObjectDetector {
      * @param metaFile      The location of the meta file used to retrieve anchors and labels if a labelFile is not provided.
      * @param anchorArray   The list of anchor pairs used by the YOLOClassifier to label recognitions.
      * @param imageUtil     The instance of the ImageUtil class used to save images. Either initialized, or set to null.
-     * @param outputDir     The directory to which images will be saved.
      * @param labelImage    The boolean flag signifying if images should be saved with or without bounding boxes. If true,
      *                      the frames will be saved with bounding boxes, and vice versa.     
      * @param saveRate      The rate at which images will be saved, once per every saveRate frames. Non-positive values are
@@ -92,16 +92,17 @@ public class ObjectDetector {
      * @param vantiq        The Vantiq variable used to connect to the VANTIQ SDK. Either authenticated, or set to null.
      * @param sourceName    The name of the VANTIQ Source
      */
+    @SuppressWarnings({"PMD.ParamNumberCheck", "PMD.CognitiveComplexity", "PMD.ExcessiveParameterList"})
     public ObjectDetector(float thresh, String graphFile, String labelFile, String metaFile, double[] anchorArray,
-                          ImageUtil imageUtil, String outputDir, Boolean labelImage, int saveRate,
+                          ImageUtil imageUtil, Boolean labelImage, int saveRate,
                           Vantiq vantiq, String sourceName) {
         try {
             graph_def = IOUtil.readAllBytesOrExit(graphFile);
             // Parse meta file if it exists, and get all general information we need
             if (metaFile != null) {
                 parseMetaFile(metaFile);
-                int frameHeight = (int) ((Map<String,Object>) metaFileMap.get("net")).get("height");
-                int frameWidth = (int) ((Map<String,Object>) metaFileMap.get("net")).get("width");
+                int frameHeight = (int) ((Map<String, Object>) metaFileMap.get("net")).get("height");
+                int frameWidth = (int) ((Map<String, Object>) metaFileMap.get("net")).get("width");
                 // Check that meta file has appropriate frame size, and that user has not overwritten frame size in Config
                 if (frameHeight == frameWidth && frameHeight % 32 == 0 && metaConfigOptions.useMetaIfAvailable) {
                     // Set config value to the .meta file's frame size
@@ -263,7 +264,7 @@ public class ObjectDetector {
      */
     private void parseMetaFile(String metaFile) throws JsonParseException, JsonMappingException, IOException {
         byte[] metaFileData = Files.readAllBytes(Paths.get(metaFile));
-        this.metaFileMap = new HashMap<String,Object>();
+        this.metaFileMap = new HashMap<String, Object>();
         ObjectMapper objectMapper = new ObjectMapper();
         this.metaFileMap = objectMapper.readValue(metaFileData, HashMap.class);
     }

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static edu.ml.tensorflow.Config.MEAN;
@@ -43,7 +44,8 @@ public class ObjectDetector {
 
     // This will be used to create
     // "year-month-date-hour-minute-seconds"
-    private static final  SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd--HH-mm-ss");
+    private static final  SimpleDateFormat format =
+            new SimpleDateFormat("yyyy-MM-dd--HH-mm-ss", Locale.getDefault());
     
     // Getting meta config options for YOLO Processor
     public MetaBasedConfig metaConfigOptions = new MetaBasedConfig();
@@ -92,7 +94,7 @@ public class ObjectDetector {
      * @param vantiq        The Vantiq variable used to connect to the VANTIQ SDK. Either authenticated, or set to null.
      * @param sourceName    The name of the VANTIQ Source
      */
-    @SuppressWarnings({"PMD.ParameterNumberCheck", "PMD.CognitiveComplexity", "PMD.ExcessiveParameterList"})
+    @SuppressWarnings({"CheckStyle.ParameterNumberCheck", "PMD.CognitiveComplexity", "PMD.ExcessiveParameterList"})
     public ObjectDetector(float thresh, String graphFile, String labelFile, String metaFile, double[] anchorArray,
                           ImageUtil imageUtil, Boolean labelImage, int saveRate,
                           Vantiq vantiq, String sourceName) {

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
@@ -94,7 +94,7 @@ public class ObjectDetector {
      * @param vantiq        The Vantiq variable used to connect to the VANTIQ SDK. Either authenticated, or set to null.
      * @param sourceName    The name of the VANTIQ Source
      */
-    @SuppressWarnings({"Checkstyle.ParameterNumberCheck", "PMD.CognitiveComplexity", "PMD.ExcessiveParameterList"})
+    @SuppressWarnings({"checkstyle.ParameterNumberCheck", "PMD.CognitiveComplexity", "PMD.ExcessiveParameterList"})
     public ObjectDetector(float thresh, String graphFile, String labelFile, String metaFile, double[] anchorArray,
                           ImageUtil imageUtil, Boolean labelImage, int saveRate,
                           Vantiq vantiq, String sourceName) {

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
@@ -32,11 +32,10 @@ public class ImageUtil {
     public Boolean queryResize = false;
     public int longEdge = 0;
     public Boolean uploadAsImage = false;
-    public Boolean labelImage = false;
 
     // Used to upload image to VANTIQ as VANTIQ Image
-    final static String IMAGE_RESOURCE_PATH = "/resources/images";
-    final static String IMAGE_SAVE_FORMAT = "jpg";
+    static final String IMAGE_RESOURCE_PATH = "/resources/images";
+    static final String IMAGE_SAVE_FORMAT = "jpg";
 
     /**
      * Label image with classes and predictions given by the TensorFLow YOLO Implementation
@@ -67,6 +66,7 @@ public class ImageUtil {
      * @param image     The image to save
      * @param target    The name of the file to be written
      */
+    @SuppressWarnings({"PMD.CognitiveComplexity"})
     public void saveImage(final BufferedImage image, final String target) {
         File fileToUpload = null;
         if (outputDir != null) {
@@ -86,10 +86,7 @@ public class ImageUtil {
             }
         }
         if (vantiq != null) {
-            LOGGER.error("Uploading {} ...", target);
             if (fileToUpload != null) {
-                LOGGER.error("Uploading {}", fileToUpload.getName());
-
                 uploadImage(fileToUpload, target);
             } else {
                 try {
@@ -101,8 +98,6 @@ public class ImageUtil {
                         BufferedImage resizedImage = resizeImage(image);
                         ImageIO.write(resizedImage, IMAGE_SAVE_FORMAT, imgFile);
                     }
-                    LOGGER.error("Uploading null file {}", imgFile.getName());
-
                     uploadImage(imgFile, target);
                 } catch (IOException e) {
                     LOGGER.error("Unable to save image {}", target, e);
@@ -238,7 +233,7 @@ public class ImageUtil {
 
     public static byte[] getBytesForImage(final BufferedImage bi) {
 
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()){
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
             ImageIO.write(bi, IMAGE_SAVE_FORMAT, baos);
             baos.flush();
             return baos.toByteArray();

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
@@ -121,7 +121,10 @@ public class ImageUtil {
                 ImageIO.write(resizedImage, IMAGE_SAVE_FORMAT, tmpFile);
                 fileToUpload = tmpFile;
             } catch (IOException e) {
-                LOGGER.error("An error occurred while reading and/or resizing the locally saved image file. " + e.getMessage());
+                if (LOGGER.isErrorEnabled()) {
+                    LOGGER.error("An error occurred while reading and/or resizing the locally saved image file. "
+                            + e.getMessage());
+                }
             }
         }
         uploadToVantiq(fileToUpload, target);

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -678,6 +678,11 @@ public class ObjectRecognitionCore {
        if (neuralNetResults.getLastFilename() != null) {
            map.put("filename", neuralNetResults.getLastFilename());
        }
+
+       String encodedImage = neuralNetResults.getEncodedImage();
+       if (encodedImage != null) {
+           map.put("encodedImage", encodedImage);
+       }
        
        map.put("sourceName", sourceName);
        map.put("timestamp", imageResults.getTimestamp());
@@ -695,6 +700,7 @@ public class ObjectRecognitionCore {
        } else {
            map.put("neuralNet", new LinkedHashMap<>());
        }
+
        if (locationMapper != null) {
            // Then our source is configured to create a set of mapped results in addition to the NN results.
            List<Map<String, ?>> mappedResults = locationMapper.mapResults(nnRes);

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetResults.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetResults.java
@@ -20,6 +20,9 @@ public class NeuralNetResults {
      * A Map containing any data that should be passed to the source
      */
     protected Map<String, ?>          otherData   = null;
+
+    /* String containing the base64-encoded image that was just evaluated, assuming that's desired */
+    protected String                  encodedImage = null;
     
     public NeuralNetResults() {
         // Do nothing
@@ -76,10 +79,23 @@ public class NeuralNetResults {
     }
 
     /**
-     * @param otherData A Map containing any data that should be passed to the source
+     * @param lastFilename A String containing the name of the last saved image file.  Used in testing
      */
     public void setLastFilename(String lastFilename) {
         this.lastFilename = lastFilename;
     }
-    
+
+    /**
+     * @param ei String the base64-encoded image to return
+     */
+    public void setEncodedImage(String ei) {
+        this.encodedImage = ei;
+    }
+
+    /**
+     * @return String the base64-encoded image to return
+     */
+    public String getEncodedImage() {
+        return encodedImage;
+    }
 }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetUtils.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetUtils.java
@@ -13,6 +13,7 @@ import javax.imageio.ImageIO;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("PMD.AbstractClassWithoutAbstractMethod")
 public abstract class NeuralNetUtils {
     
     Logger log = LoggerFactory.getLogger(this.getClass());

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetUtils.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetUtils.java
@@ -5,6 +5,7 @@ import java.awt.image.RasterFormatException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 import javax.imageio.ImageIO;
@@ -38,7 +39,7 @@ public abstract class NeuralNetUtils {
             // Convert BufferedImage to byte[] and save it
             ImageIO.write(croppedImage, "jpg", baos);
             baos.flush();
-            image = baos.toByteArray();
+            return baos.toByteArray();
         } catch (IOException e) {
             log.error("An error occured when trying to crop the captured image. Image will not be cropped.");
         } catch (RasterFormatException e) {
@@ -57,6 +58,7 @@ public abstract class NeuralNetUtils {
      * @return String containing the base64 encoding of the image bytes
      */
     public static String convertToBase64(byte[] image) {
-        return Base64.getEncoder().encodeToString(image);
+        byte[] encBytes = Base64.getEncoder().encode(image);
+        return new String(encBytes, StandardCharsets.UTF_8);
     }
 }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetUtils.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetUtils.java
@@ -5,6 +5,7 @@ import java.awt.image.RasterFormatException;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Base64;
 
 import javax.imageio.ImageIO;
 
@@ -48,5 +49,14 @@ public abstract class NeuralNetUtils {
         }
         
         return image;
+    }
+
+    /**
+     * Converts the incoming image (well, really, any byte array) to a base 64 string
+     * @param image byte[] byte encoding of the image
+     * @return String containing the base64 encoding of the image bytes
+     */
+    public static String convertToBase64(byte[] image) {
+        return Base64.getEncoder().encodeToString(image);
     }
 }

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -143,7 +143,7 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
      * @param authToken         The authToken used to with the VANTIQ SDK
      * @throws Exception        Thrown when an invalid configuration is requested
      */
-    @SuppressWarnings({"PMD.CognitiveComplexity", "CheckStyle.MethodLengthCheck"})
+    @SuppressWarnings({"PMD.CognitiveComplexity", "Checkstyle.MethodLengthCheck"})
     private void setup(Map<String, ?> neuralNet, String sourceName, String modelDirectory,
                        String authToken, String server) throws Exception {
         this.server = server;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -143,7 +143,7 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
      * @param authToken         The authToken used to with the VANTIQ SDK
      * @throws Exception        Thrown when an invalid configuration is requested
      */
-    @SuppressWarnings({"PMD.CognitiveComplexity", "checkstyle.MethodLengthCheck"})
+    @SuppressWarnings({"PMD.CognitiveComplexity", "checkstyle.methodlengthcheck"})
     private void setup(Map<String, ?> neuralNet, String sourceName, String modelDirectory,
                        String authToken, String server) throws Exception {
         this.server = server;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -143,7 +143,7 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
      * @param authToken         The authToken used to with the VANTIQ SDK
      * @throws Exception        Thrown when an invalid configuration is requested
      */
-    @SuppressWarnings({"PMD.CognitiveComplexity", "PMD.MethodLengthCheck"})
+    @SuppressWarnings({"PMD.CognitiveComplexity", "CheckStyle.MethodLengthCheck"})
     private void setup(Map<String, ?> neuralNet, String sourceName, String modelDirectory,
                        String authToken, String server) throws Exception {
         this.server = server;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -143,7 +143,7 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
      * @param authToken         The authToken used to with the VANTIQ SDK
      * @throws Exception        Thrown when an invalid configuration is requested
      */
-    @SuppressWarnings({"PMD.CognitiveComplexity", "checkstyle.methodlengthcheck"})
+    @SuppressWarnings({"PMD.CognitiveComplexity", "methodlengthcheck", "MethodLengthCheck"})
     private void setup(Map<String, ?> neuralNet, String sourceName, String modelDirectory,
                        String authToken, String server) throws Exception {
         this.server = server;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -143,7 +143,7 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
      * @param authToken         The authToken used to with the VANTIQ SDK
      * @throws Exception        Thrown when an invalid configuration is requested
      */
-    @SuppressWarnings("PMD.CognitiveComplexity")
+    @SuppressWarnings({"PMD.CognitiveComplexity", "PMD.MethodLengthCheck"})
     private void setup(Map<String, ?> neuralNet, String sourceName, String modelDirectory,
                        String authToken, String server) throws Exception {
         this.server = server;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -247,7 +247,7 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
                    uploadAsImage = (Boolean) neuralNet.get(UPLOAD_AS_IMAGE);
                }
            }
-
+           
            // Check if any resolution configurations have been set
            if (neuralNet.get(SAVED_RESOLUTION) instanceof Map) {
                @SuppressWarnings("rawtypes")

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -143,7 +143,7 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
      * @param authToken         The authToken used to with the VANTIQ SDK
      * @throws Exception        Thrown when an invalid configuration is requested
      */
-    @SuppressWarnings({"PMD.CognitiveComplexity", "Checkstyle.MethodLengthCheck"})
+    @SuppressWarnings({"PMD.CognitiveComplexity", "checkstyle.MethodLengthCheck"})
     private void setup(Map<String, ?> neuralNet, String sourceName, String modelDirectory,
                        String authToken, String server) throws Exception {
         this.server = server;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -143,7 +143,7 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
      * @param authToken         The authToken used to with the VANTIQ SDK
      * @throws Exception        Thrown when an invalid configuration is requested
      */
-    @SuppressWarnings({"PMD.CognitiveComplexity", "methodlengthcheck", "MethodLengthCheck"})
+    @SuppressWarnings({"PMD.CognitiveComplexity", "Checkstyle:MethodLengthCheck"})
     private void setup(Map<String, ?> neuralNet, String sourceName, String modelDirectory,
                        String authToken, String server) throws Exception {
         this.server = server;

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecConfig.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecConfig.java
@@ -227,7 +227,7 @@ public class TestObjRecConfig {
     @Test
     public void testInvalidImageUploadConfig() {
         Map<String, Object> conf = minimalConfig();
-        neuralNet.put("uploadAsImage", "jibberish");
+        neuralNet.put("uploadAsImage", "gibberish");
         sendConfig(conf);
         assertFalse("Should not fail when image upload config is a string", configIsFailed());
 
@@ -247,7 +247,40 @@ public class TestObjRecConfig {
         sendConfig(conf);
         assertFalse("Should not fail when image upload config is false", configIsFailed());
     }
-    
+
+    @Test
+    public void testInvalidIncludeEncodedConfig() {
+        Map<String, Object> conf = minimalConfig();
+        neuralNet.put("includeEncodedImage", "gibberish");
+        sendConfig(conf);
+        assertFalse("Should not fail when image include is garbage", configIsFailed());
+
+        neuralNet.put("includeEncodedImage", 10);
+        sendConfig(conf);
+        assertFalse("Should not fail when image include config is an int", configIsFailed());
+    }
+
+    @Test
+    public void testValidIncludeEncodedConfig() {
+        Map<String, Object> conf = minimalConfig();
+        neuralNet.put("includeEncodedImage", true);
+        sendConfig(conf);
+        assertFalse("Should not fail when image include config is true", configIsFailed());
+
+        neuralNet.put("includeEncodedImage", false);
+        sendConfig(conf);
+        assertFalse("Should not fail when image include config is false", configIsFailed());
+
+        neuralNet.put("includeEncodedImage", "true");
+        sendConfig(conf);
+        assertFalse("Should not fail when image include config is true String", configIsFailed());
+
+        neuralNet.put("includeEncodedImage", "false");
+        sendConfig(conf);
+        assertFalse("Should not fail when image include config is false String", configIsFailed());
+    }
+
+
     @Test
     public void testMinimalConfig() {
         nCore.start(5); // Need a client to avoid NPEs on sends

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecConfig.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecConfig.java
@@ -280,7 +280,6 @@ public class TestObjRecConfig {
         assertFalse("Should not fail when image include config is false String", configIsFailed());
     }
 
-
     @Test
     public void testMinimalConfig() {
         nCore.start(5); // Need a client to avoid NPEs on sends

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetTestBase.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetTestBase.java
@@ -114,7 +114,8 @@ public class NeuralNetTestBase extends ObjRecTestBase {
             return null;
         }
     }
-
+    
+    @SuppressWarnings("PMD.CognitiveComplexity")
     public static void checkUploadToVantiq(String name, Vantiq vantiq, String resourceName) throws InterruptedException {
         boolean done = false;
         int retries = 0;

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetTestBase.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetTestBase.java
@@ -91,7 +91,6 @@ public class NeuralNetTestBase extends ObjRecTestBase {
     protected static void deleteSourceImpl(Vantiq vantiq) throws Exception {
         if (createdImpl) {
             vantiq.deleteOne(VANTIQ_SOURCE_IMPL, OR_SRC_TYPE);
-            createdImpl = false;
         }
 
         VantiqResponse resp = vantiq.selectOne(VANTIQ_SOURCE_IMPL, OR_SRC_TYPE);
@@ -100,9 +99,10 @@ public class NeuralNetTestBase extends ObjRecTestBase {
             if (errors.size() != 1 || !errors.get(0).getCode().equals("io.vantiq.resource.not.found")) {
                 fail("Error deleting source impl" + resp.getErrors());
             }
-        } else {
+        } else if (createdImpl) {
             fail(OR_SRC_TYPE + " source impl found after deletion.");
         }
+        createdImpl = false;
     }
 
     public static byte[] getTestImage() {
@@ -120,7 +120,6 @@ public class NeuralNetTestBase extends ObjRecTestBase {
         int retries = 0;
         int maxRetries = WAIT_FOR_ASYNC_MILLIS / 50;
         while (!done) {
-            done = true;
             VantiqResponse vantiqResponse = vantiq.selectOne(resourceName, name);
             if (vantiqResponse.hasErrors()) {
                 if (++retries < maxRetries) {
@@ -134,6 +133,11 @@ public class NeuralNetTestBase extends ObjRecTestBase {
                         }
                     }
                 }
+            } else if (vantiqResponse.isSuccess()) {
+                done = true;
+            } else {
+                retries += 1;
+                Thread.sleep(50);
             }
         }
     }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetTestBase.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetTestBase.java
@@ -174,7 +174,7 @@ public class NeuralNetTestBase extends ObjRecTestBase {
     }
 
     public static void deleteSource(Vantiq vantiq) {
-        Map<String,Object> where = new LinkedHashMap<String,Object>();
+        Map<String, Object> where = new LinkedHashMap<>();
         where.put("name", testSourceName);
         VantiqResponse response = vantiq.delete("system.sources", where);
     }
@@ -192,7 +192,7 @@ public class NeuralNetTestBase extends ObjRecTestBase {
     }
 
     public static void deleteType(Vantiq vantiq) {
-        Map<String,Object> where = new LinkedHashMap<String,Object>();
+        Map<String, Object> where = new LinkedHashMap<>();
         where.put("name", testTypeName);
         VantiqResponse response = vantiq.delete("system.types", where);
     }
@@ -210,7 +210,7 @@ public class NeuralNetTestBase extends ObjRecTestBase {
     }
 
     public static void deleteRule(Vantiq vantiq) {
-        Map<String,Object> where = new LinkedHashMap<String,Object>();
+        Map<String, Object> where = new LinkedHashMap<>();
         where.put("name", testRuleName);
         VantiqResponse response = vantiq.delete("system.rules", where);
     }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
@@ -8,14 +8,12 @@
 
 package io.vantiq.extsrc.objectRecognition.neuralNet;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.lang.reflect.Array;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -57,7 +57,7 @@ import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
 
-@SuppressWarnings({"PMD.ExcessiveClassLength", "PMD.AbbreviationAsWordInNameCheck"})
+@SuppressWarnings({"PMD.ExcessiveClassLength", "PMD.AbbreviationAsWordInNameCheck", "PMD.ExcessivePublicCount"})
 @Slf4j
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class TestYoloProcessor extends NeuralNetTestBase {
@@ -1877,7 +1877,9 @@ public class TestYoloProcessor extends NeuralNetTestBase {
             if (shouldSaveImage) {
                 // Checking that image was saved to VANTIQ
                 Thread.sleep(1000);
-                log.debug("Checking for image file: {}", results.getLastFilename());
+                if (log.isDebugEnabled()) {
+                    log.debug("Checking for image file: {}", results.getLastFilename());
+                }
                 checkUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_IMAGES);
                 vantiqSavedImageFiles.add(results.getLastFilename());
             }
@@ -2059,8 +2061,10 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         // If the image is labeled, our copy from above should be different from the returned value.
         // Otherwise, they should be the same.
         if (encoded != null) {
-            log.debug("Labeling: {}, length expected encoded: {}, length returned: {}", ypImageSaver.labelImage,
-                    encoded.length(),  results.getEncodedImage().length());
+            if (log.isDebugEnabled()) {
+                log.debug("Labeling: {}, length expected encoded: {}, length returned: {}", ypImageSaver.labelImage,
+                        encoded.length(), results.getEncodedImage().length());
+            }
             assert ((encoded.length() == results.getEncodedImage().length()) != ypImageSaver.labelImage);
             assert (results.getEncodedImage().equals(encoded) != ypImageSaver.labelImage);
         } else {
@@ -2074,7 +2078,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
     }
 
     byte[] imageAsSeenByProcessor(byte[] input) {
-        try (ByteArrayInputStream bis = new ByteArrayInputStream(input)){
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(input)) {
             BufferedImage bi = ImageIO.read(bis);
             return ImageUtil.getBytesForImage(bi);
         } catch (IOException e) {

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -184,21 +184,21 @@ public class TestYoloQueries extends NeuralNetTestBase {
     public void testInvalidImageUploadParameters() {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         Map<String, Object> params = new LinkedHashMap<>();
         params.put("operation", "upload");
-
+        
         invalidParametersHelper(params, "upload");
     }
-
+    
     @Test
     public void testInvalidImageDeleteParameters() {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         Map<String, Object> params = new LinkedHashMap<>();
         params.put("operation", "delete");
-
+        
         invalidParametersHelper(params, "delete");
     }
 
@@ -206,33 +206,33 @@ public class TestYoloQueries extends NeuralNetTestBase {
     public void testProcessNextFrameLocal() {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         // Make sure that output directory has not yet been created
         File outputDir = new File(OUTPUT_DIR);
         assert !outputDir.exists();
-
+        
         // Run query without setting "operation":"processNextFrame"
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         params.put("NNsaveImage", "local");
         params.put("NNoutputDir", OUTPUT_DIR);
         params.put("NNfileName", IMAGE_8.get("name"));
-
+        
         querySource(params);
-
+        
         // Check we saved a file in the output directory
         outputDir = new File(OUTPUT_DIR);
         assert outputDir.exists();
-
+        
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         File[] outputDirFiles = outputDir.listFiles();
         assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE_8.get("name") + ".jpg");
-
+        
         // Deleting directory for next test
         deleteDirectory(OUTPUT_DIR);
         assert !outputDir.exists();
-
+        
         // Running query with operation set to "processNextFrame"
         params.put("operation", "processNextFrame");
         querySource(params);
@@ -246,178 +246,178 @@ public class TestYoloQueries extends NeuralNetTestBase {
         assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE_8.get("name") + ".jpg");
-
+        
         // Deleting directory for next test
         deleteDirectory(OUTPUT_DIR);
         assert !outputDir.exists();
-
+        
         // Running query with no specific filename set
         params.remove("NNfileName");
         querySource(params);
-
+        
         // Check we saved a file in the output directory
         outputDir = new File(OUTPUT_DIR);
         assert outputDir.exists();
-
+        
         // Check there is only one file, and it's name is equivalent to the last saved file
         outputDirFiles = outputDir.listFiles();
         assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
-
+        
         int index = core.lastQueryFilename.lastIndexOf('/') + 1;
         assert outputDirFiles[0].getName().equals(core.lastQueryFilename.substring(index));
-
+        
         deleteDirectory(OUTPUT_DIR);
     }
-
+    
     @Test
     public void testProcessNextFrameVantiq() throws InterruptedException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         // Run query without setting "operation":"processNextFrame"
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         params.put("NNsaveImage", "vantiq");
         params.put("NNfileName", QUERY_FILENAME);
-
+        
         querySource(params);
-
+        
         // Check that file was saved to Vantiq
         Thread.sleep(1000);
         checkUploadToVantiq(IMAGE_8.get("filename"), vantiq, VANTIQ_DOCUMENTS);
-
+        
         // Deleting file for next test
         deleteFileFromVantiq(IMAGE_8.get("filename"));
-
+        
         // Running query with operation set to "processNextFrame"
         params.put("operation", "processNextFrame");
         querySource(params);
-
+        
         // Check that file was saved to Vantiq
         Thread.sleep(1000);
         checkUploadToVantiq(IMAGE_8.get("filename"), vantiq, VANTIQ_DOCUMENTS);
-
+        
         // Deleting file for next test
         deleteFileFromVantiq(IMAGE_8.get("filename"));
-
+        
         // Running query with no specific filename set
         params.remove("NNfileName");
         querySource(params);
-
+        
         // Check that file was saved to Vantiq
         Thread.sleep(1000);
         checkUploadToVantiq(core.lastQueryFilename, vantiq, VANTIQ_DOCUMENTS);
-
+        
         deleteFileFromVantiq(core.lastQueryFilename);
         vantiqUploadFiles.add(core.lastQueryFilename);
     }
-
+    
     @Test
     public void testProcessNextFrameBoth() throws InterruptedException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         // Make sure that output directory has not yet been created
         File outputDir = new File(OUTPUT_DIR);
         assert !outputDir.exists();
-
+        
         // Run query without setting "operation":"processNextFrame"
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         params.put("NNsaveImage", "both");
         params.put("NNoutputDir", OUTPUT_DIR);
         params.put("NNfileName", IMAGE_8.get("name"));
-
+        
         querySource(params);
-
+        
         // Check we saved a file in the output directory
         outputDir = new File(OUTPUT_DIR);
         assert outputDir.exists();
-
+        
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         File[] outputDirFiles = outputDir.listFiles();
         assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE_8.get("name") + ".jpg");
-
+        
         // Check that file was saved to Vantiq
         Thread.sleep(1000);
         checkUploadToVantiq(IMAGE_8.get("filename"), vantiq, VANTIQ_DOCUMENTS);
-
+        
         // Deleting file for next test
         deleteFileFromVantiq(IMAGE_8.get("filename"));
-
+        
         // Deleting directory for next test
         deleteDirectory(OUTPUT_DIR);
         assert !outputDir.exists();
-
+        
         // Running query with operation set to "processNextFrame"
         params.put("operation", "processNextFrame");
         querySource(params);
-
+        
         // Check we saved a file in the output directory
         outputDir = new File(OUTPUT_DIR);
         assert outputDir.exists();
-
+        
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         outputDirFiles = outputDir.listFiles();
         assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals(IMAGE_8.get("name") + ".jpg");
-
+        
         // Check that file was saved to Vantiq
         Thread.sleep(1000);
         checkUploadToVantiq(IMAGE_8.get("filename"), vantiq, VANTIQ_DOCUMENTS);
-
+        
         // Deleting file for next test
         deleteFileFromVantiq(IMAGE_8.get("filename"));
-
+        
         // Deleting directory for next test
         deleteDirectory(OUTPUT_DIR);
         assert !outputDir.exists();
-
+        
         // Running query with no specific filename set
         params.remove("NNfileName");
         querySource(params);
-
+        
         // Check we saved a file in the output directory
         outputDir = new File(OUTPUT_DIR);
         assert outputDir.exists();
-
+        
         // Check there is only one file, and it's name is equivalent to the last saved file
         outputDirFiles = outputDir.listFiles();
         assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
-
+        
         int index = core.lastQueryFilename.lastIndexOf('/') + 1;
         assert outputDirFiles[0].getName().equals(core.lastQueryFilename.substring(index));
-
+        
         // Check that file was saved to Vantiq
         Thread.sleep(1000);
         checkUploadToVantiq(core.lastQueryFilename, vantiq, VANTIQ_DOCUMENTS);
-
+        
         deleteFileFromVantiq(core.lastQueryFilename);
         vantiqUploadFiles.add(core.lastQueryFilename);
-
+        
         deleteDirectory(OUTPUT_DIR);
     }
-
+    
     @Test
     public void testImageNameUploadOne() throws IOException, InterruptedException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         addLocalTestImages();
-
+        
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         params.put("operation", "upload");
         params.put("imageName", IMAGE_2.get("date"));
-
+        
         querySource(params);
-
+        
         // Check the file was uploaded
         Thread.sleep(1000);
         checkUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
-
+        
         // Checking that none of the other images were uploaded to VANTIQ
         checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
@@ -426,24 +426,24 @@ public class TestYoloQueries extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
     }
-
+    
     @Test
     public void testImageDateUploadAll() throws IOException, InterruptedException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         addLocalTestImages();
-
+        
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         params.put("operation", "upload");
-
+        
         List<String> imageDate = new ArrayList<String>();
         imageDate.add("-");
         imageDate.add("-");
         params.put("imageDate", imageDate);
-
+        
         querySource(params);
-
+        
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
         checkUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
@@ -454,28 +454,28 @@ public class TestYoloQueries extends NeuralNetTestBase {
         checkUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         checkUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
     }
-
+    
     @Test
     public void testImageDateUploadOne() throws InterruptedException, IOException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         addLocalTestImages();
-
+        
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         params.put("operation", "upload");
-
+        
         List<String> imageDate = new ArrayList<String>();
         imageDate.add(START_DATE);
         imageDate.add(START_DATE);
         params.put("imageDate", imageDate);
-
+        
         querySource(params);
-
+        
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
         checkUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
-
+        
         // Checking that none of the other images were uploaded to VANTIQ
         checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
@@ -484,29 +484,29 @@ public class TestYoloQueries extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
     }
-
+    
     @Test
     public void testImageDateUploadBefore() throws InterruptedException, IOException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         addLocalTestImages();
-
+        
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         params.put("operation", "upload");
-
+        
         List<String> imageDate = new ArrayList<String>();
         imageDate.add("-");
         imageDate.add(START_DATE);
         params.put("imageDate", imageDate);
-
+        
         querySource(params);
-
+        
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
         checkUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         checkUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
-
+        
         // Checking that none of the other images were uploaded to VANTIQ
         checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
@@ -514,85 +514,84 @@ public class TestYoloQueries extends NeuralNetTestBase {
         checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
     }
-
+    
     @Test
     public void testImageDateUploadAfter() throws InterruptedException, IOException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         addLocalTestImages();
-
+        
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         params.put("operation", "upload");
-
+        
         List<String> imageDate = new ArrayList<String>();
         imageDate.add(END_DATE);
         imageDate.add("-");
         params.put("imageDate", imageDate);
-
+        
         querySource(params);
-
+        
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(1000);
         checkUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         checkUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         checkUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         checkUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
-
+        
         // Checking that none of the other images were uploaded to VANTIQ
         checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
     }
-
+    
     @Test
     public void testImageDateUploadRange() throws InterruptedException, IOException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         addLocalTestImages();
-
+        
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         params.put("operation", "upload");
-
-        List<String> imageDate = new ArrayList<String>();
+                List<String> imageDate = new ArrayList<String>();
         imageDate.add(START_DATE);
         imageDate.add(END_DATE);
         params.put("imageDate", imageDate);
-
+        
         querySource(params);
-
+        
         // Checking that all images were uploaded to VANTIQ
         Thread.sleep(3000);
         checkUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         checkUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         checkUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
-
+        
         // Checking that none of the other images were uploaded to VANTIQ
         checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
         checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
     }
-
+    
     @Test
     public void testImageUploadChangeResolution() throws InterruptedException, IOException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         addLocalTestImages();
-
+        
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         params.put("operation", "upload");
-
+        
         Map<String, Object> savedResolution = new LinkedHashMap<>();
         savedResolution.put("longEdge", RESIZED_IMAGE_WIDTH);
-
+        
         params.put("imageName", IMAGE_2.get("date"));
         params.put("savedResolution", savedResolution);
-
+        
         querySource(params);
-
+        
         // Checking that image was saved to VANTIQ
         Thread.sleep(1000);
         vantiqResponse = vantiq.selectOne("system.documents", IMAGE_2.get("filename"));
@@ -604,125 +603,125 @@ public class TestYoloQueries extends NeuralNetTestBase {
                 }
             }
         }
-
+        
         // Get the path to the saved image in VANTIQ
         JsonObject responseObj = (JsonObject) vantiqResponse.getBody();
         JsonElement pathJSON = responseObj.get("content");
         String imagePath = pathJSON.getAsString();
-
+        
         // Download image so we can confirm dimensions
         vantiqResponse = vantiq.download(imagePath);
         BufferedSource source = (BufferedSource) vantiqResponse.getBody();
         byte[] imageBytes = source.readByteArray();
         InputStream imageStream = new ByteArrayInputStream(imageBytes);
         BufferedImage resizedImage = ImageIO.read(imageStream);
-
+        
         assert resizedImage.getWidth() == RESIZED_IMAGE_WIDTH;
         assert resizedImage.getHeight() == RESIZED_IMAGE_HEIGHT;
     }
-
+    
     @Test
     public void testImageNameDeleteOne() throws IOException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         addLocalTestImages();
-
+        
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         params.put("operation", "delete");
         params.put("imageName", IMAGE_3.get("date"));
-
+        
         querySource(params);
-
+        
         // Check that directory still exists, and that only the one file inside was deleted
         File outputDir = new File(OUTPUT_DIR);
         assert outputDir.exists();
         File[] outputDirFiles = outputDir.listFiles();
         assert outputDirFiles != null;
         assert outputDirFiles.length == 7;
-
+        
         for (File file : outputDirFiles) {
             if (file.getName().equals(IMAGE_3.get("date") + ".jpg")) {
                 fail("This file should have been deleted.");
             }
         }
-
+        
         deleteDirectory(OUTPUT_DIR);
     }
-
+    
     @Test
     public void testImageDateDeleteAll() throws IOException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         addLocalTestImages();
-
+        
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         params.put("operation", "delete");
-
+        
         List<String> imageDate = new ArrayList<String>();
         imageDate.add("-");
         imageDate.add("-");
-
+        
         params.put("imageDate", imageDate);
-
+        
         querySource(params);
-
+        
         File d = new File(OUTPUT_DIR);
         File[] dList = d.listFiles();
         assert dList != null;
         assert dList.length == 1;
         assert dList[0].getName().equals(IMAGE_8.get("name") + ".jpg");
     }
-
+    
     @Test
     public void testImageDateDeleteBefore() throws IOException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         addLocalTestImages();
-
+        
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         params.put("operation", "delete");
-
+        
         List<String> imageDate = new ArrayList<String>();
         imageDate.add("-");
         imageDate.add(START_DATE);
-
+        
         params.put("imageDate", imageDate);
-
+        
         querySource(params);
-
+        
         File d = new File(OUTPUT_DIR);
         File[] dList = d.listFiles();
         assert dList != null;
         assert dList.length == 6;
-
+        
         for (File imageFile: dList) {
             if (imageFile.getName().equals(IMAGE_1.get("filename")) || imageFile.getName().equals(IMAGE_2.get("filename"))) {
                 fail("Image should have been deleted locally.");
             }
         }
     }
-
+    
     @Test
     public void testImageDateDeleteAfter() throws IOException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         addLocalTestImages();
-
+        
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         params.put("operation", "delete");
-
+        
         List<String> imageDate = new ArrayList<String>();
         imageDate.add(START_DATE);
         imageDate.add("-");
-
+        
         params.put("imageDate", imageDate);
-
+        
         querySource(params);
-
+        
         File d = new File(OUTPUT_DIR);
         File[] dList = d.listFiles();
         assert dList != null;
@@ -731,30 +730,30 @@ public class TestYoloQueries extends NeuralNetTestBase {
             assert file.getName().equals(IMAGE_1.get("date") + ".jpg") || file.getName().equals(IMAGE_8.get("name") + ".jpg");
         }
     }
-
+    
     @Test
     public void testImageDateDeleteRange() throws IOException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         addLocalTestImages();
-
+        
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         params.put("operation", "delete");
-
+        
         List<String> imageDate = new ArrayList<String>();
         imageDate.add(START_DATE);
         imageDate.add(END_DATE);
-
+        
         params.put("imageDate", imageDate);
-
+        
         querySource(params);
-
+        
         File d = new File(OUTPUT_DIR);
         File[] dList = d.listFiles();
         assert dList != null;
         assert dList.length == 5;
-
+        
         for (File imageFile: dList) {
             if (imageFile.getName().equals(IMAGE_2.get("date") + ".jpg") && imageFile.getName().equals(IMAGE_3.get("date") + ".jpg")
                     && imageFile.getName().equals(IMAGE_4.get("date") + ".jpg")) {
@@ -762,94 +761,94 @@ public class TestYoloQueries extends NeuralNetTestBase {
             }
         }
     }
-
+    
     @Test
     public void testInvalidPreCroppingQuery() throws IOException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         // Make sure that output directory has not yet been created
         File outputDir = new File(OUTPUT_DIR);
         assert !outputDir.exists();
-
+        
         Map<String,Object> params = new LinkedHashMap<String,Object>();
-
+        
         // Invalid preCrop, it isn't a map
         params.put("cropBeforeAnalysis", "jibberish");
-
+        
         // Run query without setting "operation":"processNextFrame"
         params.put("NNsaveImage", "local");
         params.put("NNoutputDir", OUTPUT_DIR);
         params.put("NNfileName", "testInvalidPreCrop");
-
+        
         querySource(params);
-
+        
         // Check we saved a file in the output directory
         outputDir = new File(OUTPUT_DIR);
         assert outputDir.exists();
-
+        
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         File[] outputDirFiles = outputDir.listFiles();
         assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals("testInvalidPreCrop.jpg");
-
+        
         File resizedImageFile = new File(OUTPUT_DIR + "/" + outputDirFiles[0].getName());
         BufferedImage resizedImage = ImageIO.read(resizedImageFile);
         // If we're here, then we can read the image which is what we expect
     }
-
+    
     @SuppressWarnings("rawtypes")
     @Test
     public void testPreCroppingQueryEncode() throws IOException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         // Make sure that output directory has not yet been created
         File outputDir = new File(OUTPUT_DIR);
         assert !outputDir.exists();
-
+        
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         Map<String, Object> preCrop = new LinkedHashMap<>();
-
+        
         preCrop.put("x", PRECROP_TOP_LEFT_X_COORDINATE);
         preCrop.put("y", PRECROP_TOP_LEFT_Y_COORDINATE);
         preCrop.put("width", CROPPED_WIDTH);
         preCrop.put("height", CROPPED_HEIGHT);
-
+        
         params.put("cropBeforeAnalysis", preCrop);
-
+        
         // Run query without setting "operation":"processNextFrame"
         params.put("NNsaveImage", "local");
         params.put("NNoutputDir", OUTPUT_DIR);
         params.put("NNfileName", "testPreCrop");
         params.put("includeEncodedImage", true);
         params.put("sendFullResponse", true);
-
+        
         VantiqResponse resp = querySourceWithResponse(params);
-
+        
         // Check we saved a file in the output directory
         outputDir = new File(OUTPUT_DIR);
         assert outputDir.exists();
-
+        
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         File[] outputDirFiles = outputDir.listFiles();
         assert outputDirFiles != null;
         assert outputDirFiles.length == 1;
         assert outputDirFiles[0].getName().equals("testPreCrop.jpg");
-
+        
         File resizedImageFile = new File(OUTPUT_DIR + "/" + outputDirFiles[0].getName());
         byte[] resizedImageBytes = Files.readAllBytes(Paths.get(resizedImageFile.getAbsolutePath()));
-
+        
         ByteArrayInputStream img = new ByteArrayInputStream(resizedImageBytes);
         BufferedImage resizedImage = ImageIO.read(img);
-
+        
         assert resizedImage.getWidth() == CROPPED_WIDTH;
         assert resizedImage.getHeight() == CROPPED_HEIGHT;
-
+        
         // Now, check that this image has been encoded correctly.
         String encodedImage = NeuralNetUtils.convertToBase64(resizedImageBytes);
-
+        
         if (resp.hasErrors()) {
             for (VantiqError err: resp.getErrors()) {
                 log.error("Query had errors: {}::{}", err.getCode(), err.getMessage());
@@ -866,36 +865,36 @@ public class TestYoloQueries extends NeuralNetTestBase {
         byte[] retBytes = Base64.getDecoder().decode(returnedImage.getBytes(StandardCharsets.UTF_8));
         try (ByteArrayInputStream retImgStream = new ByteArrayInputStream(retBytes)) {
             BufferedImage retImg = ImageIO.read(retImgStream);
-
+            
             assert retImg.getWidth() == CROPPED_WIDTH;
             assert retImg.getHeight() == CROPPED_HEIGHT;
             assert encodedImage.length() == returnedImage.length();
             assert returnedImage.equals(encodedImage);
         }
     }
-
+    
     @SuppressWarnings("rawtypes")
     @Test
     public void testLocalLabelQueryEncode() throws IOException {
         doLabelTest(true, true, true);
     }
-
+    
     @SuppressWarnings("rawtypes")
     @Test
     public void testLocalLabelNoSaveQueryEncode() throws IOException {
         doLabelTest(true, true, false);
     }
-
+    
     public void doLabelTest(boolean localLabelRequest, boolean includeEncoded, boolean saveImage) throws IOException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-
+        
         // Make sure that output directory has not yet been created
         File outputDir = new File(OUTPUT_DIR);
         assert !outputDir.exists();
-
+        
         Map<String,Object> params = new LinkedHashMap<String,Object>();
-
+        
         // Run query without setting "operation":"processNextFrame"
         if (saveImage) {
             params.put("NNsaveImage", "local");
@@ -907,7 +906,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         if (localLabelRequest) {
             params.put("labelImage", "true");
         }
-
+        
         VantiqResponse resp = querySourceWithResponse(params);
         if (resp.hasErrors()) {
             for (VantiqError err : resp.getErrors()) {
@@ -919,32 +918,32 @@ public class TestYoloQueries extends NeuralNetTestBase {
         assert resp.getBody() instanceof JsonObject;
         JsonObject responseObj = (JsonObject) resp.getBody();
         assert responseObj.has("encodedImage") == includeEncoded;
-
+        
         BufferedImage image = null;
         String encodedImage = null;
         if (saveImage) {
             // Check we saved a file in the output directory
             outputDir = new File(OUTPUT_DIR);
             assert outputDir.exists();
-
+            
             // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
             File[] outputDirFiles = outputDir.listFiles();
             assert outputDirFiles != null;
             assert outputDirFiles.length == 1;
             assert outputDirFiles[0].getName().equals("testLabel.jpg");
-
+            
             File imageFile = new File(OUTPUT_DIR + "/" + outputDirFiles[0].getName());
             byte[] imageBytes = Files.readAllBytes(Paths.get(imageFile.getAbsolutePath()));
-
+            
             ByteArrayInputStream img = new ByteArrayInputStream(imageBytes);
             image = ImageIO.read(img);
             // Now, check that this image has been encoded correctly.
             encodedImage = NeuralNetUtils.convertToBase64(imageBytes);
         }
-
+        
         if (includeEncoded) {
             String returnedImage = responseObj.getAsJsonPrimitive("encodedImage").getAsString();
-
+            
             if (encodedImage != null) {
                 log.debug("Encoded image size: {} -- returned image size: {}",
                         encodedImage.length(), returnedImage.length());
@@ -952,10 +951,10 @@ public class TestYoloQueries extends NeuralNetTestBase {
             byte[] retBytes = Base64.getDecoder().decode(returnedImage.getBytes(StandardCharsets.UTF_8));
             try (ByteArrayInputStream retImgStream = new ByteArrayInputStream(retBytes)) {
                 BufferedImage retImg = ImageIO.read(retImgStream);
-
+                
                 // In the no-save case, we'll just validate that we got an encoded image back & that we can
                 // turn it into an image.
-
+                
                 if (image != null) {
                     assert retImg.getWidth() == image.getWidth();
                     assert retImg.getHeight() == image.getHeight();
@@ -965,7 +964,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
             }
         }
     }
-
+    
    @Test
     public void testPreCroppingQuery() throws IOException {
         // Only run test with intended vantiq availability

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -212,7 +212,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         assert !outputDir.exists();
         
         // Run query without setting "operation":"processNextFrame"
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         params.put("NNsaveImage", "local");
         params.put("NNoutputDir", OUTPUT_DIR);
         params.put("NNfileName", IMAGE_8.get("name"));
@@ -276,7 +276,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         
         // Run query without setting "operation":"processNextFrame"
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         params.put("NNsaveImage", "vantiq");
         params.put("NNfileName", QUERY_FILENAME);
         
@@ -322,7 +322,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         assert !outputDir.exists();
         
         // Run query without setting "operation":"processNextFrame"
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         params.put("NNsaveImage", "both");
         params.put("NNoutputDir", OUTPUT_DIR);
         params.put("NNfileName", IMAGE_8.get("name"));
@@ -408,7 +408,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         addLocalTestImages();
         
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         params.put("operation", "upload");
         params.put("imageName", IMAGE_2.get("date"));
         
@@ -434,7 +434,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         addLocalTestImages();
         
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         params.put("operation", "upload");
         
         List<String> imageDate = new ArrayList<String>();
@@ -462,7 +462,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         addLocalTestImages();
         
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         params.put("operation", "upload");
         
         List<String> imageDate = new ArrayList<String>();
@@ -492,7 +492,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         addLocalTestImages();
         
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         params.put("operation", "upload");
         
         List<String> imageDate = new ArrayList<String>();
@@ -522,7 +522,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         addLocalTestImages();
         
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         params.put("operation", "upload");
         
         List<String> imageDate = new ArrayList<String>();
@@ -552,7 +552,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         addLocalTestImages();
         
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         params.put("operation", "upload");
         
         List<String> imageDate = new ArrayList<String>();
@@ -582,7 +582,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         addLocalTestImages();
         
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         params.put("operation", "upload");
         
         Map<String, Object> savedResolution = new LinkedHashMap<>();
@@ -628,7 +628,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         addLocalTestImages();
         
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         params.put("operation", "delete");
         params.put("imageName", IMAGE_3.get("date"));
         
@@ -657,7 +657,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         addLocalTestImages();
         
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         params.put("operation", "delete");
         
         List<String> imageDate = new ArrayList<String>();
@@ -682,7 +682,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         addLocalTestImages();
         
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         params.put("operation", "delete");
         
         List<String> imageDate = new ArrayList<String>();
@@ -712,7 +712,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         addLocalTestImages();
         
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         params.put("operation", "delete");
         
         List<String> imageDate = new ArrayList<String>();
@@ -739,7 +739,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         addLocalTestImages();
         
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         params.put("operation", "delete");
         
         List<String> imageDate = new ArrayList<String>();
@@ -772,7 +772,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         File outputDir = new File(OUTPUT_DIR);
         assert !outputDir.exists();
         
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         
         // Invalid preCrop, it isn't a map
         params.put("cropBeforeAnalysis", "jibberish");
@@ -809,7 +809,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         File outputDir = new File(OUTPUT_DIR);
         assert !outputDir.exists();
         
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         Map<String, Object> preCrop = new LinkedHashMap<>();
         
         preCrop.put("x", PRECROP_TOP_LEFT_X_COORDINATE);
@@ -863,8 +863,13 @@ public class TestYoloQueries extends NeuralNetTestBase {
         JsonObject responseObj = (JsonObject) resp.getBody();
         assert responseObj.has("encodedImage");
         String returnedImage = responseObj.getAsJsonPrimitive("encodedImage").getAsString();
-        log.debug("Encoded image size: {} -- returned image size: {}", encodedImage.length(), returnedImage.length());
-        log.trace("Encoded image: {} -- returned image: {}", encodedImage, returnedImage);
+        if (log.isDebugEnabled()) {
+            log.debug("Encoded image size: {} -- returned image size: {}", encodedImage.length(),
+                    returnedImage.length());
+            if (log.isTraceEnabled()) {
+                log.trace("Encoded image: {} -- returned image: {}", encodedImage, returnedImage);
+            }
+        }
         byte[] retBytes = Base64.getDecoder().decode(returnedImage.getBytes(StandardCharsets.UTF_8));
         try (ByteArrayInputStream retImgStream = new ByteArrayInputStream(retBytes)) {
             BufferedImage retImg = ImageIO.read(retImgStream);
@@ -896,7 +901,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         File outputDir = new File(OUTPUT_DIR);
         assert !outputDir.exists();
         
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         
         // Run query without setting "operation":"processNextFrame"
         if (saveImage) {
@@ -912,8 +917,10 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         VantiqResponse resp = querySourceWithResponse(params);
         if (resp.hasErrors()) {
-            for (VantiqError err : resp.getErrors()) {
-                log.error("Query had errors: {}::{}", err.getCode(), err.getMessage());
+            if (log.isErrorEnabled()) {
+                for (VantiqError err : resp.getErrors()) {
+                    log.error("Query had errors: {}::{}", err.getCode(), err.getMessage());
+                }
             }
         }
         assert resp.isSuccess();
@@ -948,8 +955,10 @@ public class TestYoloQueries extends NeuralNetTestBase {
             String returnedImage = responseObj.getAsJsonPrimitive("encodedImage").getAsString();
             
             if (encodedImage != null) {
-                log.debug("Encoded image size: {} -- returned image size: {}",
-                        encodedImage.length(), returnedImage.length());
+                if (log.isDebugEnabled()) {
+                    log.debug("Encoded image size: {} -- returned image size: {}",
+                            encodedImage.length(), returnedImage.length());
+                }
             }
             byte[] retBytes = Base64.getDecoder().decode(returnedImage.getBytes(StandardCharsets.UTF_8));
             try (ByteArrayInputStream retImgStream = new ByteArrayInputStream(retBytes)) {
@@ -977,7 +986,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         File outputDir = new File(OUTPUT_DIR);
         assert !outputDir.exists();
                 
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         Map<String, Object> preCrop = new LinkedHashMap<>();
         
         preCrop.put("x", PRECROP_TOP_LEFT_X_COORDINATE);
@@ -1018,7 +1027,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
 
         addLocalTestImages();
 
-        Map<String,Object> params = new LinkedHashMap<String,Object>();
+        Map<String, Object> params = new LinkedHashMap<>();
         params.put("operation", "upload");
         params.put("uploadAsImage", true);
 
@@ -1053,7 +1062,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
     
     // ================================================= Helper functions =================================================
     
-    public static void setupSource(Map<String,Object> sourceDef) {
+    public static void setupSource(Map<String, Object> sourceDef) {
         VantiqResponse insertResponse = vantiq.insert("system.sources", sourceDef);
         if (insertResponse.isSuccess()) {
             core = new ObjectRecognitionCore(SOURCE_NAME, testAuthToken, testVantiqServer, MODEL_DIRECTORY);;
@@ -1061,11 +1070,11 @@ public class TestYoloQueries extends NeuralNetTestBase {
         }
     }
     
-    public static void querySource(Map<String,Object> params) {
+    public static void querySource(Map<String, Object> params) {
         vantiq.query(SOURCE_NAME, params);
     }
 
-    public static VantiqResponse querySourceWithResponse(Map<String,Object> params) {
+    public static VantiqResponse querySourceWithResponse(Map<String, Object> params) {
         return vantiq.query(SOURCE_NAME, params);
     }
     
@@ -1074,7 +1083,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         vantiq.deleteOne(VANTIQ_IMAGES, filename);
     }
     
-    public void checkQueryError(Map<String,Object> params, String operation) {
+    public void checkQueryError(Map<String, Object> params, String operation) {
         vantiqResponse = vantiq.query(SOURCE_NAME, params);
         assert vantiqResponse.hasErrors();
         String errorMessage = vantiqResponse.getErrors().get(0).getMessage();
@@ -1084,7 +1093,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         }
     }
     
-    public void checkQueryErrorImageDateListSize(Map<String,Object> params) {
+    public void checkQueryErrorImageDateListSize(Map<String, Object> params) {
         vantiqResponse = vantiq.query(SOURCE_NAME, params);
         assert vantiqResponse.hasErrors();
         String errorMessage = vantiqResponse.getErrors().get(0).getMessage();
@@ -1094,7 +1103,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         }
     }
     
-    public void checkQueryErrorInvalidDate(Map<String,Object> params) {
+    public void checkQueryErrorInvalidDate(Map<String, Object> params) {
         vantiqResponse = vantiq.query(SOURCE_NAME, params);
         assert vantiqResponse.hasErrors();
         String errorMessage = vantiqResponse.getErrors().get(0).getMessage();
@@ -1104,7 +1113,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         }
     }
     
-    public void invalidParametersHelper(Map<String,Object> params, String operation) {
+    public void invalidParametersHelper(Map<String, Object> params, String operation) {
         // Not including imageName or imageDate
         checkQueryError(params, operation);
         
@@ -1147,13 +1156,13 @@ public class TestYoloQueries extends NeuralNetTestBase {
         checkQueryErrorImageDateListSize(params);
     }
     
-    public static Map<String,Object> createSourceDef() {
-        Map<String,Object> sourceDef = new LinkedHashMap<String,Object>();
-        Map<String,Object> sourceConfig = new LinkedHashMap<String,Object>();
-        Map<String,Object> objRecConfig = new LinkedHashMap<String,Object>();
-        Map<String,Object> dataSource = new LinkedHashMap<String,Object>();
-        Map<String,Object> general = new LinkedHashMap<String,Object>();
-        Map<String,Object> neuralNet = new LinkedHashMap<String,Object>();
+    public static Map<String, Object> createSourceDef() {
+        Map<String, Object> sourceDef = new LinkedHashMap<>();
+        Map<String, Object> sourceConfig = new LinkedHashMap<>();
+        Map<String, Object> objRecConfig = new LinkedHashMap<>();
+        Map<String, Object> dataSource = new LinkedHashMap<>();
+        Map<String, Object> general = new LinkedHashMap<>();
+        Map<String, Object> neuralNet = new LinkedHashMap<>();
         
         // Setting up dataSource config options
         dataSource.put("camera", IP_CAMERA_URL);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -893,6 +893,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         doLabelTest(true, true, false);
     }
     
+    @SuppressWarnings("PMD.CognitiveComplexity")
     public void doLabelTest(boolean localLabelRequest, boolean includeEncoded, boolean saveImage) throws IOException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
@@ -954,11 +955,9 @@ public class TestYoloQueries extends NeuralNetTestBase {
         if (includeEncoded) {
             String returnedImage = responseObj.getAsJsonPrimitive("encodedImage").getAsString();
             
-            if (encodedImage != null) {
-                if (log.isDebugEnabled()) {
-                    log.debug("Encoded image size: {} -- returned image size: {}",
-                            encodedImage.length(), returnedImage.length());
-                }
+            if (encodedImage != null && log.isDebugEnabled()) {
+                log.debug("Encoded image size: {} -- returned image size: {}",
+                        encodedImage.length(), returnedImage.length());
             }
             byte[] retBytes = Base64.getDecoder().decode(returnedImage.getBytes(StandardCharsets.UTF_8));
             try (ByteArrayInputStream retImgStream = new ByteArrayInputStream(retBytes)) {

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -851,8 +851,10 @@ public class TestYoloQueries extends NeuralNetTestBase {
         String encodedImage = NeuralNetUtils.convertToBase64(resizedImageBytes);
         
         if (resp.hasErrors()) {
-            for (VantiqError err: resp.getErrors()) {
-                log.error("Query had errors: {}::{}", err.getCode(), err.getMessage());
+            if (log.isErrorEnabled()) {
+                for (VantiqError err : resp.getErrors()) {
+                    log.error("Query had errors: {}::{}", err.getCode(), err.getMessage());
+                }
             }
         }
         assert resp.isSuccess();

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -201,7 +201,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         invalidParametersHelper(params, "delete");
     }
-
+    
     @Test
     public void testProcessNextFrameLocal() {
         // Only run test with intended vantiq availability
@@ -236,11 +236,11 @@ public class TestYoloQueries extends NeuralNetTestBase {
         // Running query with operation set to "processNextFrame"
         params.put("operation", "processNextFrame");
         querySource(params);
-
+        
         // Check we saved a file in the output directory
         outputDir = new File(OUTPUT_DIR);
         assert outputDir.exists();
-
+        
         // Check there is only one file, and it's name is equivalent to QUERY_FILENAME
         outputDirFiles = outputDir.listFiles();
         assert outputDirFiles != null;
@@ -554,7 +554,8 @@ public class TestYoloQueries extends NeuralNetTestBase {
         
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         params.put("operation", "upload");
-                List<String> imageDate = new ArrayList<String>();
+        
+        List<String> imageDate = new ArrayList<String>();
         imageDate.add(START_DATE);
         imageDate.add(END_DATE);
         params.put("imageDate", imageDate);


### PR DESCRIPTION
Fixes #317 

Adds `includeEncodedImage` to configuration & query parameters.  When set, the results (for a query, when `sendFullResponse` is true) will include a property `encodedImage` whose value is the Base64 encoded image on which the results are based.  If `labelImage` is true, the labeling will be included in the resulting image.

Added tests, etc., for same.