### PR TITLE
Add warning when createConsumer() called multiple times.

### DIFF
--- a/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqEndpoint.java
+++ b/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqEndpoint.java
@@ -20,7 +20,6 @@ import io.vantiq.extsrc.camel.utils.ClientRegistry;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.camel.CamelContext;
 import org.apache.camel.CamelException;
 import org.apache.camel.Category;
 import org.apache.camel.Consumer;
@@ -146,7 +145,6 @@ public class VantiqEndpoint extends DefaultEndpoint {
                               " not used in multiple places. That said, sometimes this error result from defining " +
                               "routes without ids.  Please add ids to any routes in use and retry.");
         }
-        CamelContext ctx = getCamelContext();
         Consumer consumer = new VantiqConsumer(this, processor);
         consumerCreated = true;
         configureConsumer(consumer);


### PR DESCRIPTION
This may be due to caller error -- there could be > 1 route defined using the same consumer (which is an error).  However, it is also the case that defining (even a single) route with no id can cause this to happen (as is the case in this issue). This appears to be an issue with Apache camel itself.  See Camel issues [14969](https://issues.apache.org/jira/browse/CAMEL-14969) and [13651](https://issues.apache.org/jira/browse/CAMEL-13651) which appear to be similar but not quite the same.

To help folks resolve this, we'll dump out an error and a hint.  Tried to return the same consumer, but that doesn't avoid the issue.