### PR TITLE
Set base version for Java compatibility to 1.8 in prep for Camel stuff

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,6 +136,9 @@ subprojects {
     }
 
     sourceCompatibility = 1.8
+    java.sourceCompatibility = 1.8
+    java.targetCompatibility = JavaVersion.VERSION_1_8
+
 
     // Simulate provided dependencies
     configurations {


### PR DESCRIPTION
The camel code is compatible with Java's 1.11 & 1.17.  To build that on Jenkins, we'll need to convert the Jenkins jobs to 1.11.  But our older connectors don't necessarily want/need to make this move yet, so we'll set the base version 1.8, overriding it 1.11 where required.