### PR TITLE
Fix sporadic reconnect/reconfig issue

### DIFF
--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -59,7 +59,7 @@ public class TestJDBC extends TestJDBCBase {
     static final String TIME = "9:24:18";
     static final String FORMATTED_TIMESTAMP = "2018-08-15T09:24:18.000-0700";
     static final String FORMATTED_TIME = "09:24:18.000-0800";
-    static final String VANTIQ_FORMATTED_TIMESTAMP = "2018-08-15T16:24:18Z";
+    static final String VANTIQ_FORMATTED_TIMESTAMP = "2018-08-15T16:24:18.000Z";
     
     // Queries to test oddball types
     static final String CREATE_TABLE_EXTENDED_TYPES = "create table TestTypes(id int, ts TIMESTAMP, testDate DATE, "
@@ -601,7 +601,7 @@ public class TestJDBC extends TestJDBCBase {
         String vantiqTimestamp = responseMap.get("timestamp").getAsString();
         
         // Check that the date was offset by adding 7 hours (since original date ends in 0700)
-        assert vantiqTimestamp.equals(VANTIQ_FORMATTED_TIMESTAMP);
+        assertEquals("Formatted time stamp", VANTIQ_FORMATTED_TIMESTAMP, vantiqTimestamp);
         
         // Delete the Type from VANTIQ
         deleteType();


### PR DESCRIPTION
Fixes #354 

Adds retry logic to ExtJSdk's ExtensionWebSocketClient.doCoreReconnect().  Due to the way the server must function, there is a small window where a restarting source can be in a discombobulated state.  When we encounter this, retry the connect a few times.  This should close the window where errors of the for OP_CONNECT_EXTENSION failed because there was no associates stream service."  These were rare, but did occur.

Also fixed issue with date formatting test.