### PR TITLE
Update imports for python connector SDK & connector

### DIFF
--- a/extpsdk/build.gradle
+++ b/extpsdk/build.gradle
@@ -1,7 +1,7 @@
 import org.gradle.internal.os.OperatingSystem
 
 plugins {
-    id 'ru.vyarus.use-python' version '2.3.0'
+    id 'ru.vyarus.use-python' version '3.0.0'
 }
 
 ext {
@@ -11,7 +11,7 @@ ext {
         pypi_repo = 'testpypi'
     }
     if (!project.rootProject.hasProperty('vantiqConnectorSdkVersion')) {
-        vantiqConnectorSdkVersion = '1.1.12'
+        vantiqConnectorSdkVersion = '1.1.13'
     }
 }
 
@@ -20,6 +20,9 @@ python {
     pythonBinary
     // path to python binary (global by default)
     pythonPath
+    // Let pip parse the requirements to txt file
+    // use-python plugin has issues with more complex requirements.txt specifications
+    requirements.strict = false
     // additional environment variables, visible for all python commands
     // Note: We specify the directory paths to search in the pytest.ini file
     environment = [:]
@@ -55,23 +58,22 @@ python {
     // copy virtualenv instead of symlink (when created)
     envCopy = false
 
-    pip 'pip:22.0.4'
+    pip 'pip:23.1.2'
 
-    // Product use
-    pip 'websockets:10.2'
+    // For product runtime
+    pip 'websockets:11.0.3'
     pip 'jprops:2.0.2'
 
     // For testing
-    pip 'pytest:6.2.5'
-    pip 'pytest-asyncio:0.18.3'
-    pip 'pytest-pythonpath:0.7.4'
+    pip 'pytest:7.3.1'
+    pip 'pytest-asyncio:0.21.0'
     pip 'pytest-timeout:2.1.0'
-    pip 'pytest-html:3.1.1'   // To generate html reports from pytest cases
+    pip 'pytest-html:3.2.0'   // To generate html reports from pytest cases
 
     // For build generation
-    pip 'build:0.7.0'  // For building the distribution
+    pip 'build:0.10.0'  // For building the distribution
     // For publication
-    pip 'twine:4.0.0'
+    pip 'twine:4.0.2'
 }
 
 task pytest(type: PythonTask) {

--- a/extpsdk/pytest.ini
+++ b/extpsdk/pytest.ini
@@ -6,6 +6,5 @@ minversion = 6.0
 addopts = -rE -q --junit-xml=./build/test-results/test/TEST-io.vantiq.extsrc.extpsdk.pytest.xml
 asyncio_mode = strict
 testpaths = src/test/python
-python_paths =
-    src/main/python
+pythonpath = src/main/python
 

--- a/extpsdk/requirements.txt
+++ b/extpsdk/requirements.txt
@@ -18,13 +18,12 @@ pluggy==1.0.0; python_version >= '3.6'
 prodict==0.8.18
 py==1.11.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 pyparsing==3.0.7; python_version >= '3.6'
-pytest-asyncio==0.18.3
-pytest-html==3.1.1
-pytest-pythonpath==0.7.4
+pytest-asyncio==0.21.0
+pytest-html==3.2.0
 pytest-timeout==2.1.0
-pytest==6.2.5
+pytest==7.3.1
 setuptools==65.5.1
 signals==0.0.2
 toml==0.10.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
-websockets==10.2
+websockets==11.0.3
 wheel==0.38.1

--- a/extpsdk/src/main/templates/setup.cfg.tmpl
+++ b/extpsdk/src/main/templates/setup.cfg.tmpl
@@ -19,5 +19,5 @@ package_dir = =src/main/python
 py_modules = vantiqconnectorsdk
 python_requires = >=3.8
 install_requires=
-    websockets>=10.2
+    websockets>=11.0.3
     jprops>=2.0.2

--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -14,7 +14,7 @@ ext {
     if (!project.rootProject.hasProperty('pyExecSrcVersion')) {
         pyExecSrcVersion = '1.1.11'
     }
-    vantiqSdkVersion = '1.1.2'
+    vantiqSdkVersion = '1.1.3'
     vantiqConnectorSdkVersion = '1.1.12'
 }
 

--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -1,7 +1,7 @@
 import org.gradle.internal.os.OperatingSystem
 
 plugins {
-    id 'ru.vyarus.use-python' version '2.3.0'
+    id 'ru.vyarus.use-python' version '3.0.0'
 }
 
 ext {
@@ -12,7 +12,7 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('pyExecSrcVersion')) {
-        pyExecSrcVersion = '1.1.10'
+        pyExecSrcVersion = '1.1.11'
     }
     vantiqSdkVersion = '1.1.2'
     vantiqConnectorSdkVersion = '1.1.12'
@@ -23,6 +23,11 @@ python {
     pythonBinary
     // path to python binary (global by default)
     pythonPath
+    // Let pip parse the requirements to txt file
+    // use-python plugin has issues with more complex requirements.txt specifications.
+    // Moreover, this module has no requirements.txt file.  The generated one ends up containing
+    // some development parts apparently included in pytest, so we don't want to require those.
+    requirements.use = false
     // additional environment variables, visible for all python commands
     // Note: We specify the directory paths to search in the pytest.ini file
     environment = [:]
@@ -58,19 +63,18 @@ python {
     // copy virtualenv instead of symlink (when created)
     envCopy = false
 
-    pip 'pip:22.0.4'
+    pip 'pip:23.1.2'
 
     // For product runtime
-    pip 'websockets:10.2'
-    pip 'codetiming:1.3.0'
+    pip 'websockets:11.0.3'
+    pip 'codetiming:1.4.0'
 
     // For testing
-    pip 'aioresponses:0.7.3'
-    pip 'pytest:6.2.5'
-    pip 'pytest-asyncio:0.18.3'
-    pip 'pytest-pythonpath:0.7.4'
+    pip 'aioresponses:0.7.4'
+    pip 'pytest:7.3.1'
+    pip 'pytest-asyncio:0.21.0'
     pip 'pytest-timeout:2.1.0'
-    pip 'pytest-html:3.1.1'   // To generate html reports from pytest cases
+    pip 'pytest-html:3.2.0'   // To generate html reports from pytest cases
 
     // Note:  Placing these last even though they have to do with the product
     // There appears to be an issue with the pytest-asyncio that's present in the test.pypi,org
@@ -86,9 +90,9 @@ python {
     pip "vantiqsdk:${vantiqSdkVersion}"
 
      // For build generation
-    pip 'build:0.7.0'  // For building the distribution
+    pip 'build:0.10.0'  // For building the distribution
     // For publication
-    pip 'twine:4.0.0'
+    pip 'twine:4.0.2'
 }
 
 tasks.withType(PythonTask) {
@@ -109,6 +113,7 @@ tasks.withType(PythonTask) {
 task pytest(type: PythonTask) {
     println project.projectDir
     module = 'pytest'
+    extraArgs = ['--capture=fd']
 }
 
 task generateDockerFile(type: Copy) {

--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -15,7 +15,7 @@ ext {
         pyExecSrcVersion = '1.1.11'
     }
     vantiqSdkVersion = '1.1.3'
-    vantiqConnectorSdkVersion = '1.1.12'
+    vantiqConnectorSdkVersion = '1.1.13'
 }
 
 python {

--- a/pythonExecSource/pytest.ini
+++ b/pythonExecSource/pytest.ini
@@ -4,6 +4,4 @@ minversion = 6.0
 addopts = -rE -q --html=./build/reports/tests/test/index.html --junit-xml=./build/test-results/test/TEST-io.vantiq.pyexecsource.pytest.xml
 asyncio_mode = strict
 testpaths = src/test/python
-python_paths =
-    src/main/python
 pythonpath = src/main/python

--- a/pythonExecSource/pytest.ini
+++ b/pythonExecSource/pytest.ini
@@ -6,3 +6,4 @@ asyncio_mode = strict
 testpaths = src/test/python
 python_paths =
     src/main/python
+pythonpath = src/main/python


### PR DESCRIPTION
Fixes #381 

Update imports for python connector SDK & python connector for python 3.10 compatibility.

Analog to similar change just done for Vantiq Python SDK.