### PR TITLE
Infrastructure for Camel kamelet conversion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ subprojects {
     apply plugin: 'groovy'
     apply plugin: 'idea'
     apply plugin: 'eclipse'
-    if (!['extpdk', 'pythonExecSource'].contains(it.name)) {
+    if (!['extpdk', 'pythonExecSource', 'kamelet2assembly'].contains(it.name)) {
         apply plugin: 'java'
     }
     apply plugin: 'com.chrisgahlert.gradle-dcompose-plugin'

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,34 @@
+
+plugins {
+    id 'java'
+    id 'io.franzbecker.gradle-lombok' version '5.0.0'
+}
+
+repositories {
+    mavenCentral()
+}
+
+ext {
+    apacheCommonsLangVersion = '3.12.0'
+    jacksonVersion = '2.14.2'
+    log4JVersion='2.17.2'
+    lombokVersion = '1.18.24'
+    slf4jApiVersion = '1.7.25'
+    vantiqSDKVersion = '1.1.1'
+}
+
+dependencies {
+    implementation "org.projectlombok:lombok:${lombokVersion}"
+    implementation "org.snakeyaml:snakeyaml-engine:2.6"
+    implementation "org.apache.logging.log4j:log4j-slf4j-impl:${log4JVersion}"
+    implementation "org.apache.commons:commons-lang3:${apacheCommonsLangVersion}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+}
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/buildSrc/src/main/java/io/vantiq/extsrc/assy/tasks/AssemblyGen.java
+++ b/buildSrc/src/main/java/io/vantiq/extsrc/assy/tasks/AssemblyGen.java
@@ -1,0 +1,336 @@
+package io.vantiq.extsrc.assy.tasks;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ArrayUtils;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.TaskAction;
+import org.snakeyaml.engine.v2.api.DumpSettings;
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.api.Dump;
+import org.snakeyaml.engine.v2.common.FlowStyle;
+import org.gradle.api.Project;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * Gradle task to build assembly specifications from Camel Kamelet definitions.
+ */
+
+@Slf4j
+public class AssemblyGen extends DefaultTask {
+    public static final String KAMELET_GEN_BASE = "vantiqGeneratedResources";
+    public static final String VANTIQ_SERVER_CONFIG = "vantiq://server.config";
+    public static final String VANTIQ_SERVER_CONFIG_JSON = VANTIQ_SERVER_CONFIG + "?consumerOutputJson=true";
+    
+    public static final String KAMELETS_RESOURCE_FOLDER = "kamelets";
+    public static final String KAMELETS_RESOURCE_PATH = KAMELETS_RESOURCE_FOLDER + "/";
+    public static final String YAML_FILE_TYPE = ".yaml";
+    public static final String YML_FILE_TYPE = ".yml";
+    public static final String SOURCE_KAMELET_PREFIX = "-source.kamelet";
+    public static final String SINK_KAMELET_PREFIX = "-sink.kamelet";
+    public static final String SOURCE_KAMELET_YAML_SUFFIX = SOURCE_KAMELET_PREFIX + YAML_FILE_TYPE;
+    public static final String SOURCE_KAMELET_YML_SUFFIX = SOURCE_KAMELET_PREFIX + YML_FILE_TYPE;
+    public static final String SINK_KAMELET_YAML_SUFFIX = SINK_KAMELET_PREFIX + YAML_FILE_TYPE;
+    public static final String SINK_KAMELET_YML_SUFFIX = SINK_KAMELET_PREFIX + YML_FILE_TYPE;
+    
+    public final Project project;
+    
+    @Inject
+    public AssemblyGen(Project project) {
+        if (project == null) {
+            throw new GradleException("AssemblyGen requires a non-null project.");
+        }
+        this.project = project;
+    }
+    
+    @OutputDirectory
+    public File getOutputDirectory() {
+        if (!(project.property("buildDir") instanceof File)) {
+            throw new GradleException("Internal Error: buildDir not a file: " + project.property("buildDir"));
+        }
+    
+        File buildDir = (File) project.property("buildDir");
+    
+        assert buildDir != null;
+        return Path.of(buildDir.getAbsolutePath(), KAMELET_GEN_BASE).toFile();
+    }
+    
+    /**
+     * Overall processing for the generation of assemblies from kamelet declarations.
+     *
+     * @throws Exception
+     */
+    @TaskAction
+    public void generateAssemblies() throws Exception {
+        File buildDir = (File) project.property("buildDir");
+        assert buildDir != null;
+        if (!(buildDir.exists() && buildDir.isDirectory())) {
+            throw new GradleException("Internal Error: BuildDir not present or not directory: " + buildDir);
+        }
+        Path generateBase = Paths.get(buildDir.getAbsolutePath(), KAMELET_GEN_BASE);
+        if (!Files.exists(generateBase)) {
+            log.info("Creating base dir: {}", generateBase);
+            generateBase = Files.createDirectories(generateBase);
+        }
+        LoadSettings settings = LoadSettings.builder().build();
+        Load load = new Load(settings);
+    
+        // From the gradle data, construct the list of resolved dependencies & build a class loader to use
+        Configuration conf = project.getConfigurations().getByName("runtimeClasspath");
+        Set<File> files = conf.resolve();
+        log.info("File count from runtimeClasspath: {}", files.size());
+        File[] jars = files.toArray(new File[0]);
+        ArrayList<URL> urls = new ArrayList<>(jars.length);
+        for (File f: jars) {
+            log.debug("Adding {} to list of URLs", f.toURI().toURL());
+            urls.add(f.toURI().toURL());
+        }
+        URLClassLoader classloader =
+                new URLClassLoader(urls.toArray(new URL[0]));
+        // Find the URL that contains the "kamelets/" folder (which contains the kamelets toprocess)
+        URL klUrl = classloader.getResource(KAMELETS_RESOURCE_FOLDER);
+        log.debug("URL for kamelets: {}", klUrl);
+        if (klUrl == null) {
+            throw new GradleException("'kamelets' resource is null");
+        }
+        
+        // Find path for jar file containing 'kamelets' folder
+        String klString = klUrl.toString();
+        klString = klString.substring(0, klString.indexOf("!/"));
+        klString = klString.substring(9);
+        
+        try (JarFile jf = new JarFile(klString)) {
+            Enumeration<JarEntry> it = jf.entries();
+            String[] discards = new String[0];
+            int kameletCount = 0;
+            // For each entry in this JAR file, determine if it's one we care about
+            while (it.hasMoreElements()) {
+                JarEntry x = it.nextElement();
+                if (x.getName().startsWith(KAMELETS_RESOURCE_PATH)) {
+                    String klet = x.getName().substring(KAMELETS_RESOURCE_PATH.length());
+                    if (klet.endsWith(SOURCE_KAMELET_YAML_SUFFIX) || klet.endsWith(SOURCE_KAMELET_YML_SUFFIX)
+                            || klet.endsWith(SINK_KAMELET_YAML_SUFFIX) || klet.endsWith(SINK_KAMELET_YML_SUFFIX)) {
+                        
+                        // If it's a source or sink kamelet, we'll turn it into an assembly containing a source to
+                        // process messages to or from that connection.
+                        log.info("    name: {}", klet);
+                        // First, read the YAML file that defines the kamelet.  From this, we'll extract the
+                        // appropriate information to construct our assembly.
+                        Map<String, Object> yamlMap = getYamlEnt(load, classloader, klet);
+                        kameletCount += 1;
+                        log.debug("    \n<<<Result: parsed.size(): {}, parsed: {}>>>\n", yamlMap.size(),
+                                  yamlMap.get("spec"));
+                
+                        //noinspection unchecked
+                        String title =
+                                (String) ((Map<String, Object>) ((Map<String, Object>)
+                                        yamlMap.get("spec")).get("definition")).get("title");
+                        log.debug("Found spec for {}", title);
+                
+                        // Read any defined properties.  These will become properties for our assembly.
+                        //noinspection unchecked
+                        Map<String, Object> props =
+                                (Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>)
+                                        yamlMap.get("spec")).get("definition")).get("properties");
+                        log.debug("    containing {} properties:", props.size());
+                        props.forEach((k, v) -> {
+                            //noinspection unchecked
+                            log.debug("        name: {}, [type: {}, desc: {}]", k,
+                                      ((Map<String, String>) v).get("type"),
+                                      ((Map<String, String>) v).get("description"));
+                        });
+                        String kamName = klet.substring(0, klet.indexOf(".kamelet.yaml"));
+    
+                        DumpSettings dumpSettings = DumpSettings.builder()
+                                                                .setIndent(4)
+                                                                // FLOW (default)serializes any embedded maps.
+                                                                // This "recurses".
+                                                                .setDefaultFlowStyle(FlowStyle.BLOCK)
+                                                                .build();
+                        Dump dumper = new Dump(dumpSettings);
+                        
+                        // Now, extract the route template.  This will become our route document after we change
+                        // kamelet://source or kamelet::sink to vantiq server URLs
+                        
+                        //noinspection unchecked
+                        Map<String, Object> template = (Map<String, Object>) ((Map<String, Object>)
+                                yamlMap.get("spec")).get("template");
+                        String originalTemplateString = dumper.dumpToString(template);
+                        log.info("\n>>>   Original Template as Yaml:\n{}", originalTemplateString);
+    
+                        template = constructRouteText(template);
+    
+                         // Now, generate & populate results
+                        Path thisKameletDirectory = Paths.get(generateBase.toAbsolutePath().toString(), kamName);
+                        if (!Files.exists(thisKameletDirectory)) {
+                            log.info("Creating kamelet-specific project directory: {}", thisKameletDirectory);
+                            thisKameletDirectory = Files.createDirectories(thisKameletDirectory);
+                        }
+                        log.info("\nResults for Kamelet: {}", kamName);
+                        log.info("\n>>>   Properties:");
+                        props.forEach((name, val) -> {
+                            //noinspection unchecked
+                            log.info("    Name: {} :: [title: {}, type: {}, desc: {}]", name,
+                                     ((Map<String, String>) val).get("t!itle"),
+                                     ((Map<String, String>) val).get("type"),
+                                     ((Map<String, String>) val).get("description"));
+                        });
+                        
+                        LinkedHashMap<String, Object> revision = new LinkedHashMap<>();
+                        String routeDocumentString = dumper.dumpToString(template);
+    
+                        log.info("\n>>>   Converted Template as Yaml:\n{}", routeDocumentString);
+                        log.info("\nWriting project to: {}", thisKameletDirectory);
+                
+                        Path propFile = Paths.get(thisKameletDirectory.toAbsolutePath().toString(), "props.json");
+                        // FIXME: Convert this to a project file defining the assembly
+                        Files.writeString(propFile, convertMapToJson(props));
+                        
+                        // FIXME: This should become a Vantiq document included in the project/assembly
+                        Path yamlConfig = Paths.get(thisKameletDirectory.toAbsolutePath().toString(),
+                                                    kamName + ".routes.yaml");
+                        Files.writeString(yamlConfig, routeDocumentString);
+                    }
+                } else {
+                    discards = ArrayUtils.add(discards, x.getName());
+                }
+            }
+    
+            if (discards.length > 0) {
+                log.debug("Discards");
+                for (String dumped : discards) {
+                    log.debug("        dumped: {}", dumped);
+                }
+            }
+            project.getLogger().lifecycle("{} kamelets found & parsed.",
+                                     kameletCount);
+            project.getLogger().lifecycle("    {} kamelets discarded (neither source nor sink as determined by " +
+                                                  "naming conventions).",
+                                          discards.length);
+        } catch (Exception e) {
+            throw new GradleException("Error opening jar file: " + klString + " :: " +
+                                              e.getClass().getName() + " -- " + e.getMessage());
+        }
+    }
+    
+    // Convert the route template into a reified route using the vantiq://server.config style endpoints
+    Map<String, Object> constructRouteText(Map<String, Object> template) {
+        processStep(template);
+        return template;
+    }
+    
+    // For a particular step, convert it & its children
+    void processStep(Map<String, Object> step) {
+        log.debug("processStep() processing {}", step);
+        for (Map.Entry<String, Object> ent: step.entrySet()) {
+            String k = ent.getKey();
+            Object v = ent.getValue();
+            Map<String, Object> stepDef = null;
+            if (v instanceof Map) {
+                //noinspection unchecked
+                stepDef = (Map<String, Object>) v;
+            }
+            log.debug("Found template key: {}, value: {}", k, v);
+            if (k.equals("from") && stepDef != null) {
+                if (stepDef.containsKey("uri") && stepDef.get("uri") instanceof String &&
+                        ((String) stepDef.get("uri")).equals("kamelet:source")) {
+                    stepDef.put("uri", VANTIQ_SERVER_CONFIG_JSON);
+                    log.debug("Replaced {} with{}", stepDef.get("uri"), VANTIQ_SERVER_CONFIG_JSON);
+                }
+                
+                for (Map.Entry<String, Object> oneEntry: stepDef.entrySet()) {
+                    String stepKey = oneEntry.getKey();
+                    Object stepVal = oneEntry.getValue();
+                
+                    if (stepKey.equalsIgnoreCase("steps")
+                                    || stepKey.equalsIgnoreCase("choice")
+                                    || stepKey.equalsIgnoreCase("when")) {
+                        if (stepVal instanceof Map) {
+                            //noinspection unchecked
+                            processStep((Map<String, Object>) stepVal);
+                        } else if (stepVal instanceof List) {
+                            //noinspection unchecked
+                            processSteps((List<Map<String, Object>>) stepVal);
+                        }
+                    }
+                }
+            } else if (k.equals("to") && "kamelet:sink".equals(v)) {
+                log.debug("Replacing value of key {}:{} with \"vantiq://server.config\"", k, v);
+                ent.setValue("vantiq://server.config");
+            } else if (k.equals("to") && stepDef != null && stepDef.containsKey("uri")
+                    && "kamelet:sink".equals(stepDef.get("uri"))) {
+                stepDef.put("uri", "vantiq://server.config");
+    
+            }
+        }
+    }
+    
+    // For a list of steps, convert each child
+    void processSteps(List<Map<String, Object>> steps) {
+        for (Map<String, Object> step: steps) {
+            processStep(step);
+        }
+    }
+    
+    String convertMapToJson(Map<String, Object> source) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        
+        try {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(source);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+    
+    /**
+     * Using the YAML loader, read the named resource from the project classloader (remember, we are in a Gradle task).
+     *
+     * Return as a Map.
+     *
+     * @param loader Load Yaml loader
+     * @param projectClassLoader ClassLoader class loader from which to get the named entity
+     * @param name String name of resource from which to extract the YAML file information
+     * @return Map<String, Object> representing the route
+     */
+    Map<String, Object> getYamlEnt(Load loader, ClassLoader projectClassLoader, String name) {
+        String kameletToFetch = KAMELETS_RESOURCE_PATH + name;
+        InputStream kameletStream = projectClassLoader.getResourceAsStream(kameletToFetch);
+    
+        if (kameletStream == null) {
+            throw new GradleException("Cannot read kamelet Stream: " + kameletToFetch);
+        }
+        Object raw = loader.loadFromInputStream(kameletStream);
+        if (!(raw instanceof Map)) {
+            throw new GradleException("Internal Error:  Expected Map from kamelStream, got " +
+                                              kameletStream.getClass().getName());
+        }
+        //noinspection unchecked
+        Map<String, Object> parsed = (Map<String, Object>) raw;
+        if (parsed.size() == 0) {
+            throw new GradleException("Setup Conditions: No values found in kameletStream.");
+        }
+        return parsed;
+    }
+}

--- a/camelComponent/README.md
+++ b/camelComponent/README.md
@@ -81,7 +81,11 @@ your Source Implementation) as the Source Type. No configuration information is 
 ## Messages from the Source
 
 Messages that are sent to the component will arrive in a Camel Exchange as a Java Map, where the keys in the map
-correspond to the property names in the object sent from Vantiq.  Messages sent to Vantiq from the component will
+correspond to the property names in the object sent from Vantiq. If desired, you change this behavior
+by adding the `consumerOutputJson` component endpoint option (see below) with a value of `true`.
+When so specified, messages sent to a Vantiq consumer will arrive in a Camel Exchange as a JSON string.
+
+Messages sent to Vantiq from the component will
 arrive as Vail objects, where the property names correspond to the Map keys.
 
 ## Exchanges to Vantiq
@@ -96,7 +100,7 @@ in Json format will be accepted as well.
 The URI for the Vantiq connection takes the following form:
 
 ```
-    vantiq://host[:port]?sourceName=<source name>&accessToken=<access token>[&sendPings=<boolean>][&failedMessageQueueSize=<int>]
+    vantiq://host[:port]?sourceName=<source name>&accessToken=<access token>[&sendPings=<boolean>][&failedMessageQueueSize=<int>][&consumerOutputJson=<boolean>]
 ```
 
 ### Component Endpoint Options
@@ -109,6 +113,7 @@ The endpoint options apply to producer and consumer endpoints.  The following ar
 * **accessToken** is the access token used for the connection
 * **sendPings** [optional] a boolean value indicating whether to periodically ping the Vantiq server (default is false)
 * **failedMessageQueueSize** [optional] an integer value indicating how many messages to hold for sending when the connection to the Vantiq server fails.
+* **consumerOutputJson** [optional] a boolean value indicating whether messages sent from Vantiq to the Vantiq component (_i.e._, a Vantiq Consumer) should be put into an Apache Camel Exchange as a JSON message.  If false, messages are put into an exchange as a Java Map.
 
 For example, to create an Apache Camel application that receives messages from a Vantiq system at `vantiq.example.com`
 from source `exampleSource` and access token `FD10s0x...`, we would use something like the following:

--- a/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqConsumer.java
+++ b/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqConsumer.java
@@ -11,6 +11,8 @@ package io.vantiq.extsrc.camel;
 import static org.apache.camel.ExchangePattern.InOnly;
 import static org.apache.camel.ExchangePattern.InOut;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vantiq.extjsdk.ExtensionServiceMessage;
 import io.vantiq.extjsdk.ExtensionWebSocketClient;
 import io.vantiq.extjsdk.Handler;
@@ -29,6 +31,8 @@ public class VantiqConsumer extends DefaultConsumer {
     private ExtensionWebSocketClient vantiqClient;
 
     private ExecutorService executorService;
+    
+    ObjectMapper mapper = new ObjectMapper();
     
     public VantiqConsumer(VantiqEndpoint endpoint, Processor processor) {
         super(endpoint, processor);
@@ -92,6 +96,12 @@ public class VantiqConsumer extends DefaultConsumer {
         } else {
             ExtensionServiceMessage message = (ExtensionServiceMessage) msg;
             Object msgBody = message.getObject();
+
+            if (endpoint.isConsumerOutputJson()) {
+                // Convert to JSON output
+               JsonNode jnode =  mapper.convertValue(msgBody, JsonNode.class);
+               msgBody = jnode.toPrettyString();
+            }
     
             // Create an exchange to move our message along.  In the publish case,
             // we have no interest in the result, so we'll allow it to be released when

--- a/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqEndpoint.java
+++ b/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqEndpoint.java
@@ -71,6 +71,11 @@ public class VantiqEndpoint extends DefaultEndpoint {
     @Setter
     private boolean noSsl;
     
+    @UriParam(defaultValue = "false")
+    @Getter
+    @Setter
+    private boolean consumerOutputJson;
+    
     @UriParam(defaultValue = "25")
     @Setter
     private int failedMessageQueueSize;

--- a/camelConnector/README.md
+++ b/camelConnector/README.md
@@ -132,11 +132,48 @@ The Configuration document may look similar to the following example:
 
 ### Options Available for camelRuntime
 
-*   **appName**: Optional -- name of the app.  If not provided, default to _camelConnectorApp_.
-*   **routesDocument** or **routesList** and **routesFormat**: Required. This is list of Camel routes to run.
+* **appName**: Optional -- name of the app.  If not provided, default to _camelConnectorApp_.
+* **routesDocument** or **routesList** and **routesFormat**: Required. This is the list of Camel routes to run.
     * **routesDocument** -- the name of a Vantiq Document containing the XML or YAML definition of the routes to run. The format of the document (XML or YAML) will be determined from the file name (_e.g._, `routes.xml`)
     * **routesList** and **routesFormat** -- the XML or YAML specification of the Camel routes to run.  The **routesList** property should contain the appropriate text, and the **routesFormat** should contain either `xml` or `yml` indicating the style used to specify the routes.
-    * *Note*: You must specify either the **routesDocument** or **routesList** _AND_ **routesFormat** properties, but not both.
+      * *Note*: You must specify either the **routesDocument** or **routesList** _AND_ **routesFormat** properties, but not both.
+* **componentProperties** -- a list of JSON objects which contain the component name & associated properties. These are used by some components for their configuration and/or operation. Values here may include security information (clientId or tokens).
+    * The format of this values is a list of JSON objects, where each JSON object contains a **componentName** property containing the name of the component for which these properties are to be applied, and **componentProperties** containing a Json object consisting of property names and values.
+    * For example, if we needed to define the `clientId` and `securityToken` properties for the `example` component, we would add the following to the `camelRuntime` section of the source configuration.
+  
+        ```json
+        {
+            "camelRuntime": {
+            ...
+            "componentProperties": [
+                {
+                    "componentName": "example",
+                    "componentProperties": {
+                        "clientId": "me@example.com",
+                        "securityToken": "someExampleToken..."
+                    }
+                }
+           ],
+           ...
+           }    
+        }
+        ```
+
+* **propertyValues** -- a JSON object where each property specifies the name and value to be provided for the Apache Camel property placeholder. [Property placeholders](https://camel.apache.org/manual/using-propertyplaceholder.html) can be used in Camel routes to supply values at the route configuration time. 
+    * For example, to provide values for the properties `name` and `company`, you would add the following the the `camelRuntime` section.
+  
+    ```json
+    {
+        "camelRuntime": {
+            ...
+            "propertyValues": {
+                "name": "fred",
+                "company": "vantiq"
+            }
+            ...
+        }
+   }
+   ```
 
 ### Options available for general
 
@@ -199,7 +236,7 @@ Messages are sent to the source as _notifications_, and are delivered as _events
 Messages sent to Vantiq from the component/connector will
 arrive as VAIL objects, where the property names correspond to the Map keys.
 The Vantiq Component expects messages in an exchange to arrive in the form of a Java Map.  However, messages arriving
-in Json format will be accepted as well.
+in JSON format will be accepted as well.
 When constructing your Camel Application, you must keep this in mind.
 
 ## Messages from the Source

--- a/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/connector/CamelHandleConfiguration.java
+++ b/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/connector/CamelHandleConfiguration.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 
 
 /**
@@ -59,6 +60,7 @@ public class CamelHandleConfiguration extends Handler<ExtensionServiceMessage> {
     public static final String ROUTES_LIST = "routesList";
     public static final String ROUTES_FORMAT = "routesFormat";
     public static final String COMPONENT_PROPERTIES = "componentProperties";
+    public static final String PROPERTY_VALUES = "propertyValues";
     
     public static final String VANTIQ = "vantiq";
     
@@ -130,6 +132,38 @@ public class CamelHandleConfiguration extends Handler<ExtensionServiceMessage> {
         if (gotList && !(target instanceof String)) {
             log.error("Camel connector with the {} property requires the {} property as well.",
                       ROUTES_LIST, ROUTES_FORMAT);
+            failConfig();
+            return;
+        }
+        
+        target = camelConfig.get(PROPERTY_VALUES);
+        if (target != null) {
+            if (!(target instanceof Map)) {
+                log.error("Camel connector property {} should be a simple JSON object (found {}).",
+                          PROPERTY_VALUES, target.getClass().getName());
+                failConfig();
+                return;
+            } else {
+                // It's coming from JSON, so the key must be a string...
+                Map<String, Object> input = (Map<String, Object>) target;
+                Properties propVals = new Properties(input.size());
+                input.forEach( (k, v) -> {
+                    if (!(k != null && v instanceof String)) {
+                        String kclass = "null";
+                        String vclass = "null";
+                        if (k != null) {
+                            kclass = k.getClass().getName();
+                        }
+                        if (v != null && v.getClass() != null) {
+                            vclass = v.getClass().getName();
+                        }
+                        log.error("Camel connector {} value must have a String key ({}: {})  and value ({}: {}).",
+                                  PROPERTY_VALUES, k, kclass, v, vclass);
+                        failConfig();
+                    }
+                });
+                
+            }
         }
         
         target = camelConfig.get(COMPONENT_PROPERTIES);
@@ -221,6 +255,16 @@ public class CamelHandleConfiguration extends Handler<ExtensionServiceMessage> {
             List<Map<String, Object>> componentProperties =
                     (List<Map<String, Object>>) camelConfig.get(COMPONENT_PROPERTIES);
     
+            // This is checked in the caller
+            //noinspection unchecked
+            Map<String, String> input = (Map<String, String>) camelConfig.get(PROPERTY_VALUES);
+            // Camel wants these as a Java Properties object, so perform the conversion as required.
+            Properties propVals = null;
+            if (input != null) {
+                propVals = new Properties(input.size());
+                input.forEach(propVals::setProperty);
+            }
+    
             // If we get this far, then we're ready to run start from the new configuration.  If we have an old
             // configuration running, we'll need to shut it down first.
     
@@ -247,7 +291,7 @@ public class CamelHandleConfiguration extends Handler<ExtensionServiceMessage> {
             CamelRunner runner =
                          new CamelRunner(appName, Objects.requireNonNull(routeSpec).get(ROUTES_LIST),
                                          routeSpec.get(ROUTES_FORMAT), repoList,
-                                         componentCache, componentLib, componentProperties);
+                                         componentCache, componentLib, componentProperties, propVals);
             if (additionalLibraries != null) {
                 runner.setAdditionalLibraries(additionalLibraries);
             }

--- a/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelDiscovery.java
+++ b/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelDiscovery.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
 
@@ -34,10 +35,7 @@ public class CamelDiscovery {
     public static final String COMPONENTS_TO_LOAD = "componentsToLoad";
     public static final String SYSTEM_DATAFORMATS = "systemDataFormats";
     public static final String DATAFORMATS_TO_LOAD = "dataFormatsToLoad";
-    
-    
     public static final String VANTIQ_COMPONENT_SCHEME = "vantiq";
-    
     private static final String COMPONENTS_KEY_NAME = "components";
     private static final String DATAFORMATS_KEY_NAME = "dataformats";
     private static final String CAMEL_VERSION_KEY_NAME = "camelVersion";
@@ -49,7 +47,8 @@ public class CamelDiscovery {
     /**
      * Determine the set of components used in the routes in a route builder.
      *
-     ** @param rb RouteBuilder containing the set of routes from which to discover components
+     * @param rb RouteBuilder containing the set of routes from which to discover components
+     * @param propertyValues Properties set of properties, keyed by name, to provide for the route
      *
      * @return Map<String, Set<String>> containing two Set entries:
      *          systemComponents -- (informational) and
@@ -57,7 +56,8 @@ public class CamelDiscovery {
      *
      * @throws DiscoveryException when exceptions encountered during processing.
      */
-    Map<String, Set<String>> performComponentDiscovery(RouteBuilder rb) throws DiscoveryException {
+    Map<String, Set<String>> performComponentDiscovery(RouteBuilder rb, Properties propertyValues)
+            throws DiscoveryException {
         
         try (DefaultCamelContext ctx = new DefaultCamelContext()) {
             ExtendedCamelContext ectx = ctx.adapt(ExtendedCamelContext.class);
@@ -67,9 +67,15 @@ public class CamelDiscovery {
             ectx.setDataFormatResolver(edfr);
             EnumeratingConfigurerResolver epcr = new EnumeratingConfigurerResolver();
             ectx.setConfigurerResolver(epcr);
+            
+            // If our current context has local properties, we'll need to provide them to the context we create for
+            // discovery, since things like the URLs could be defined in properties, and that's used for discovery.
+            // We define a new context for use here since we're overriding all the resolvers with those specially
+            // designed for discovery.
+            ectx.getPropertiesComponent().setLocalProperties(propertyValues);
+
             log.debug("Discovering Camel (version {}) components using context: {}", ectx.getVersion(), ectx.getName());
     
-            assert ectx.getComponentResolver() instanceof EnumeratingComponentResolver;
             try {
                 ectx.addRoutes(rb);
                 ectx.start();
@@ -97,6 +103,7 @@ public class CamelDiscovery {
             retVal.put(SYSTEM_DATAFORMATS, edfr.getSystemDataFormatsUsed());
             retVal.put(DATAFORMATS_TO_LOAD, edfr.getDataFormatsToLoad());
             return retVal;
+            // Note that ectx will be closed via the try-with-resources construct
         } catch (Exception e) {
             log.error("Trapped exception preparing or completing component discovery", e);
             throw new DiscoveryException("Exception preparing or completing component discovery processing", e);

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentDiscoveryTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentDiscoveryTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 /**
@@ -202,17 +203,26 @@ public class VantiqComponentDiscoveryTest extends CamelTestSupport {
     }
     
     @Test
+    public void testParameterizedXmlRouteDiscovery() throws Exception {
+        ParameterizedXmlRoutes rb = new ParameterizedXmlRoutes();
+        performDiscoveryTest(rb, rb.getRequiredProperties());
+    }
+    
+    @Test
     public void testBeansInRouteDiscovery() throws Exception {
         RouteBuilder rb = new BeanIncludingRoutes(context);
         performDiscoveryTest(rb);
     }
     
     void performDiscoveryTest(RouteBuilder rb) throws Exception {
+        performDiscoveryTest(rb, null);
+    }
+    void performDiscoveryTest(RouteBuilder rb, Properties propertyValues) throws Exception {
         assert rb instanceof TestExpectations;
         setUseRouteBuilder(false);
         CamelDiscovery discoverer = new CamelDiscovery();
         
-        Map<String, Set<String>> discResults = discoverer.performComponentDiscovery(rb);
+        Map<String, Set<String>> discResults = discoverer.performComponentDiscovery(rb, propertyValues);
         
         List<String> expectedCTL = ((TestExpectations) rb).getExpectedComponentsToLoad();
         List<String> expectedSysComp = ((TestExpectations) rb).getExpectedSystemComponents();
@@ -505,6 +515,44 @@ public class VantiqComponentDiscoveryTest extends CamelTestSupport {
         }
     }
     
+    private static class ParameterizedXmlRoutes extends RouteBuilder implements TestExpectations {
+        
+        @Override
+        public List<String> getExpectedComponentsToLoad() {
+            return List.of("salesforce");
+        }
+        
+        @Override
+        public List<String> getExpectedSystemComponents() {
+            return List.of("direct-vm");
+        }
+        
+        @Override
+        public void configure() throws Exception {
+            String content = ""
+                    + "    <routes>"
+                    + "        <route id=\"salesforce1\">"
+                    + "            <from uri=\"salesforce:CamelTestTopic?notifyForFields=ALL"
+                    + "&amp;notifyForOperations=ALL&amp;sObjectName=Merchandise__c&amp;updateTopic=true"
+                    + "&amp;sObjectQuery={{query}}\"/>"
+                    + "            <to uri=\"salesforce:createSObject?sObjectName={{outputObjectName}}\"/>"
+                    + "            <to uri=\"{{directNotifier}}\"/>"
+                    + "        </route>"
+                    + "    </routes>";
+            RouteBuilder rb = new XmlRouteBuilder(content).getRouteBuilder();
+            rb.configure();
+            this.setRouteCollection(rb.getRouteCollection());
+        }
+        
+        public Properties getRequiredProperties() {
+            Properties props = new Properties();
+            props.setProperty("query", "SELECT Id, Name FROM Merchandise__c");
+            props.setProperty("outputObjectName", "TestEvent__e");
+            props.setProperty("directNotifier", "direct-vm:salesforce-notifier");
+            return props;
+        }
+    }
+    
     private static class BeanIncludingRoutes extends RouteBuilder implements TestExpectations {
     
         CamelContext ctx;
@@ -558,7 +606,7 @@ public class VantiqComponentDiscoveryTest extends CamelTestSupport {
             + "                 sharedAccessName: \"someRandomKey\" \n"
             + "                 sharedAccessKey: \"RAW(MY TOKEN)\" \n";
     
-            // YAML support needs a camel context.  So provide oe during setup...
+            // YAML support needs a camel context.  So provide one during setup...
             RouteBuilder rb = new YamlRouteBuilder(ctx, content).getRouteBuilder();
             rb.configure();
             this.setRouteCollection(rb.getRouteCollection());

--- a/kamelet2assembly/build.gradle
+++ b/kamelet2assembly/build.gradle
@@ -1,0 +1,45 @@
+import io.vantiq.extsrc.assy.tasks.AssemblyGen
+
+plugins {
+//    id 'pl.allegro.tech.build.axion-release' version '1.6.0'
+    id 'com.chrisgahlert.gradle-dcompose-plugin' apply false //version '0.17.1' apply false
+    id 'java'
+    id 'maven-publish'
+    id 'io.franzbecker.gradle-lombok'// version '5.0.0'
+}
+
+repositories {
+    mavenCentral()
+}
+
+ext {
+    apacheCommonsLangVersion = '3.12.0'
+    camelVersion='3.18.3'
+    gsonVersion = '2.9.1'
+    ivyVersion = '2.5.1'
+    jacksonVersion = '2.14.2'
+    junitVersion = '4.13.2'
+    junitVintageEngineVersion = '5.8.2'
+    junitVersion = '4.13.2'
+    log4JVersion='2.17.2'
+    lombokVersion = '1.18.24'
+    slf4jApiVersion = '1.7.25'
+    vantiqSDKVersion = '1.1.1'
+}
+
+dependencies {
+    implementation "org.projectlombok:lombok:${lombokVersion}"
+    implementation "org.apache.camel.kamelets:camel-kamelets:3.20.2"
+}
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
+test {
+    useJUnitPlatform()
+}
+
+tasks.register('generateAssemblies', AssemblyGen)
+
+assemble.finalizedBy('generateAssemblies')

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,7 @@ include 'udpSource'
 include 'CSVSource'
 include 'testConnector'
 include 'objectRecognitionSource'
+include 'kamelet2assembly'
 if (System.env.EASY_MODBUS_LOC) {
     include 'EasyModbusSource' 
 }


### PR DESCRIPTION
Fixes #387 

This adds infrastructure in the form of a specialized Gradle task to convert the published Apache Camel kamelets into Vantiq assemblies.

At this point, we are adding the `kamelet2assemblies` subproject and the task infrastructure to begin the interpretation. We are not yet building assemblies;  instead, we convert the kamelet definition obtained from the maven repo (via a gradle dependency) to some proof of concept artifacts.  The next step will be to begin to convert those artifacts into Vantiq projects/assemblies.

Since this will be some ongoing work, I have created a _staging_ branch, `fhc-vantiqAssemblies`, into which we'll merge the various parts until the whole is ready for release. This _staging_ branch is the branch into which this PR will be merged.  Once complete, we can merge the staging branch into master.  But there's no real point on inflicting a bunch of partially completed stuff that doesn't work on the world.

For background, a _kamelet_ is a packaging of some standard routes for accessing various (about 80 number) different data sources and sinks.  They do this in a parameterized manner, and are packaged for use in a Camel-K environment (a set of operators deployed into Kubernetes that allows the system to sort of construct itself).  

The Apache Camel connector will be deployable via these assemblies, allowing the relatively easy deployment of a means to attach these 80 runtime environments to Vantiq.  Each of the 80 data environments has a _source_ and a _sink_ variant, so we end up with 160 different connection possibilities (80 environments * 2 _directions_).

As noted, this is the beginning.  Subsequent PR's will push the various artifacts closer to project/assembly definitions.

In this PR, we add the subproject and create a `gradle` task (type) that will perform the conversion based on the dependencies describe in the invoking project.   This task will product a bunch of build artifacts that will eventually become the sources for the assemblies (via subsequent PRs).