### PR TITLE
Fhc fix overzealous vantiq URL fixup

### DIFF
--- a/camelComponent/src/test/java/io/vantiq/extsrc/camel/ClientRegistryTest.java
+++ b/camelComponent/src/test/java/io/vantiq/extsrc/camel/ClientRegistryTest.java
@@ -1,11 +1,13 @@
 package io.vantiq.extsrc.camel;
 
+import static org.assertj.core.api.Fail.fail;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import io.vantiq.extjsdk.ExtensionWebSocketClient;
 import io.vantiq.extsrc.camel.utils.ClientRegistry;
+import org.apache.camel.CamelException;
 import org.junit.After;
 import org.junit.Test;
 
@@ -98,6 +100,44 @@ public class ClientRegistryTest {
         buildAndVerify(SOURCE_NAME, SERVER_URL_W_SPACES, false);
         
         assertEquals("Known client count", 1, ClientRegistry.getKnownClientCount());
+    }
+    
+    @Test
+    public void testUriAdjustment() {
+        String newUrl = null;
+        try {
+            newUrl = VantiqEndpoint.adjustVantiqTarget("vantiq://somewhere", false);
+            assert newUrl.equals("https://somewhere");
+    
+            newUrl = VantiqEndpoint.adjustVantiqTarget("vantiq://somewhere", false);
+            assert newUrl.equals("https://somewhere");
+    
+            newUrl = VantiqEndpoint.adjustVantiqTarget("https://internal.vantiq.com", false);
+            assert newUrl.equals("https://internal.vantiq.com");
+    
+            newUrl = VantiqEndpoint.adjustVantiqTarget("https://internal.vantiq.com", true);
+            assert newUrl.equals("https://internal.vantiq.com");
+    
+            newUrl = VantiqEndpoint.adjustVantiqTarget("vantiq://internal.vantiq.com", false);
+            assert newUrl.equals("https://internal.vantiq.com");
+    
+            newUrl = VantiqEndpoint.adjustVantiqTarget("vantiq://internal.vantiq.com", true);
+            assert newUrl.equals("http://internal.vantiq.com");
+    
+            newUrl = VantiqEndpoint.adjustVantiqTarget("https://vantiqnode:8080", false);
+            assert newUrl.equals("https://vantiqnode:8080");
+    
+            newUrl = VantiqEndpoint.adjustVantiqTarget("https://vantiqnode:8080", true);
+            assert newUrl.equals("https://vantiqnode:8080");
+    
+            newUrl = VantiqEndpoint.adjustVantiqTarget("vantiq://vantiqnode:8080", false);
+            assert newUrl.equals("https://vantiqnode:8080");
+    
+            newUrl = VantiqEndpoint.adjustVantiqTarget("vantiq://vantiqnode:8080", true);
+            assert newUrl.equals("http://vantiqnode:8080");
+        } catch (CamelException ce) {
+            fail("Could not complete adjustment for URI: " + newUrl, ce);
+        }
     }
     
     public void buildAndVerify(String srcName, String target, boolean shouldBeCreated) {

--- a/camelComponent/src/test/java/io/vantiq/extsrc/camel/VantiqLiveComponentTest.java
+++ b/camelComponent/src/test/java/io/vantiq/extsrc/camel/VantiqLiveComponentTest.java
@@ -434,7 +434,6 @@ public class VantiqLiveComponentTest extends CamelTestSupport {
         sourceDef.put("name", testSourceName);
         sourceDef.put("type", SRC_IMPL_TYPE);
         sourceDef.put("active", "true");
-        sourceDef.put("direction", "BOTH");
         sourceDef.put("config", new LinkedHashMap<String, Object>());
     
         VantiqResponse insertResponse = vantiq.insert("system.sources", sourceDef);
@@ -454,7 +453,6 @@ public class VantiqLiveComponentTest extends CamelTestSupport {
         sourceDef.put("name", testQuerySourceName);
         sourceDef.put("type", SRC_IMPL_TYPE);
         sourceDef.put("active", "true");
-        sourceDef.put("direction", "BOTH");
         sourceDef.put("config", new LinkedHashMap<String, Object>());
         
         VantiqResponse insertResponse = vantiq.insert("system.sources", sourceDef);

--- a/camelConnector/src/main/docker/Dockerfile
+++ b/camelConnector/src/main/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM amazoncorretto:11-alpine-jdk
+RUN mkdir /app
+ADD camelConnector.tar /app
+WORKDIR /app
+ENTRYPOINT ["./camelConnector/bin/camelConnector"]


### PR DESCRIPTION
Fixes #367 

Our mechanism for fixing up the vantiq:// URL's was faulty, made worse by some recent changes.

Convert to mechanism whereby we use the URI class to replace the protoco _only_ when its value is `vantiq`.  This way, we don't inadvertently replace the string `vantiq` elsewhere in the URI.