### PR TITLE
Add support for camel property placeholders (& resolution)

### DIFF
--- a/camelConnector/README.md
+++ b/camelConnector/README.md
@@ -132,11 +132,48 @@ The Configuration document may look similar to the following example:
 
 ### Options Available for camelRuntime
 
-*   **appName**: Optional -- name of the app.  If not provided, default to _camelConnectorApp_.
-*   **routesDocument** or **routesList** and **routesFormat**: Required. This is list of Camel routes to run.
-    * **routesDocument** -- the name of a Vantiq Document containing the XML or YAML definition of the routes to run. The format of the document (XML or YAML) will be determined from the file name (_e.g._, `routes.xml`)
-    * **routesList** and **routesFormat** -- the XML or YAML specification of the Camel routes to run.  The **routesList** property should contain the appropriate text, and the **routesFormat** should contain either `xml` or `yml` indicating the style used to specify the routes.
-    * *Note*: You must specify either the **routesDocument** or **routesList** _AND_ **routesFormat** properties, but not both.
+* **appName**: Optional -- name of the app.  If not provided, default to _camelConnectorApp_.
+* **routesDocument** or **routesList** and **routesFormat**: Required. This is list of Camel routes to run.
+* **routesDocument** -- the name of a Vantiq Document containing the XML or YAML definition of the routes to run. The format of the document (XML or YAML) will be determined from the file name (_e.g._, `routes.xml`)
+* **routesList** and **routesFormat** -- the XML or YAML specification of the Camel routes to run.  The **routesList** property should contain the appropriate text, and the **routesFormat** should contain either `xml` or `yml` indicating the style used to specify the routes.
+      * *Note*: You must specify either the **routesDocument** or **routesList** _AND_ **routesFormat** properties, but not both.
+* **componentProperties** -- a list of JSON objects which contain the component name & associated properties. These are used by some components for their configuration and/or operation. Values here may include security information (clientId or tokens).
+    * The format of this values is a list of JSON objects, where each JSON object contains a **componentName** property containing the name of the component for which these properties are to be applied, and **componentProperties** containing a Json object consisting of property names and values.
+    * For example, if we needed to define the `clientId` and `securityToken` properties for the `example` component, we would add the following to the `camelRuntime` section of the source configuration.
+  
+        ```json
+        {
+            "camelRuntime": {
+            ...
+            "componentProperties": [
+                {
+                    "componentName": "example",
+                    "componentProperties": {
+                        "clientId": "me@example.com",
+                        "securityToken": "someExampleToken..."
+                    }
+                }
+           ],
+           ...
+           }    
+        }
+        ```
+
+* **propertyValues** -- a JSON object where each property specifies the name and value to be provided for the Apache Camel property placeholder. [Property placeholders](https://camel.apache.org/manual/using-propertyplaceholder.html) can be used in Camel routes to supply values at the route configuration time. 
+    * For example, to provide values for the properties `name` and `company`, you would add the following the the `camelRuntime` section.
+  
+    ```json
+    {
+        "camelRuntime": {
+            ...
+            "propertyValues": {
+                "name": "fred",
+                "company": "vantiq"
+            }
+            ...
+        }
+   }
+   ```
 
 ### Options available for general
 
@@ -199,7 +236,7 @@ Messages are sent to the source as _notifications_, and are delivered as _events
 Messages sent to Vantiq from the component/connector will
 arrive as VAIL objects, where the property names correspond to the Map keys.
 The Vantiq Component expects messages in an exchange to arrive in the form of a Java Map.  However, messages arriving
-in Json format will be accepted as well.
+in JSON format will be accepted as well.
 When constructing your Camel Application, you must keep this in mind.
 
 ## Messages from the Source

--- a/camelConnector/README.md
+++ b/camelConnector/README.md
@@ -133,9 +133,9 @@ The Configuration document may look similar to the following example:
 ### Options Available for camelRuntime
 
 * **appName**: Optional -- name of the app.  If not provided, default to _camelConnectorApp_.
-* **routesDocument** or **routesList** and **routesFormat**: Required. This is list of Camel routes to run.
-* **routesDocument** -- the name of a Vantiq Document containing the XML or YAML definition of the routes to run. The format of the document (XML or YAML) will be determined from the file name (_e.g._, `routes.xml`)
-* **routesList** and **routesFormat** -- the XML or YAML specification of the Camel routes to run.  The **routesList** property should contain the appropriate text, and the **routesFormat** should contain either `xml` or `yml` indicating the style used to specify the routes.
+* **routesDocument** or **routesList** and **routesFormat**: Required. This is the list of Camel routes to run.
+    * **routesDocument** -- the name of a Vantiq Document containing the XML or YAML definition of the routes to run. The format of the document (XML or YAML) will be determined from the file name (_e.g._, `routes.xml`)
+    * **routesList** and **routesFormat** -- the XML or YAML specification of the Camel routes to run.  The **routesList** property should contain the appropriate text, and the **routesFormat** should contain either `xml` or `yml` indicating the style used to specify the routes.
       * *Note*: You must specify either the **routesDocument** or **routesList** _AND_ **routesFormat** properties, but not both.
 * **componentProperties** -- a list of JSON objects which contain the component name & associated properties. These are used by some components for their configuration and/or operation. Values here may include security information (clientId or tokens).
     * The format of this values is a list of JSON objects, where each JSON object contains a **componentName** property containing the name of the component for which these properties are to be applied, and **componentProperties** containing a Json object consisting of property names and values.

--- a/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/connector/CamelHandleConfiguration.java
+++ b/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/connector/CamelHandleConfiguration.java
@@ -132,6 +132,8 @@ public class CamelHandleConfiguration extends Handler<ExtensionServiceMessage> {
         if (gotList && !(target instanceof String)) {
             log.error("Camel connector with the {} property requires the {} property as well.",
                       ROUTES_LIST, ROUTES_FORMAT);
+            failConfig();
+            return;
         }
         
         target = camelConfig.get(PROPERTY_VALUES);

--- a/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/connector/CamelHandleConfiguration.java
+++ b/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/connector/CamelHandleConfiguration.java
@@ -257,8 +257,11 @@ public class CamelHandleConfiguration extends Handler<ExtensionServiceMessage> {
             //noinspection unchecked
             Map<String, String> input = (Map<String, String>) camelConfig.get(PROPERTY_VALUES);
             // Camel wants these as a Java Properties object, so perform the conversion as required.
-            Properties propVals = new Properties(input.size());
-            input.forEach(propVals::setProperty);
+            Properties propVals = null;
+            if (input != null) {
+                propVals = new Properties(input.size());
+                input.forEach(propVals::setProperty);
+            }
     
             // If we get this far, then we're ready to run start from the new configuration.  If we have an old
             // configuration running, we'll need to shut it down first.

--- a/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelDiscovery.java
+++ b/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelDiscovery.java
@@ -48,7 +48,7 @@ public class CamelDiscovery {
      * Determine the set of components used in the routes in a route builder.
      *
      * @param rb RouteBuilder containing the set of routes from which to discover components
-     * @param placeholderValues Properties set of properties, keyed by name, to provide for the route
+     * @param propertyValues Properties set of properties, keyed by name, to provide for the route
      *
      * @return Map<String, Set<String>> containing two Set entries:
      *          systemComponents -- (informational) and
@@ -56,7 +56,7 @@ public class CamelDiscovery {
      *
      * @throws DiscoveryException when exceptions encountered during processing.
      */
-    Map<String, Set<String>> performComponentDiscovery(RouteBuilder rb, Properties placeholderValues)
+    Map<String, Set<String>> performComponentDiscovery(RouteBuilder rb, Properties propertyValues)
             throws DiscoveryException {
         
         try (DefaultCamelContext ctx = new DefaultCamelContext()) {
@@ -72,7 +72,7 @@ public class CamelDiscovery {
             // discovery, since things like the URLs could be defined in properties, and that's used for discovery.
             // We define a new context for use here since we're overriding all the resolvers with those specially
             // designed for discovery.
-            ectx.getPropertiesComponent().setLocalProperties(placeholderValues);
+            ectx.getPropertiesComponent().setLocalProperties(propertyValues);
 
             log.debug("Discovering Camel (version {}) components using context: {}", ectx.getVersion(), ectx.getName());
     

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/VantiqConfigurationTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/VantiqConfigurationTest.java
@@ -56,7 +56,7 @@ public class VantiqConfigurationTest {
     }
     
     void performConfigTest(String appName, String route, String routeFormat,
-                           List<Map<String, Object>> compInitProps, Properties placeholderValues, Verifier vfy) {
+                           List<Map<String, Object>> compInitProps, Properties propertyValues, Verifier vfy) {
         assumeTrue(!sfLoginUrl.equals(MISSING_VALUE) && !sfClientId.equals(MISSING_VALUE) &&
                            !sfClientSecret.equals(MISSING_VALUE) && !sfRefreshToken.equals(MISSING_VALUE));
         Map<String, Object> simpleConfig = new HashMap<>();
@@ -76,8 +76,8 @@ public class VantiqConfigurationTest {
         if (compInitProps != null) {
             camelAppConfig.put(COMPONENT_PROPERTIES, compInitProps);
         }
-        if (placeholderValues != null) {
-            camelAppConfig.put(PROPERTY_VALUES, placeholderValues);
+        if (propertyValues != null) {
+            camelAppConfig.put(PROPERTY_VALUES, propertyValues);
         }
         
         String fauxVantiqUrl = "http://someVantiqServer";
@@ -136,7 +136,7 @@ public class VantiqConfigurationTest {
     }
     
     @Test
-    public void testComponentInitConfigurationWithPlaceholderValues() {
+    public void testComponentInitConfigurationWithPropertyValues() {
         Properties props = new Properties(pValues.size());
         // Though officially frowned upon, Properties.putAll here from a Map<String, String> is safe as it cannot put
         // non-String keys or values into the Properties base map.

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/VantiqConfigurationTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/VantiqConfigurationTest.java
@@ -8,6 +8,7 @@ import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.COMP
 import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.COMPONENT_LIB;
 import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.COMPONENT_PROPERTIES;
 import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.GENERAL;
+import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.PROPERTY_VALUES;
 import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.ROUTES_FORMAT;
 import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.ROUTES_LIST;
 import static io.vantiq.extsrc.camelconn.discover.VantiqComponentResolverTest.MISSING_VALUE;
@@ -26,15 +27,22 @@ import io.vantiq.extjsdk.ExtensionServiceMessage;
 import io.vantiq.extsrc.camelconn.discover.CamelRunner;
 import org.apache.camel.CamelContext;
 import org.apache.commons.lang3.function.TriFunction;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 
 import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 public class VantiqConfigurationTest {
+    
+    
+    @Rule
+    public TestName name = new TestName();
     
     private final String BUILD_DIR = System.getProperty("BUILD_DIR", "build");
     private final String CAMEL_CONN_BASE_DIR = "camelConnBase";
@@ -42,56 +50,13 @@ public class VantiqConfigurationTest {
     private final String CACHE_DIR = CAMEL_BASE_PATH + "cacheDir";
     private final String LOADED_LIBRARIES = CAMEL_BASE_PATH + "loadedLib";
     
-    @Test
-    public void testSimpleConfiguration() {
-        Map<String, Object> simpleConfig = new HashMap<>();
-        Map<String, Object> camelConfig = new HashMap<>();
-        simpleConfig.put(CAMEL_CONFIG, camelConfig);
-        Map<String, String> camelAppConfig = new HashMap<>();
-        camelConfig.put(CAMEL_APP, camelAppConfig);
-        Map<String, String> generalConfig = new HashMap<>();
-        camelConfig.put(GENERAL, generalConfig);
-        
-        generalConfig.put(COMPONENT_CACHE, CACHE_DIR);
-        generalConfig.put(COMPONENT_LIB, LOADED_LIBRARIES);
-        
-        camelAppConfig.put(ROUTES_LIST, XML_ROUTE);
-        camelAppConfig.put(ROUTES_FORMAT, "xml");
-        camelAppConfig.put(APP_NAME, "testSimpleConfiguration");
-    
-        String fauxVantiqUrl = "http://someVantiqServer";
-        ExtensionServiceMessage esm = new ExtensionServiceMessage(fauxVantiqUrl);
-        esm.op = OP_CONFIGURE_EXTENSION;
-        esm.object = simpleConfig;
-        
-        CamelCore core = new CamelCore("testSimpleConfiguration", "someAccessToken", fauxVantiqUrl);
-        CamelHandleConfiguration handler = new CamelHandleConfiguration(core);
-        
-        handler.handleMessage(esm);
-        assertTrue("handler completed", handler.isComplete());
-        assertNotNull("Camel Runner", handler.getCurrentCamelRunner());
-        assertTrue("Runner started", handler.getCurrentCamelRunner().isStarted());
-        assertNotNull("Runner's Camel Context", handler.getCurrentCamelRunner().getCamelContext());
-        assertNotNull("Runner's thread", handler.getCurrentCamelRunner().getCamelThread());
-        
-        // Assuming things worked, now we have a camel app running.  We'll run our test against it & verify
-    
-        TriFunction<CamelContext, String, Object, Boolean> verifyOperation = defineVerifyOperation();
-        CamelContext runnerContext = handler.getCurrentCamelRunner().getCamelContext();
-        assertTrue("Context Running", runnerContext.isStarted());
-        assert verifyOperation.apply(runnerContext, QUERY_MONKEY, RESPONSE_MONKEY);
-        assert verifyOperation.apply(runnerContext, QUERY_AARDVARK, RESPONSE_AARDVARK);
-    
-        handler.getCurrentCamelRunner().close();
-        try {
-            handler.getCurrentCamelRunner().getCamelThread().join(TimeUnit.SECONDS.toMillis(10));
-        } catch (InterruptedException ie) {
-            fail("Trapped Interrupted Exception");
-        }
+    // Interface to use in declaration.  We'll pass lambda's in to do the actual verification work
+    interface Verifier {
+        void doVerify(CamelContext runnerContext);
     }
     
-    @Test
-    public void testComponentInitConfiguration() {
+    void performConfigTest(String appName, String route, String routeFormat,
+                           List<Map<String, Object>> compInitProps, Properties placeholderValues, Verifier vfy) {
         assumeTrue(!sfLoginUrl.equals(MISSING_VALUE) && !sfClientId.equals(MISSING_VALUE) &&
                            !sfClientSecret.equals(MISSING_VALUE) && !sfRefreshToken.equals(MISSING_VALUE));
         Map<String, Object> simpleConfig = new HashMap<>();
@@ -105,17 +70,23 @@ public class VantiqConfigurationTest {
         generalConfig.put(COMPONENT_CACHE, CACHE_DIR);
         generalConfig.put(COMPONENT_LIB, LOADED_LIBRARIES);
         
-        camelAppConfig.put(ROUTES_LIST, SALESFORCETASKS_YAML);
-        camelAppConfig.put(ROUTES_FORMAT, "yaml");
-        camelAppConfig.put(APP_NAME, "testComponentInitConfiguration");
-        camelAppConfig.put(COMPONENT_PROPERTIES, getComponentsToInit());
+        camelAppConfig.put(ROUTES_LIST, route);
+        camelAppConfig.put(ROUTES_FORMAT, routeFormat);
+        camelAppConfig.put(APP_NAME, appName);
+        if (compInitProps != null) {
+            camelAppConfig.put(COMPONENT_PROPERTIES, compInitProps);
+        }
+        if (placeholderValues != null) {
+            camelAppConfig.put(PROPERTY_VALUES, placeholderValues);
+        }
         
         String fauxVantiqUrl = "http://someVantiqServer";
         ExtensionServiceMessage esm = new ExtensionServiceMessage(fauxVantiqUrl);
         esm.op = OP_CONFIGURE_EXTENSION;
         esm.object = simpleConfig;
         
-        CamelCore core = new CamelCore("testComponentInitConfiguration", "someAccessToken", fauxVantiqUrl);
+        CamelCore core = new CamelCore("testComponentInitConfiguration",
+                                       "someAccessToken", fauxVantiqUrl);
         CamelHandleConfiguration handler = new CamelHandleConfiguration(core);
         
         handler.handleMessage(esm);
@@ -127,12 +98,11 @@ public class VantiqConfigurationTest {
         
         // Assuming things worked, now we have a camel app running.  We'll run our test against it & verify
         
-        TriFunction<CamelContext, String, Object, Boolean> verifyOperation = defineVerifyOperation();
         CamelContext runnerContext = handler.getCurrentCamelRunner().getCamelContext();
         assertTrue("Context Running", runnerContext.isStarted());
-        assert verifyOperation.apply(runnerContext, "not used", Map.of( "done", true));
-        assert verifyOperation.apply(runnerContext, "not used", Map.of( "done", true));
         
+        vfy.doVerify(runnerContext);
+    
         handler.getCurrentCamelRunner().close();
         try {
             handler.getCurrentCamelRunner().getCamelThread().join(TimeUnit.SECONDS.toMillis(10));
@@ -141,6 +111,45 @@ public class VantiqConfigurationTest {
         }
     }
     
+    @Test
+    public void testSimpleConfiguration() {
+        performConfigTest(name.getMethodName(), XML_ROUTE, "xml",
+                          null, null,
+                          (CamelContext runnerContext) -> {
+                              TriFunction<CamelContext, String, Object, Boolean> verifyOperation =
+                                      defineVerifyOperation();
+                              assert verifyOperation.apply(runnerContext, QUERY_MONKEY, RESPONSE_MONKEY);
+                              assert verifyOperation.apply(runnerContext, QUERY_AARDVARK, RESPONSE_AARDVARK);
+                          });
+    }
+    
+    @Test
+    public void testComponentInitConfiguration() {
+        performConfigTest(name.getMethodName(), SALESFORCETASKS_YAML, "yaml",
+                          getComponentsToInit(), null,
+                          (CamelContext runnerContext) -> {
+                              TriFunction<CamelContext, String, Object, Boolean> verifyOperation =
+                                      defineVerifyOperation();
+                            assert verifyOperation.apply(runnerContext, "not used", Map.of("done", true));
+                            assert verifyOperation.apply(runnerContext, "not used", Map.of("done", true));
+                        });
+    }
+    
+    @Test
+    public void testComponentInitConfigurationWithPlaceholderValues() {
+        Properties props = new Properties(pValues.size());
+        // Though officially frowned upon, Properties.putAll here from a Map<String, String> is safe as it cannot put
+        // non-String keys or values into the Properties base map.
+        props.putAll(pValues);
+        performConfigTest(name.getMethodName(), PARAMETERIZED_SALESFORCE_ROUTE, "yaml",
+                          getComponentsToInit(), props,
+                          (CamelContext runnerContext) -> {
+                              TriFunction<CamelContext, String, Object, Boolean> verifyOperation =
+                                      defineVerifyOperation();
+                              assert verifyOperation.apply(runnerContext, "not used", Map.of("done", true));
+                              assert verifyOperation.apply(runnerContext, "not used", Map.of("done", true));
+                          });
+    }
     
     public static final String sfLoginUrl = System.getProperty("camel-salesforce-loginUrl", MISSING_VALUE);
     public static final String sfClientId = System.getProperty("camel-salesforce-clientId", MISSING_VALUE);
@@ -176,4 +185,21 @@ public class VantiqConfigurationTest {
         );
     }
     
+    public static final String PARAMETERIZED_SALESFORCE_ROUTE  = "\n"
+            + "- route:\n"
+            + "    id: \"Salesforce from yaml-route\"\n"
+            + "    from:\n"
+            + "      uri: \"{{directStart}}\"\n"
+            + "      steps:\n"
+//        + "        - set-exchange-pattern: \"inOut\"\n" // Leaving as a reminder re: how to do in/out YAML routes
+            + "        - to:\n"
+            + "            uri: \"salesforce:query?rawPayload=true&SObjectQuery={{query}}\"\n"
+            + "        - unmarshal:\n"
+            + "            json: {}\n"
+            + "        - to:\n"
+            + "            uri: \"{{mockResult}}\"\n";
+    
+    public static final Map<String, String> pValues = Map.of("directStart", "direct:start",
+                                                             "query", "SELECT Id, Subject, OwnerId from Task",
+                                                             "mockResult", "mock:result");
 }

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentDiscoveryTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentDiscoveryTest.java
@@ -217,12 +217,12 @@ public class VantiqComponentDiscoveryTest extends CamelTestSupport {
     void performDiscoveryTest(RouteBuilder rb) throws Exception {
         performDiscoveryTest(rb, null);
     }
-    void performDiscoveryTest(RouteBuilder rb, Properties placeholderValues) throws Exception {
+    void performDiscoveryTest(RouteBuilder rb, Properties propertyValues) throws Exception {
         assert rb instanceof TestExpectations;
         setUseRouteBuilder(false);
         CamelDiscovery discoverer = new CamelDiscovery();
         
-        Map<String, Set<String>> discResults = discoverer.performComponentDiscovery(rb, placeholderValues);
+        Map<String, Set<String>> discResults = discoverer.performComponentDiscovery(rb, propertyValues);
         
         List<String> expectedCTL = ((TestExpectations) rb).getExpectedComponentsToLoad();
         List<String> expectedSysComp = ((TestExpectations) rb).getExpectedSystemComponents();

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentResolverTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentResolverTest.java
@@ -459,13 +459,13 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
         FileUtil.forceDelete(cache);    // Clear the cache
         setUseRouteBuilder(false);
         
-        Properties placeholderValues = new Properties(3);
-        placeholderValues.setProperty("directStart", "direct:start");
-        placeholderValues.setProperty("dnsDig", "dns:dig");
-        placeholderValues.setProperty("mockResult", "mock:result");
+        Properties propertyValues = new Properties(3);
+        propertyValues.setProperty("directStart", "direct:start");
+        propertyValues.setProperty("dnsDig", "dns:dig");
+        propertyValues.setProperty("mockResult", "mock:result");
         
         performLoadAndRunTest(YAML_ROUTE_PARAMETERIZED, "yaml", null, false,
-                              placeholderValues);
+                              propertyValues);
     }
     
     @Test
@@ -574,7 +574,7 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
     
     public void performLoadAndRunTest(String content, String contentType,
                                       List<Map<String, Object>> compToInit, boolean defeatVerify,
-                                      Properties placeholderValues) throws Exception {
+                                      Properties propertyValues) throws Exception {
         // To do this test, we'll create a callable that the test method will call. In this case, the callable "sends"
         // message to the route which, in turn, makes the dig call to lookup a monkey.  We verify that the expected
         // results is presented.
@@ -589,7 +589,7 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
         
         try (CamelRunner runner =
                      new CamelRunner(this.getTestMethodName(), content, contentType, null,
-                                     IVY_CACHE_PATH, DEST_PATH, compToInit, placeholderValues)) {
+                                     IVY_CACHE_PATH, DEST_PATH, compToInit, propertyValues)) {
             openedRunner = runner;
             runner.runRoutes(false);
             runnerContext = runner.getCamelContext();
@@ -616,7 +616,8 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
         performLoadAndRunTest(rb, true, compToInit, null);
     }
     public void performLoadAndRunTest(RouteBuilder rb, boolean shouldStart,
-                                      List<Map<String, Object>> componentToInit, Properties placeholderValues) throws Exception {
+                                      List<Map<String, Object>> componentToInit,
+                                      Properties propertyValues) throws Exception {
         // To do this test, we'll create a callable that the test method will call. In this case, the callable "sends"
         // message to the route which, in turn, makes the dig call to lookup a monkey & aardvark.  We verify that the
         // expected results are presented.
@@ -630,7 +631,7 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
         
         try (CamelRunner runner =
                      new CamelRunner(this.getTestMethodName(), rb, null, IVY_CACHE_PATH, DEST_PATH,
-                                     componentToInit, placeholderValues)) {
+                                     componentToInit, propertyValues)) {
             openedRunner = runner;
             runner.runRoutes(false);
             runnerContext = runner.getCamelContext();

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentResolverTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentResolverTest.java
@@ -43,6 +43,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * Perform unit tests for component resolution
@@ -240,7 +241,7 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
         setUseRouteBuilder(false);
         try (CamelRunner runner = new CamelRunner(this.getTestMethodName(), rb, null,
                                                   IVY_CACHE_PATH, DEST_PATH,
-                                                  rb.getComponentsToInit())) {
+                                                  rb.getComponentsToInit(), null)) {
             runner.runRoutes(false);
         }
     }
@@ -253,7 +254,7 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
         setUseRouteBuilder(false);
         try (CamelRunner runner = new CamelRunner(this.getTestMethodName(), rb, null,
                                                   IVY_CACHE_PATH, DEST_PATH,
-                                                  rb.getComponentsToInit())) {
+                                                  rb.getComponentsToInit(), null)) {
             runner.runRoutes(false);
         }
     }
@@ -269,7 +270,7 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
         repoList.add(new URI("https://vantiqmaven.s3.amazonaws.com/"));
         repoList.add(new URI("https://repo.maven.apache.org/maven2/"));
         try (CamelRunner runner = new CamelRunner(this.getTestMethodName(),rb, repoList,
-                                                  IVY_CACHE_PATH, DEST_PATH, rb.getComponentsToInit())) {
+                                                  IVY_CACHE_PATH, DEST_PATH, rb.getComponentsToInit(), null)) {
             runner.runRoutes(false);
         }
     }
@@ -319,7 +320,7 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
         RouteBuilderWithProps rb = new MakeDigCallMarshaledAvroFailure();
         assertNotNull("No routebuilder", rb);
         
-        performLoadAndRunTest(rb, false, rb.getComponentsToInit());
+        performLoadAndRunTest(rb, false, rb.getComponentsToInit(), null);
     }
     
     @Test
@@ -396,6 +397,17 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
             + "        - to:\n"
             + "            uri: \"mock:result\"\n";
     
+    public static final String YAML_ROUTE_PARAMETERIZED =  "\n"
+            + "- route:\n"
+            + "    id: \"Dig from yaml-route\"\n"
+            + "    from:\n"
+            + "      uri: \"{{directStart}}\"\n"
+            + "      steps:\n"
+            + "        - to:\n"
+            + "            uri: \"{{dnsDig}}\"\n"
+            + "        - to:\n"
+            + "            uri: \"{{mockResult}}\"\n";
+    
     public static final String ROUTE_WITH_BEAN = "\n"
             + "- route: \n"
             + "    id: \"EventHub Sink\" \n"
@@ -443,11 +455,25 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
     }
     
     @Test
+    public void testStartRunLoadedComponentsFromYamlTextParameterized() throws Exception {
+        FileUtil.forceDelete(cache);    // Clear the cache
+        setUseRouteBuilder(false);
+        
+        Properties placeholderValues = new Properties(3);
+        placeholderValues.setProperty("directStart", "direct:start");
+        placeholderValues.setProperty("dnsDig", "dns:dig");
+        placeholderValues.setProperty("mockResult", "mock:result");
+        
+        performLoadAndRunTest(YAML_ROUTE_PARAMETERIZED, "yaml", null, false,
+                              placeholderValues);
+    }
+    
+    @Test
     public void testDiscoverBeanRoute() throws Exception {
         FileUtil.forceDelete(cache);
         setUseRouteBuilder(false);
         
-        performLoadAndRunTest(ROUTE_WITH_BEAN, "yaml", null, true);
+        performLoadAndRunTest(ROUTE_WITH_BEAN, "yaml", null, true, null);
     }
     
     /**
@@ -543,11 +569,12 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
     
     public void performLoadAndRunTest(String content, String contentType,
                                       List<Map<String, Object>> compToInit) throws Exception {
-        performLoadAndRunTest(content, contentType, compToInit, false);
+        performLoadAndRunTest(content, contentType, compToInit, false, null);
     }
     
     public void performLoadAndRunTest(String content, String contentType,
-                                      List<Map<String, Object>> compToInit, boolean defeatVerify) throws Exception {
+                                      List<Map<String, Object>> compToInit, boolean defeatVerify,
+                                      Properties placeholderValues) throws Exception {
         // To do this test, we'll create a callable that the test method will call. In this case, the callable "sends"
         // message to the route which, in turn, makes the dig call to lookup a monkey.  We verify that the expected
         // results is presented.
@@ -562,7 +589,7 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
         
         try (CamelRunner runner =
                      new CamelRunner(this.getTestMethodName(), content, contentType, null,
-                                     IVY_CACHE_PATH, DEST_PATH, compToInit)) {
+                                     IVY_CACHE_PATH, DEST_PATH, compToInit, placeholderValues)) {
             openedRunner = runner;
             runner.runRoutes(false);
             runnerContext = runner.getCamelContext();
@@ -586,10 +613,10 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
     }
     
     public void performLoadAndRunTest(RouteBuilder rb, List<Map<String, Object>> compToInit) throws Exception {
-        performLoadAndRunTest(rb, true, compToInit);
+        performLoadAndRunTest(rb, true, compToInit, null);
     }
     public void performLoadAndRunTest(RouteBuilder rb, boolean shouldStart,
-                                      List<Map<String, Object>> componentToInit) throws Exception {
+                                      List<Map<String, Object>> componentToInit, Properties placeholderValues) throws Exception {
         // To do this test, we'll create a callable that the test method will call. In this case, the callable "sends"
         // message to the route which, in turn, makes the dig call to lookup a monkey & aardvark.  We verify that the
         // expected results are presented.
@@ -603,7 +630,7 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
         
         try (CamelRunner runner =
                      new CamelRunner(this.getTestMethodName(), rb, null, IVY_CACHE_PATH, DEST_PATH,
-                                     componentToInit)) {
+                                     componentToInit, placeholderValues)) {
             openedRunner = runner;
             runner.runRoutes(false);
             runnerContext = runner.getCamelContext();
@@ -644,7 +671,7 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
         assertNotNull("runnerThread is null", runnerThread);
         assertTrue("ShouldStart: " + shouldStart + ", runnerThread: " + runnerThread +
                            ", ...isAlive: " + runnerThread.isAlive(),
-                   !shouldStart || runnerThread != null && !runnerThread.isAlive());
+                   !shouldStart || !runnerThread.isAlive());
         assert runnerContext != null && runnerContext.isStopped();
     }
     

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentResolverTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentResolverTest.java
@@ -669,10 +669,17 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
         }
     
         assertNotNull("runnerThread is null", runnerThread);
+        assert runnerContext != null && runnerContext.isStopped();
+        int deathWaitCount = 30;
+        // Wait for thread to die off.  Otherwise, spurious errors occasionally.
+        while (runnerThread.isAlive() && deathWaitCount > 0) {
+            Thread.sleep(500);
+            deathWaitCount -= 1;
+        }
+        // Ensure that the running thread has completed.  Issue of test resource starvation, not product
         assertTrue("ShouldStart: " + shouldStart + ", runnerThread: " + runnerThread +
                            ", ...isAlive: " + runnerThread.isAlive(),
                    !shouldStart || !runnerThread.isAlive());
-        assert runnerContext != null && runnerContext.isStopped();
     }
     
     private static abstract class RouteBuilderWithProps extends RouteBuilder {


### PR DESCRIPTION
Fixes #385

Apache Camel has support for including property placeholders in routes so that the route can be specialized at the time of invocation.  These are done by including the property placeholder name in double curly brackets (_e.g._, `{{somePropertyName}}`).  We don't really have to deal with these -- they are all handled by the camel mechanism.

However, for that mechanism to work, we must provide a way to pass values in.  We do this by adding a `propertyValues` section to a source configuration for the Camel connector.  When so provided, this must be a JSON object with values for properties keyed by the property name.

When this is provided, we'll initialize the `PropertiesComponent` in Camel with these values and let camel do its job.

Add tests & documentation (the readme).  Turns out, the documentation for component properties (used in component configuration) wasn't added, so added that, too.