### PR TITLE
Add docker file to build camelConnector

### DIFF
--- a/camelConnector/src/main/docker/Dockerfile
+++ b/camelConnector/src/main/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM amazoncorretto:11-alpine-jdk
+RUN mkdir /app
+ADD camelConnector.tar /app
+WORKDIR /app
+ENTRYPOINT ["./camelConnector/bin/camelConnector"]


### PR DESCRIPTION
Fixes #365

Using amazoncorretto, alpine variant, since it makes for an image that's over 100MB smaller.