### PR TITLE
Allow connections to > 1 Vantiq

### DIFF
--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -297,7 +297,6 @@ public class ExtensionWebSocketClient {
         return localProbeFuture != null && localLivenessSocket != null && !localLivenessSocket.isClosed();
     }
     
-    
     /**
      * Attempts to connect to the source using the given target url and authentication token. If the connection fails,
      * {@link #isOpen}, {@link #isAuthed}, and {@link #isConnected} can be used to identify if the connection failed
@@ -344,7 +343,6 @@ public class ExtensionWebSocketClient {
     public synchronized CompletableFuture<Boolean> initiateWebsocketConnection(String url) {
         boolean sendPings = utils.obtainSendPingStatus();
         return initiateWebsocketConnection(url, sendPings);
-    
     }
     /**
      * Creates a WebSocket connection to the given URL. Does nothing if a connection has already been established

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -14,11 +14,7 @@ package io.vantiq.extjsdk;
 
 // For decoding of the messages received
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-// WebSocket imports
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.WebSocket;
+import com.google.common.collect.EvictingQueue;
 
 import java.io.IOException;
 import java.net.ServerSocket;
@@ -29,17 +25,19 @@ import java.util.Map;
 import java.util.concurrent.*;
 import java.util.Queue;
 import java.util.UUID;
-
-import com.google.common.collect.EvictingQueue;
-
-// Logging
+// WebSocket imports
 import okio.ByteString;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.WebSocket;
+// Logging
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * A client that handles the WebSocket connection with a Vantiq deployment, for the purposes of Extension sources.
  */
