### PR TITLE
Make PlaceholderComponent subclass BeanComponent.

### DIFF
--- a/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelRunner.java
+++ b/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelRunner.java
@@ -479,7 +479,12 @@ public class CamelRunner extends MainSupport implements Closeable {
      * @throws Exception for errors in loading the routes.
      */
     protected RouteBuilder loadRouteFromText(String specification, String specificationType) throws Exception {
-        log.debug("Loading route (specificationType {}): {}", specificationType, specification);
+        log.debug("Loading route from {} specificationType", specificationType);
+        if (log.isTraceEnabled()) {
+            // Dump route spec out here only under trace.  Camel may have substituted key values and we don't want
+            // these in the log files
+            log.trace("Loading route (specificationType {}): {}", specificationType, specification);
+        }
         ExtendedCamelContext extendedCamelContext = camelContext.adapt(ExtendedCamelContext.class);
         RoutesLoader loader = extendedCamelContext.getRoutesLoader();
         Resource resource = ResourceHelper.fromString("in-memory." + specificationType, specification);

--- a/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/PlaceholderComponent.java
+++ b/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/PlaceholderComponent.java
@@ -9,7 +9,7 @@
 package io.vantiq.extsrc.camelconn.discover;
 
 import org.apache.camel.Endpoint;
-import org.apache.camel.support.DefaultComponent;
+import org.apache.camel.component.bean.BeanComponent;
 
 import java.util.Map;
 
@@ -17,8 +17,19 @@ import java.util.Map;
  * This component is a placeholder used to allow the connector to gather the set of components it will need.
  * This component has sufficient content to allow the route building (but not starting) to complete, allowing
  * the connector to determine the set of components it will need (via the {@link EnumeratingComponentResolver}).
+ *
+ * Note that rather than simply extending the Default Component, we extend the BeanComponent instead.  For non-bean
+ * components, this is harmless as BeanComponent, in turn, extends DefaultComponent.  And the method overrides
+ * provided herein keep anything from starting up anyway (we are only doing this to satisfy Camel that things are
+ * basically runnable.
+ *
+ * For things where Camel expects a BeanComponent, it checks that the component instance IsA BeanComponent,
+ * complaining vociferously if that's not the case and shutting everything down (See issue
+ * (<a href="https://github.com/Vantiq/vantiq-extension-sources/issues/372">#372</a>.)
+ * With this change, non-bean component discovery continues to operate as expected, and bean component discovery
+ * now succeeds.
  **/
-class PlaceholderComponent extends DefaultComponent {
+class PlaceholderComponent extends BeanComponent {
     
     @Override
     protected Endpoint createEndpoint(String uri, String remaining, Map<String, Object> parameters) throws Exception {
@@ -37,6 +48,14 @@ class PlaceholderComponent extends DefaultComponent {
      */
     @Override
     protected void doStart() {
+        // noop
+    }
+    
+    /**
+     * This is a placeholder only, used to facilitate our discovery of necessary components.
+     */
+    @Override
+    protected void doShutdown() {
         // noop
     }
 }

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentDiscoveryTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentDiscoveryTest.java
@@ -553,9 +553,9 @@ public class VantiqComponentDiscoveryTest extends CamelTestSupport {
             + "            json: \n"
             + "              library: jackson \n"
             + "        - to: \n"
-            + "             uri: \"azure-eventhubs://mmunro-test/mmunrohub\" \n"
+            + "             uri: \"azure-eventhubs://vantiq-test/vantiqNotReallyThere\" \n"
             + "             parameters: \n"
-            + "                 sharedAccessName: \"mmunroHubSAS\" \n"
+            + "                 sharedAccessName: \"someRandomKey\" \n"
             + "                 sharedAccessKey: \"RAW(MY TOKEN)\" \n";
     
             // YAML support needs a camel context.  So provide oe during setup...


### PR DESCRIPTION
Having the `PlaceholderComponent` extend `BeanComponent` (which, in turn, extends `DefaultComponent`) allows our placeholder to be acceptable to Camel as a bean component when it tries to "start" our discovered setup (no start really happens).  This should permit discovery to proceed and allow things to work as expected.

Added test based on issue report.

Fixes #372