### PR TITLE
ExtJSdk: extension source stops retrying to connect if source is momentarily missing 

### DIFF
--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -778,6 +778,10 @@ public class ExtensionWebSocketClient {
                             continue;
                         } else {
                             log.error("Failed to connect within 10 seconds");
+                            // We could not reconnect to the source - close the connection which also triggers
+                            // the extension source close handler so it can decide what to do next (e.g., forever
+                            // retry connection, exit extension source)
+                            this.close();
                         }
                     } else {
                         isReconnected = true;


### PR DESCRIPTION
If we cannot automatically reconnect to the source (and failed enough trying), close the connection so the extension source code can decide what to do about it.

Testing this scenario was based on manual testing. In this case, removing a source definition while the extension source was connected, observing failure, recreating the source definition and validating that the extension source could reconnect automatically.

Close #377 
