### PR TITLE
Add handling for remote (or other unexpected) close of web socket.

### DIFF
--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -586,8 +586,12 @@ public class ExtensionWebSocketClient {
                     this.webSocket.send(ByteString.of(bytes));
                 }
             }
-        }
-        catch (Exception e) {
+        } catch (IllegalStateException ise) {
+            log.warn("Error sending to WebSocket", ise);
+            sourceHasDisconnected();
+            close();
+            throw new RuntimeException("Lost connection to Vantiq source", ise);
+        } catch (Exception e) {
             log.warn("Error sending to WebSocket", e);
         }
     }

--- a/extjsdk/src/test/java/io/vantiq/extjsdk/FalseWebSocket.java
+++ b/extjsdk/src/test/java/io/vantiq/extjsdk/FalseWebSocket.java
@@ -32,13 +32,20 @@ import org.jetbrains.annotations.NotNull;
  */
 public class FalseWebSocket implements WebSocket {
     FalseBufferedSink s = new FalseBufferedSink();
+    boolean closedByRemote = false;
     
     public byte[] getMessage() {
         return s.retrieveSentBytes();
     }
     
+    public void setClosedByRemote(boolean newState) {
+        closedByRemote = newState;
+    }
     @Override
     public boolean send(@NotNull ByteString bytes) {
+        if (closedByRemote) {
+            throw new IllegalStateException("Emulating remote closure or other unexpected state");
+        }
         s.write(bytes);
         return true;
     }


### PR DESCRIPTION
Fixes #359 

When a send() request fails with an illegalStateException, it means that the websocket is no longer serviceable.  This may be due to the server (remote) closing the socket or some other issue in the network connection.  When we detect this, we had previously logged the error but otherwise done nothing.

Change this behavior so that the client will close the connection and throw an exception.  The closing will cause the close handler to be called (assuming one has been configured), allowing the client to recover as is appropriate.  Alternatively,, the client can trap the exception and react to that.

Added emulation & test for this situation.