### PR TITLE
Camel Component: Add flag to have consumer output be JSON rather than Java Map default

### DIFF
--- a/camelComponent/README.md
+++ b/camelComponent/README.md
@@ -81,7 +81,11 @@ your Source Implementation) as the Source Type. No configuration information is 
 ## Messages from the Source
 
 Messages that are sent to the component will arrive in a Camel Exchange as a Java Map, where the keys in the map
-correspond to the property names in the object sent from Vantiq.  Messages sent to Vantiq from the component will
+correspond to the property names in the object sent from Vantiq. If desired, you change this behavior
+by adding the `consumerOutputJson` component endpoint option (see below) with a value of `true`.
+When so specified, messages sent to a Vantiq consumer will arrive in a Camel Exchange as a JSON string.
+
+Messages sent to Vantiq from the component will
 arrive as Vail objects, where the property names correspond to the Map keys.
 
 ## Exchanges to Vantiq
@@ -96,7 +100,7 @@ in Json format will be accepted as well.
 The URI for the Vantiq connection takes the following form:
 
 ```
-    vantiq://host[:port]?sourceName=<source name>&accessToken=<access token>[&sendPings=<boolean>][&failedMessageQueueSize=<int>]
+    vantiq://host[:port]?sourceName=<source name>&accessToken=<access token>[&sendPings=<boolean>][&failedMessageQueueSize=<int>][&consumerOutputJson=<boolean>]
 ```
 
 ### Component Endpoint Options
@@ -109,6 +113,7 @@ The endpoint options apply to producer and consumer endpoints.  The following ar
 * **accessToken** is the access token used for the connection
 * **sendPings** [optional] a boolean value indicating whether to periodically ping the Vantiq server (default is false)
 * **failedMessageQueueSize** [optional] an integer value indicating how many messages to hold for sending when the connection to the Vantiq server fails.
+* **consumerOutputJson** [optional] a boolean value indicating whether messages sent from Vantiq to the Vantiq component (_i.e._, a Vantiq Consumer) should be put into an Apache Camel Exchange as a JSON message.  If false, messages are put into an exchange as a Java Map.
 
 For example, to create an Apache Camel application that receives messages from a Vantiq system at `vantiq.example.com`
 from source `exampleSource` and access token `FD10s0x...`, we would use something like the following:

--- a/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqConsumer.java
+++ b/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqConsumer.java
@@ -11,6 +11,8 @@ package io.vantiq.extsrc.camel;
 import static org.apache.camel.ExchangePattern.InOnly;
 import static org.apache.camel.ExchangePattern.InOut;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vantiq.extjsdk.ExtensionServiceMessage;
 import io.vantiq.extjsdk.ExtensionWebSocketClient;
 import io.vantiq.extjsdk.Handler;