+@SuppressWarnings("PMD.TooManyFields")
 public class ExtensionWebSocketClient {
     
     /**

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -343,7 +343,7 @@ public class ExtensionWebSocketClient {
      * @return      A {@link CompletableFuture} that will return true when the connection succeeds, or false
      *              WebSocket fails to connect.
      */
-    synchronized public CompletableFuture<Boolean> initiateWebsocketConnection(String url) {
+    public synchronized CompletableFuture<Boolean> initiateWebsocketConnection(String url) {
         boolean sendPings = utils.obtainSendPingStatus();
         return initiateWebsocketConnection(url, sendPings);
     
@@ -357,7 +357,7 @@ public class ExtensionWebSocketClient {
      * @return      A {@link CompletableFuture} that will return true when the connection succeeds, or false
      *              WebSocket fails to connect.
      */
-    synchronized public CompletableFuture<Boolean> initiateWebsocketConnection(String url, boolean sendPings) {
+    public synchronized CompletableFuture<Boolean> initiateWebsocketConnection(String url, boolean sendPings) {
         // Only create the webSocketFuture if the websocket connection has completed or it has failed
         if (webSocket == null || !webSocketFuture.getNow(true)) {
             webSocketFuture = new CompletableFuture<>();
@@ -635,7 +635,7 @@ public class ExtensionWebSocketClient {
      * @return      A {@link CompletableFuture} that will return true when the authentication succeeds, or false
      *              when the WebSocket connection fails before authentication can occur.
      */
-    synchronized public CompletableFuture<Boolean> authenticate(String user, String pass) {
+    public synchronized CompletableFuture<Boolean> authenticate(String user, String pass) {
         Map<String, String> authData = new LinkedHashMap<>();
         authData.put("username", user);
         authData.put("password", pass);
@@ -669,7 +669,7 @@ public class ExtensionWebSocketClient {
      * @return      A {@link CompletableFuture} that will return true when the authentication succeeds, or false
      *              when the WebSocket connection fails before authentication can occur.
      */
-    synchronized public CompletableFuture<Boolean> authenticate(String token) {
+    public synchronized CompletableFuture<Boolean> authenticate(String token) {
         authData = token;
         // Only create the authFuture if there has been no request or a failed request, and a websocket request has 
         // been made
@@ -724,7 +724,7 @@ public class ExtensionWebSocketClient {
      */
     // Send a connection request for the source
     // Note that this client MUST already be authenticated or else the message will be ignored
-    synchronized public CompletableFuture<Boolean> connectToSource() {
+    public synchronized CompletableFuture<Boolean> connectToSource() {
         // Only create the authFuture if there has been no request or a failed request, and a websocket request has 
         // been made
         if (authFuture != null && (sourceFuture == null || !sourceFuture.getNow(true))) {

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/InstanceConfigUtils.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/InstanceConfigUtils.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright (c) 2022 Vantiq, Inc.
+ *
+ * All rights reserved.
+ *
+ * SPDX: MIT
+ */
+
 package io.vantiq.extjsdk;
 
 import static io.vantiq.extjsdk.Utils.AUTH_TOKEN_PROPERTY_NAME;

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/InstanceConfigUtils.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/InstanceConfigUtils.java
@@ -1,0 +1,187 @@
+package io.vantiq.extjsdk;
+
+import static io.vantiq.extjsdk.Utils.AUTH_TOKEN_PROPERTY_NAME;
+import static io.vantiq.extjsdk.Utils.PORT_PROPERTY_NAME;
+import static io.vantiq.extjsdk.Utils.SECRET_CREDENTIALS;
+import static io.vantiq.extjsdk.Utils.SEND_PING_PROPERTY_NAME;
+import static io.vantiq.extjsdk.Utils.SERVER_CONFIG_DIR;
+import static io.vantiq.extjsdk.Utils.SERVER_CONFIG_FILENAME;
+import static io.vantiq.extjsdk.Utils.SOURCES_PROPERTY_NAME;
+import static io.vantiq.extjsdk.Utils.TARGET_SERVER_PROPERTY_NAME;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Properties;
+
+public class InstanceConfigUtils {
+
+    // String used by methods to synch on
+    private final String SYNCH_LOCK = "synchLockString";
+    
+    public static final String CONFIG_WAS_PROGRAMMATIC = "configWasProgrammatic";
+
+    // The properties object containing the data from the server configuration file
+    private Properties serverConfigProperties;
+    
+    /**
+     * Provide server config properties programmatically.
+     *
+     * Used when the configuration properties necessary to connect to Vantiq are provided via a means outside
+     * the reading of the server.config file.  This also sets a property telling this class that the information
+     * was provided programmatically so that subsequent calls to obtainServerConfig will not overwrite things from
+     * the server.config file or generate an error when that file doesn't exist.
+     *
+     * If this is called repeatedly, each will override the last.
+     *
+     * @param targetServer  String URL for the Vantiq server
+     * @param authToken     String indicating the access token to use to connect to the server at targetServer
+*    * @param sources       String containing a comma separated list of source names to use.
+     * @param sendPings     Boolean indicating whether the client connection should ping the Vantiq server to maintain
+     *                      the connection.
+     * @param tcpProbePort  Integer providing a port to open for TCP probes when running in a Kubernetes environment.
+     *
+     * @return              Properties the server config properties as provided.
+     */
+    public Properties provideServerConfig(String targetServer, String authToken, String sources,
+                                                 Boolean sendPings, Integer tcpProbePort) {
+        Properties localSCP = new Properties();
+        if (StringUtils.isAnyEmpty(targetServer, authToken, sources)) {
+            throw new IllegalArgumentException("The targetServer, authToken, and sources parameters " +
+                    "must be non-null & non-empty.");
+        }
+        localSCP.put(TARGET_SERVER_PROPERTY_NAME, targetServer);
+        localSCP.put(AUTH_TOKEN_PROPERTY_NAME, authToken);
+        localSCP.put(SOURCES_PROPERTY_NAME, sources);
+        localSCP.put(SEND_PING_PROPERTY_NAME, (sendPings == null ? Boolean.FALSE.toString() : sendPings));
+        if (tcpProbePort != null) {
+            localSCP.put(PORT_PROPERTY_NAME, tcpProbePort.toString());
+        }
+        localSCP.put(CONFIG_WAS_PROGRAMMATIC, true);
+        
+        synchronized (SYNCH_LOCK) {
+            serverConfigProperties = localSCP;
+        }
+        return serverConfigProperties;
+    }
+
+    public Properties obtainServerConfig() {
+        return obtainServerConfig(SERVER_CONFIG_FILENAME);
+    }
+    
+    /**
+     * Turn the given configuration file into a {@link Properties} object.
+     *
+     * @param fileName  The name of the configuration file holding the server configuration.
+     * @return          The properties specified in the file.
+     */
+    public Properties obtainServerConfig(String fileName) {
+        synchronized (SYNCH_LOCK) {
+            boolean wasProgrammatic = false;
+            if (serverConfigProperties != null) {
+                if (serverConfigProperties.get(CONFIG_WAS_PROGRAMMATIC) instanceof Boolean) {
+                    wasProgrammatic = (Boolean) serverConfigProperties.get(CONFIG_WAS_PROGRAMMATIC);
+                }
+            }
+            // If config props were provided programmatically, don't override them.  Simply return
+            // what's already there.
+            if (wasProgrammatic) {
+                return serverConfigProperties;
+            }
+            
+            // Otherwse, re-read the file
+            File configFile = new File(SERVER_CONFIG_DIR, fileName);
+            serverConfigProperties = new Properties();
+
+            try {
+                if (!configFile.exists()) {
+                    configFile = new File(fileName);
+                }
+                serverConfigProperties.load(Files.newInputStream(configFile.toPath()));
+
+                // Next we check for the existence of an environment variable containing a secret reference to the authToken
+                // We only set it if the value is not empty and if the authToken wasn't already specified in the
+                // server.config
+                String secretAuthToken = System.getenv(SECRET_CREDENTIALS);
+                if (secretAuthToken != null && !StringUtils.isBlank(secretAuthToken)
+                        && serverConfigProperties.getProperty(AUTH_TOKEN_PROPERTY_NAME) == null) {
+                    serverConfigProperties.setProperty(AUTH_TOKEN_PROPERTY_NAME, secretAuthToken);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException("Could not find valid server configuration file. Expected location: '"
+                        + configFile.getAbsolutePath() + "'", e);
+            } catch (Exception e) {
+                throw new RuntimeException("Error occurred when trying to read the server configuration file. "
+                        + "Please ensure it is formatted properly.", e);
+            }
+
+            return serverConfigProperties;
+        }
+    }
+
+    /**
+     * Helper method used to get the TCP Probe Port if specified in the server.config
+     *
+     * @return An Integer for the port value provided in the server.config file, or null if non was specified.
+     */
+    public Integer obtainTCPProbePort() {
+        Properties localServerConfigProps;
+
+        // Get a local copy of the props while synchronized
+        synchronized (SYNCH_LOCK) {
+            localServerConfigProps = serverConfigProperties;
+        }
+
+        if (localServerConfigProps != null) {
+            // Grab the property and return result
+            String portString = localServerConfigProps.getProperty(PORT_PROPERTY_NAME);
+            if (portString != null) {
+                return Integer.valueOf(portString);
+            }
+        } else {
+            throw new RuntimeException("Error occurred when checking for the tcpProbePort property. The " +
+                    "server.config properties have not yet been captured. Before checking for specific properties, " +
+                    "the 'obtainServerConfig' method must first be called.");
+        }
+
+        return null;
+    }
+
+    /**
+     * Helper method used to get the sendPings property if specified in the server.config
+     *
+     * @return The boolean value for the sendPings property, or false if it wasn't specified
+     */
+    public boolean obtainSendPingStatus() {
+        Properties localServerConfigProps;
+
+        // Get a local copy of the props while synchronized
+        synchronized (SYNCH_LOCK) {
+            localServerConfigProps = serverConfigProperties;
+        }
+
+        if (localServerConfigProps != null) {
+            String sendPingString = localServerConfigProps.getProperty(SEND_PING_PROPERTY_NAME);
+            if (sendPingString != null) {
+                return Boolean.parseBoolean(sendPingString);
+            }
+        } else {
+            throw new RuntimeException("Error occurred when checking for the sendPings property. The server.config " +
+                    "properties have not yet been captured. Before checking for specific properties, the " +
+                    "'obtainServerConfig' method must first be called.");
+        }
+
+        return false;
+    }
+
+    /**
+     * Method used to clear the local copy of server.config properties
+     */
+    public void clearServerConfigProperties() {
+        synchronized (SYNCH_LOCK) {
+            serverConfigProperties = null;
+        }
+    }
+}

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/InstanceConfigUtils.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/InstanceConfigUtils.java
@@ -17,10 +17,6 @@ import java.nio.file.Files;
 import java.util.Properties;
 
 public class InstanceConfigUtils {
-
-    // String used by methods to synch on
-    private final String SYNCH_LOCK = "synchLockString";
-    
     public static final String CONFIG_WAS_PROGRAMMATIC = "configWasProgrammatic";
 
     // The properties object containing the data from the server configuration file
@@ -61,7 +57,7 @@ public class InstanceConfigUtils {
         }
         localSCP.put(CONFIG_WAS_PROGRAMMATIC, true);
         
-        synchronized (SYNCH_LOCK) {
+        synchronized (this) {
             serverConfigProperties = localSCP;
         }
         return serverConfigProperties;
@@ -78,7 +74,7 @@ public class InstanceConfigUtils {
      * @return          The properties specified in the file.
      */
     public Properties obtainServerConfig(String fileName) {
-        synchronized (SYNCH_LOCK) {
+        synchronized (this) {
             boolean wasProgrammatic = false;
             if (serverConfigProperties != null) {
                 if (serverConfigProperties.get(CONFIG_WAS_PROGRAMMATIC) instanceof Boolean) {
@@ -130,7 +126,7 @@ public class InstanceConfigUtils {
         Properties localServerConfigProps;
 
         // Get a local copy of the props while synchronized
-        synchronized (SYNCH_LOCK) {
+        synchronized (this) {
             localServerConfigProps = serverConfigProperties;
         }
 
@@ -158,7 +154,7 @@ public class InstanceConfigUtils {
         Properties localServerConfigProps;
 
         // Get a local copy of the props while synchronized
-        synchronized (SYNCH_LOCK) {
+        synchronized (this) {
             localServerConfigProps = serverConfigProperties;
         }
 
@@ -180,7 +176,7 @@ public class InstanceConfigUtils {
      * Method used to clear the local copy of server.config properties
      */
     public void clearServerConfigProperties() {
-        synchronized (SYNCH_LOCK) {
+        synchronized (this) {
             serverConfigProperties = null;
         }
     }

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
@@ -10,10 +10,6 @@ import java.util.Properties;
  */
 
 public class Utils {
-
-    // String used by methods to synch on
-    private final String SYNCH_LOCK = "synchLockString";
-
     public static final String SEND_PING_PROPERTY_NAME = "sendPings";
     public static final String PORT_PROPERTY_NAME = "tcpProbePort";
     public static final String SERVER_CONFIG_DIR = "serverConfig";

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
@@ -10,6 +10,8 @@ import java.util.Properties;
  */
 
 public class Utils {
+    
+    private static final String SYNCH_LOCK = "UtilsSyncLock";
     public static final String SEND_PING_PROPERTY_NAME = "sendPings";
     public static final String PORT_PROPERTY_NAME = "tcpProbePort";
     public static final String SERVER_CONFIG_DIR = "serverConfig";
@@ -18,16 +20,14 @@ public class Utils {
     public static final String TARGET_SERVER_PROPERTY_NAME = "targetServer";
     public static final String AUTH_TOKEN_PROPERTY_NAME = "authToken";
     public static final String SOURCES_PROPERTY_NAME = "sources";
-    public static final String CONFIG_WAS_PROGRAMMATIC = "configWasProgrammatic";
-
-    // The properties object containing the data from the server configuration file
-    private Properties serverConfigProperties;
     
-    static InstanceConfigUtils staticInstance = null;
+    private static InstanceConfigUtils staticInstance = null;
     
     private static void ensureStaticInstance() {
-        if (staticInstance == null) {
-            staticInstance = new InstanceConfigUtils();
+        synchronized (SYNCH_LOCK) {
+            if (staticInstance == null) {
+                staticInstance = new InstanceConfigUtils();
+            }
         }
     }
     

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/Utils.java
@@ -1,30 +1,50 @@
 package io.vantiq.extjsdk;
 
-import org.apache.commons.lang3.StringUtils;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.Properties;
+
+/**
+ * Maintains a static configuration instance.  This class is used when the configuration
+ * details are shared by all sources in the connector.
+ *
+ * Makes use of the InstanceConfigUtils class to manage the static instance.
+ */
 
 public class Utils {
 
     // String used by methods to synch on
-    private static final String SYNCH_LOCK = "synchLockString";
+    private final String SYNCH_LOCK = "synchLockString";
 
     public static final String SEND_PING_PROPERTY_NAME = "sendPings";
     public static final String PORT_PROPERTY_NAME = "tcpProbePort";
     public static final String SERVER_CONFIG_DIR = "serverConfig";
     public static final String SERVER_CONFIG_FILENAME = "server.config";
     public static final String SECRET_CREDENTIALS = "CONNECTOR_AUTH_TOKEN";
+    public static final String TARGET_SERVER_PROPERTY_NAME = "targetServer";
+    public static final String AUTH_TOKEN_PROPERTY_NAME = "authToken";
+    public static final String SOURCES_PROPERTY_NAME = "sources";
+    public static final String CONFIG_WAS_PROGRAMMATIC = "configWasProgrammatic";
 
     // The properties object containing the data from the server configuration file
-    private static Properties serverConfigProperties;
-
-    public static Properties obtainServerConfig() {
-        return obtainServerConfig(SERVER_CONFIG_FILENAME);
+    private Properties serverConfigProperties;
+    
+    static InstanceConfigUtils staticInstance = null;
+    
+    private static void ensureStaticInstance() {
+        if (staticInstance == null) {
+            staticInstance = new InstanceConfigUtils();
+        }
+    }
+    
+    public static InstanceConfigUtils getInstanceUtilsConfigInstance() {
+        ensureStaticInstance();
+        return staticInstance;
     }
 
+    public static Properties obtainServerConfig() {
+        ensureStaticInstance();
+        return staticInstance.obtainServerConfig(SERVER_CONFIG_FILENAME);
+    }
+    
     /**
      * Turn the given configuration file into a {@link Properties} object.
      *
@@ -32,34 +52,8 @@ public class Utils {
      * @return          The properties specified in the file.
      */
     public static Properties obtainServerConfig(String fileName) {
-        synchronized (SYNCH_LOCK) {
-            File configFile = new File(SERVER_CONFIG_DIR, fileName);
-            serverConfigProperties = new Properties();
-
-            try {
-                if (!configFile.exists()) {
-                    configFile = new File(fileName);
-                }
-                serverConfigProperties.load(Files.newInputStream(configFile.toPath()));
-
-                // Next we check for the existence of an environment variable containing a secret reference to the authToken
-                // We only set it if the value is not empty and if the authToken wasn't already specified in the
-                // server.config
-                String secretAuthToken = System.getenv(SECRET_CREDENTIALS);
-                if (secretAuthToken != null && !StringUtils.isBlank(secretAuthToken)
-                        && serverConfigProperties.getProperty("authToken") == null) {
-                    serverConfigProperties.setProperty("authToken", secretAuthToken);
-                }
-            } catch (IOException e) {
-                throw new RuntimeException("Could not find valid server configuration file. Expected location: '"
-                        + configFile.getAbsolutePath() + "'", e);
-            } catch (Exception e) {
-                throw new RuntimeException("Error occurred when trying to read the server configuration file. "
-                        + "Please ensure it is formatted properly.", e);
-            }
-
-            return serverConfigProperties;
-        }
+        ensureStaticInstance();
+        return staticInstance.obtainServerConfig(fileName);
     }
 
     /**
@@ -68,26 +62,8 @@ public class Utils {
      * @return An Integer for the port value provided in the server.config file, or null if non was specified.
      */
     public static Integer obtainTCPProbePort() {
-        Properties localServerConfigProps;
-
-        // Get a local copy of the props while synchronized
-        synchronized (SYNCH_LOCK) {
-            localServerConfigProps = serverConfigProperties;
-        }
-
-        if (localServerConfigProps != null) {
-            // Grab the property and return result
-            String portString = localServerConfigProps.getProperty(PORT_PROPERTY_NAME);
-            if (portString != null) {
-                return Integer.valueOf(portString);
-            }
-        } else {
-            throw new RuntimeException("Error occurred when checking for the tcpProbePort property. The " +
-                    "server.config properties have not yet been captured. Before checking for specific properties, " +
-                    "the 'obtainServerConfig' method must first be called.");
-        }
-
-        return null;
+        ensureStaticInstance();
+        return staticInstance.obtainTCPProbePort();
     }
 
     /**
@@ -96,33 +72,15 @@ public class Utils {
      * @return The boolean value for the sendPings property, or false if it wasn't specified
      */
     public static boolean obtainSendPingStatus() {
-        Properties localServerConfigProps;
-
-        // Get a local copy of the props while synchronized
-        synchronized (SYNCH_LOCK) {
-            localServerConfigProps = serverConfigProperties;
-        }
-
-        if (localServerConfigProps != null) {
-            String sendPingString = localServerConfigProps.getProperty(SEND_PING_PROPERTY_NAME);
-            if (sendPingString != null) {
-                return Boolean.parseBoolean(sendPingString);
-            }
-        } else {
-            throw new RuntimeException("Error occurred when checking for the sendPings property. The server.config " +
-                    "properties have not yet been captured. Before checking for specific properties, the " +
-                    "'obtainServerConfig' method must first be called.");
-        }
-
-        return false;
+        ensureStaticInstance();
+        return staticInstance.obtainSendPingStatus();
     }
 
     /**
      * Method used to clear the local copy of server.config properties
      */
     public static void clearServerConfigProperties() {
-        synchronized (SYNCH_LOCK) {
-            serverConfigProperties = null;
-        }
+        ensureStaticInstance();
+        staticInstance.clearServerConfigProperties();
     }
 }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/ObjRecTestBase.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/ObjRecTestBase.java
@@ -44,8 +44,8 @@ public class ObjRecTestBase {
 //    public static final String IP_CAMERA_URL = "https://wzmedia.dot.ca.gov/D4/S680_at_N_Main_St.stream/playlist.m3u8";
     // Walnut Creek/North Main camera (above) currently malfunctioning.  Swapping to Hwy 242 Junction for now.
     // Keeping old around to swap back sometime.
-    public static final String IP_CAMERA_URL = "https://wzmedia.dot.ca.gov/D4/N680_JSO_JCT_242.stream/playlist.m3u8";
-
+//    public static final String IP_CAMERA_URL = "https://wzmedia.dot.ca.gov/D4/N680_JSO_JCT_242.stream/playlist.m3u8";
+    public static final String IP_CAMERA_URL = "https://wzmedia.dot.ca.gov/D3/80_reed.stream/playlist.m3u8";
     @BeforeClass
     public static void getProps() {
         testAuthToken = System.getProperty("TestAuthToken", null);


### PR DESCRIPTION
Fixes #348 

Today, connectors are configured using the `server.config` file that provides for the connection of > 1 source to a single Vantiq.  Some future connectors may have the need to be connected to more that one Vantiq installation.

This PR refactors the `extjsdk/Utils` class so that the callers can use it the existing way (supporting configuration through the `server.config` file to a single Vantiq) or via an instance-based approach where there could be a number of different connections.

Most existing connectors are unchanged.  The refactoring moves most of the work to an `InstanceConfigUtil.java` class, and the `Util.java` class maintains a static instance of that class.  This preserves existing usage while allowing for further capabilities by exposing the worker class.  The various clients expose overloads so the configuration instance can be passed in.