@@ -29,6 +31,8 @@ public class VantiqConsumer extends DefaultConsumer {
     private ExtensionWebSocketClient vantiqClient;
 
     private ExecutorService executorService;
+    
+    ObjectMapper mapper = new ObjectMapper();
     
     public VantiqConsumer(VantiqEndpoint endpoint, Processor processor) {
         super(endpoint, processor);
@@ -92,6 +96,12 @@ public class VantiqConsumer extends DefaultConsumer {
         } else {
             ExtensionServiceMessage message = (ExtensionServiceMessage) msg;
             Object msgBody = message.getObject();
+
+            if (endpoint.isConsumerOutputJson()) {
+                // Convert to JSON output
+               JsonNode jnode =  mapper.convertValue(msgBody, JsonNode.class);
+               msgBody = jnode.toPrettyString();
+            }
     
             // Create an exchange to move our message along.  In the publish case,
             // we have no interest in the result, so we'll allow it to be released when

--- a/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqEndpoint.java
+++ b/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqEndpoint.java
@@ -71,6 +71,11 @@ public class VantiqEndpoint extends DefaultEndpoint {
     @Setter
     private boolean noSsl;
     
+    @UriParam(defaultValue = "false")
+    @Getter
+    @Setter
+    private boolean consumerOutputJson;
+    
     @UriParam(defaultValue = "25")
     @Setter
     private int failedMessageQueueSize;

--- a/camelComponent/src/test/java/io/vantiq/extsrc/camel/VantiqComponentTest.java
+++ b/camelComponent/src/test/java/io/vantiq/extsrc/camel/VantiqComponentTest.java
@@ -16,6 +16,15 @@ import io.vantiq.extjsdk.FalseClient;
 import io.vantiq.extjsdk.FalseWebSocket;
 import io.vantiq.extjsdk.Response;
 import io.vantiq.extjsdk.TestListener;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import okhttp3.WebSocket;
 import okio.ByteString;
 import org.apache.camel.Exchange;
@@ -26,16 +35,6 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class VantiqComponentTest extends CamelTestSupport {
     
@@ -59,6 +58,16 @@ public class VantiqComponentTest extends CamelTestSupport {
     private final String vantiqQuerySenderUri = "vantiq://querierdoesntmatter/" +
             "?sourceName=" + testSourceName +
             "&accessToken=" + accessToken;
+    
+    private final String vantiqJsonSenderUri = "vantiq://jsonsenderdoesntmatter/" +
+            "?sourceName=" + testSourceName +
+            "&accessToken=" + accessToken +
+            "&consumerOutputJson=true";
+    
+    private final String vantiqJsonQuerierUri = "vantiq://jsonquerierdoesntmatter/" +
+            "?sourceName=" + testSourceName +
+            "&accessToken=" + accessToken +
+            "&consumerOutputJson=true";
     
     @Test
     public void testVantiqSetup() throws Exception {
@@ -108,6 +117,7 @@ public class VantiqComponentTest extends CamelTestSupport {
             assert testSourceName.equals(lastMsg.get("sourceName"));
             assert lastMsg.containsKey("object");
             assert lastMsg.get("object") instanceof Map;
+            //noinspection unchecked
             Map<String, Object> msg = (Map<String, Object>) lastMsg.get("object");
             assert msg.containsKey("hi");
             assert ((String) msg.get("hi")).contains("mom");
@@ -131,6 +141,7 @@ public class VantiqComponentTest extends CamelTestSupport {
             assert testSourceName.equals(lastMsg.get("sourceName"));
             assert lastMsg.containsKey("object");
             assert lastMsg.get("object") instanceof Map;
+            //noinspection unchecked
             Map<String, Object> msg = (Map<String, Object>) lastMsg.get("object");
             assert msg.containsKey("hi");
             assert ((String) msg.get("hi")).contains("dad");
@@ -152,6 +163,7 @@ public class VantiqComponentTest extends CamelTestSupport {
                 assert testSourceName.equals(lastMsg.get("sourceName"));
                 assert lastMsg.containsKey("object");
                 assert lastMsg.get("object") instanceof Map;
+                //noinspection unchecked
                 Map<String, Object> testMsg = (Map<String, Object>) lastMsg.get("object");
                 assert testMsg.containsKey("hi");
                 assert ((String) testMsg.get("hi")).contains("aki");
@@ -170,6 +182,7 @@ public class VantiqComponentTest extends CamelTestSupport {
         assert testSourceName.equals(lastMsg.get("sourceName"));
         assert lastMsg.containsKey("object");
         assert lastMsg.get("object") instanceof Map;
+        //noinspection unchecked
         Map<String, Object> msg = (Map<String, Object>) lastMsg.get("object");
         assert msg.containsKey("bye");
         assert "mom".equals(msg.get("bye"));
@@ -256,6 +269,67 @@ public class VantiqComponentTest extends CamelTestSupport {
     }
     
     @Test
+    public void testVantiqConsumerOutputJson() throws Exception {
+        
+        // First, grab our test environment.
+        FauxVantiqComponent vc = (FauxVantiqComponent) context.getComponent("vantiq");
+        assert vc != null;
+        // Note that we need to fetch the endpoints by URI since there are more than one of them.
+        FauxVantiqEndpoint endp = (FauxVantiqEndpoint) context.getEndpoint(vantiqJsonSenderUri);
+        
+        assert endp.myClient.getListener() instanceof TestListener;
+        TestListener tl = (TestListener) endp.myClient.getListener();
+        
+        int expectedMsgCount = 10;
+        MockEndpoint mocked = getMockEndpoint(routeEndUri);
+        mocked.expectedMinimumMessageCount(expectedMsgCount);
+        VantiqEndpoint ve = getMandatoryEndpoint(vantiqEndpointUri, VantiqEndpoint.class);
+        assert ve != null;
+        ObjectMapper mapper = new ObjectMapper();
+        WebSocket ws = new FalseWebSocket();
+        for (int i = 0; i < expectedMsgCount; i++) {
+            ExtensionServiceMessage ep = new ExtensionServiceMessage(vantiqEndpointUri);
+            ep.op = ExtensionServiceMessage.OP_PUBLISH;
+            ep.resourceName = "SOURCES";
+            ep.resourceId = testSourceName;
+            HashMap<String, Object> msg = new HashMap<>();
+            msg.put(TEST_MSG_KEY, TEST_MSG_PREAMBLE + i);
+            ep.object = msg;
+            
+            byte[] msgBytes = mapper.writeValueAsBytes(ep);
+            
+            // Given the message bytes, simulate delivery of our WebSocket message
+            tl.onMessage(ws, new ByteString(msgBytes));
+        }
+        
+        // Consumers run in BG threads, so wait a bit for those to finish.
+        mocked.await(5L, TimeUnit.SECONDS);
+        
+        assertEquals("Mocked service expected vs. actual", expectedMsgCount, mocked.getReceivedCounter());
+        List<Exchange> exchanges = mocked.getReceivedExchanges();
+        Set<String> uniqueMsgs = new HashSet<String>();
+        exchanges.forEach(exchange -> {
+            Object exchangeBody = exchange.getIn().getBody();
+            assertNotNull("Null exchange body",  exchangeBody);
+            // Verify that we got JSON -- which will manifest here as a String, but we'll verify that we can convert it.
+            assertTrue("Vantiq Consumer Output wrong type: " + exchangeBody.getClass().getName(),
+                exchangeBody instanceof String);
+            Map msg = null;
+            try {
+                msg = mapper.readValue((String) exchangeBody, Map.class);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+            assertNotNull("Deserialized msg is null", msg);
+            assert msg.containsKey(TEST_MSG_KEY);
+            assert msg.get(TEST_MSG_KEY) instanceof String;
+            assert ((String) msg.get(TEST_MSG_KEY)).startsWith(TEST_MSG_PREAMBLE);
+            uniqueMsgs.add(((String) msg.get(TEST_MSG_KEY)));
+        });
+        assert uniqueMsgs.size() == expectedMsgCount;
+    }
+    
+    @Test
     public void testVantiqConsumerQuery() throws Exception {
         
         // First, grab our test environment.
@@ -329,6 +403,93 @@ public class VantiqComponentTest extends CamelTestSupport {
         String ra = rsp.getHeader(ExtensionServiceMessage.RESPONSE_ADDRESS_HEADER);
         assert responseAddresses.contains(ra);
     }
+    
+    @Test
+    public void testVantiqConsumerOutputJsonQuery() throws Exception {
+        
+        // First, grab our test environment.
+        FauxVantiqComponent vc = (FauxVantiqComponent) context.getComponent("vantiq");
+        assert vc != null;
+        // Note that we need to fetch the endpoints by URI since there are more than one of them.
+        FauxVantiqEndpoint endp = (FauxVantiqEndpoint) context.getEndpoint(vantiqJsonQuerierUri);
+    
+        assertNotNull("Endpoint's client is null", endp.myClient.getListener());
+        assertTrue("Endpoint's client is not a TestListener: " +
+                              endp.myClient.getListener().getClass().getName(),
+                      endp.myClient.getListener() instanceof TestListener);
+        TestListener tl = (TestListener) endp.myClient.getListener();
+        
+        int expectedMsgCount = 10;
+        MockEndpoint mocked = getMockEndpoint(routeEndUri);
+        mocked.expectedMinimumMessageCount(expectedMsgCount);
+        VantiqEndpoint ve = getMandatoryEndpoint(vantiqEndpointUri, VantiqEndpoint.class);
+        assert ve != null;
+        ObjectMapper mapper = new ObjectMapper();
+        WebSocket ws = new FalseWebSocket();
+        Set<String> responseAddresses = new HashSet<>();
+        for (int i = 0; i < expectedMsgCount; i++) {
+            ExtensionServiceMessage ep = new ExtensionServiceMessage(vantiqEndpointUri);
+            ep.op = ExtensionServiceMessage.OP_QUERY;
+            ep.resourceName = "SOURCES";
+            ep.resourceId = testSourceName;
+            Map<String, Object> hdrs = new HashMap<>();
+            String respAddr = UUID.randomUUID().toString();
+            hdrs.put(ExtensionServiceMessage.ORIGIN_ADDRESS_HEADER, respAddr);
+            responseAddresses.add(respAddr);
+            ep.messageHeaders = hdrs;
+            HashMap<String, Object> msg = new HashMap<>();
+            msg.put(TEST_MSG_KEY, TEST_MSG_PREAMBLE + i);
+            ep.object = msg;
+            
+            byte[] msgBytes = mapper.writeValueAsBytes(ep);
+            
+            // Given the message bytes, simulate delivery of our WebSocket message
+            tl.onMessage(ws, new ByteString(msgBytes));
+        }
+        
+        // Consumers run in BG threads, so wait a bit for those to finish.
+        mocked.await(5L, TimeUnit.SECONDS);
+        
+        assertEquals("Mocked service expected vs. actual", expectedMsgCount, mocked.getReceivedCounter());
+        List<Exchange> exchanges = mocked.getReceivedExchanges();
+        Set<String> uniqueMsgs = new HashSet<String>();
+        exchanges.forEach(exchange -> {
+            Object exchBody = exchange.getIn().getBody();
+            assertNotNull("Exchange boddy is null", exchBody);
+            assertTrue("Exchange body wrong type: " + exchBody.getClass().getName(),
+                       exchange.getIn().getBody() instanceof String);
+            Map msg = null;
+            try {
+                msg = mapper.readValue((String) exchBody, Map.class);
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
+            }
+            assertNotNull("Deserialized JSON message is null", msg);
+            assert msg.containsKey(TEST_MSG_KEY);
+            assert msg.get(TEST_MSG_KEY) instanceof String;
+            assert ((String) msg.get(TEST_MSG_KEY)).startsWith(TEST_MSG_PREAMBLE);
+            uniqueMsgs.add(((String) msg.get(TEST_MSG_KEY)));
+            
+            Map<String, Object> props = exchange.getProperties();
+            assert props.containsKey(ExtensionServiceMessage.RESPONSE_ADDRESS_HEADER);
+        });
+        assert uniqueMsgs.size() == expectedMsgCount;
+        
+        // Note that we need to fetch the endpoints by URI since there are more than one of them.
+        FauxVantiqEndpoint ep = (FauxVantiqEndpoint) context.getEndpoint(vantiqJsonQuerierUri);
+        FalseClient fc = ep.myClient;
+        Response rsp = fc.getLastMessageAsResponse();
+        assert rsp != null;
+        assert rsp.getBody() != null;
+        assert rsp.getStatus() == 200;
+        Object o = rsp.getBody();
+        assert o instanceof Map;
+        Map<String, Object> response = (Map) o;
+        log.debug("Found final response message: {}", response);
+        assert response.containsKey("Response");
+        String ra = rsp.getHeader(ExtensionServiceMessage.RESPONSE_ADDRESS_HEADER);
+        assert responseAddresses.contains(ra);
+    }
 
     @Override
     protected RouteBuilder createRouteBuilder() throws Exception {
@@ -351,11 +512,20 @@ public class VantiqComponentTest extends CamelTestSupport {
                 from(vantiqSenderUri)
                         .to(routeEndUri);
     
+                from(vantiqJsonSenderUri)
+                        .to(routeEndUri);
+                
                 from(vantiqQuerySenderUri)
                         .setExchangePattern(ExchangePattern.InOut)
                         .to(routeEndUri)
                             .setBody(constant("{ \"Response\": \"Message\"}"))
                         .to(vantiqQuerySenderUri);
+    
+                from(vantiqJsonQuerierUri)
+                        .setExchangePattern(ExchangePattern.InOut)
+                        .to(routeEndUri)
+                        .setBody(constant("{ \"Response\": \"Message\"}"))
+                        .to(vantiqJsonQuerierUri);
             }
         };
     }

--- a/camelComponent/src/test/java/io/vantiq/extsrc/camel/VantiqComponentTest.java
+++ b/camelComponent/src/test/java/io/vantiq/extsrc/camel/VantiqComponentTest.java
@@ -347,7 +347,7 @@ public class VantiqComponentTest extends CamelTestSupport {
                 uniqueMsgs.add(((String) ((Map) msg).get(TEST_MSG_KEY)));
             } else if (msg instanceof String) {
                 assertEquals((String) msg, extraTestMsgs.get(0));
-            } else if (msg instanceof List) {
+            } else {
                 assertEquals((List) msg, extraTestMsgs.get(1));
             }
         });


### PR DESCRIPTION
Fixes #383

This adds a flag to the camel component endpoint URL `consumerOutputJson` which changes the component's behavior when it is operating as a _consumer_ (getting messages from Vantiq & pushing them thru Camel).  While one can accomplish this using a _marshaling_ step, doing things this way makes it much easier to include Vantiq in Kamelets.  By adding this to the URL, we can avoid having to rewrite the steps portion(s) of any Kamelets using the Vantiq component.