### PR TITLE
Add ability to see message headers from Vantiq Camel Component.

### DIFF
--- a/camelComponent/README.md
+++ b/camelComponent/README.md
@@ -88,6 +88,12 @@ When so specified, messages sent to a Vantiq consumer will arrive in a Camel Exc
 Messages sent to Vantiq from the component will
 arrive as Vail objects, where the property names correspond to the Map keys.
 
+### Structured Headers and Messages
+
+By adding the `structuredMessageHeader` component endpoint option with a value of `true` (see below), you can set or access the Camel message headers.  When this option is set to `true`, messages sent to or received from the Camel Component will have two properties: `headers` and `message`, both containing Vail objects. The `message` property will contain a Vail object where each property corresponds to same-named property in the underlying message.  The `headers` property will contain a Vail object where each property contains the value of the named message header.
+
+A schema type definition for this message structure is available in `src/main/resources/types/io/vantq/extsrc/camelcomp/message.json`.
+
 ## Exchanges to Vantiq
 
 The Vantiq Component expects messages in an exchange to arrive in the form of a Java Map.  However, messages arriving
@@ -100,7 +106,7 @@ in Json format will be accepted as well.
 The URI for the Vantiq connection takes the following form:
 
 ```
-    vantiq://host[:port]?sourceName=<source name>&accessToken=<access token>[&sendPings=<boolean>][&failedMessageQueueSize=<int>][&consumerOutputJson=<boolean>]
+    vantiq://host[:port]?sourceName=<source name>&accessToken=<access token>[&sendPings=<boolean>][&failedMessageQueueSize=<int>][&consumerOutputJson=<boolean>][&structuredMessageHeader=<boolean>]
 ```
 
 ### Component Endpoint Options
@@ -114,6 +120,15 @@ The endpoint options apply to producer and consumer endpoints.  The following ar
 * **sendPings** [optional] a boolean value indicating whether to periodically ping the Vantiq server (default is false)
 * **failedMessageQueueSize** [optional] an integer value indicating how many messages to hold for sending when the connection to the Vantiq server fails.
 * **consumerOutputJson** [optional] a boolean value indicating whether messages sent from Vantiq to the Vantiq component (_i.e._, a Vantiq Consumer) should be put into an Apache Camel Exchange as a JSON message.  If false, messages are put into an exchange as a Java Map.
+* **structuredMessageHeader** [optional] a boolean value indicated whether messages sent to and from the Vantiq component (Vantiq Consumers and Producers) should be structured as
+
+    ```json
+    {
+        headers: { ... },
+        message: { ... }
+    }
+    ```  
+
 
 For example, to create an Apache Camel application that receives messages from a Vantiq system at `vantiq.example.com`
 from source `exampleSource` and access token `FD10s0x...`, we would use something like the following:

--- a/camelComponent/README.md
+++ b/camelComponent/README.md
@@ -92,7 +92,7 @@ arrive as Vail objects, where the property names correspond to the Map keys.
 
 By adding the `structuredMessageHeader` component endpoint option with a value of `true` (see below), you can set or access the Camel message headers.  When this option is set to `true`, messages sent to or received from the Camel Component will have two properties: `headers` and `message`, both containing Vail objects. The `message` property will contain a Vail object where each property corresponds to same-named property in the underlying message.  The `headers` property will contain a Vail object where each property contains the value of the named message header.
 
-A schema type definition for this message structure is available in `src/main/resources/types/io/vantq/extsrc/camelcomp/message.json`.
+A schema type definition for this message structure is available in `src/main/resources/types/io/vantiq/extsrc/camelcomp/message.json`.
 
 ## Exchanges to Vantiq
 
@@ -120,7 +120,7 @@ The endpoint options apply to producer and consumer endpoints.  The following ar
 * **sendPings** [optional] a boolean value indicating whether to periodically ping the Vantiq server (default is false)
 * **failedMessageQueueSize** [optional] an integer value indicating how many messages to hold for sending when the connection to the Vantiq server fails.
 * **consumerOutputJson** [optional] a boolean value indicating whether messages sent from Vantiq to the Vantiq component (_i.e._, a Vantiq Consumer) should be put into an Apache Camel Exchange as a JSON message.  If false, messages are put into an exchange as a Java Map.
-* **structuredMessageHeader** [optional] a boolean value indicated whether messages sent to and from the Vantiq component (Vantiq Consumers and Producers) should be structured as
+* **structuredMessageHeader** [optional] a boolean value indicating whether messages sent to and from the Vantiq component (Vantiq Consumers and Producers) should be structured as
 
     ```json
     {

--- a/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqEndpoint.java
+++ b/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqEndpoint.java
@@ -53,32 +53,48 @@ import java.util.concurrent.ExecutorService;
 @UriParams
 @Slf4j
 public class VantiqEndpoint extends DefaultEndpoint {
+    
+    public static final String STRUCTURED_MESSAGE_MESSAGE_PROPERTY = "message";
+    public static final String STRUCTURED_MESSAGE_HEADERS_PROPERTY = "headers";
+    
+    public static final String SOURCE_NAME_PARAM = "sourceName";
     @UriParam @Metadata(required = true)
     @Setter
     private String sourceName;
     
+    public static final String ACCESS_TOKEN_PARAM = "accessToken";
     @UriParam(label="security", secret = true) @Metadata(required = true)
     @Setter
     private String accessToken;
     
+    public static final String SEND_PINGS_PARAM = "sendPings";
     @UriParam(defaultValue = "false")
     @Getter
     @Setter
     private boolean sendPings;
     
+    public static final String NO_SSL_PARAM = "noSsl";
     @UriParam(defaultValue = "false")
     @Getter
     @Setter
     private boolean noSsl;
     
+    public static final String CONSUMER_OUTPUT_JSON_PARAM = "consumerOutputJson";
     @UriParam(defaultValue = "false")
     @Getter
     @Setter
     private boolean consumerOutputJson;
     
+    public static final String FAILED_MESSAGE_QUEUE_SIZE_PARAM = "failedMessageQueueSize";
     @UriParam(defaultValue = "25")
     @Setter
     private int failedMessageQueueSize;
+    
+    public static final String STRUCTURED_MESSAGE_HEADER_PARAM = "structuredMessageHeader";
+    @UriParam(defaultValue = "false")
+    @Getter
+    @Setter
+    private boolean structuredMessageHeader;
     
     @Setter
     @Getter
@@ -94,7 +110,7 @@ public class VantiqEndpoint extends DefaultEndpoint {
     @Getter
     private String endpointName;
     
-    InstanceConfigUtils utils = null;
+    InstanceConfigUtils utils;
 
     public VantiqEndpoint() {
         utils = new InstanceConfigUtils();
@@ -294,7 +310,7 @@ public class VantiqEndpoint extends DefaultEndpoint {
             this.setEndpointUri(baseUri);
             String origScheme = vantiqURI.getScheme();
             
-            StringBuffer epString = new StringBuffer(vantiqURI.toString());
+            StringBuilder epString = new StringBuilder(vantiqURI.toString());
             epString.append("?sourceName=").append(sourceName);
             this.sourceName = sourceName;
             epString.append("&accessToken=").append(accessToken);

--- a/camelComponent/src/main/resources/types/io/vantiq/extsrc/camelcomp/message.json
+++ b/camelComponent/src/main/resources/types/io/vantiq/extsrc/camelcomp/message.json
@@ -2,7 +2,7 @@
   "ars_relationships" : [ ],
   "name" : "io.vantiq.extsrc.camelcomp.message",
   "properties" : {
-    "header" : {
+    "headers" : {
       "encrypted" : false,
       "multi" : false,
       "required" : false,

--- a/camelComponent/src/main/resources/types/io/vantiq/extsrc/camelcomp/message.json
+++ b/camelComponent/src/main/resources/types/io/vantiq/extsrc/camelcomp/message.json
@@ -1,0 +1,21 @@
+{
+  "ars_relationships" : [ ],
+  "name" : "io.vantiq.extsrc.camelcomp.message",
+  "properties" : {
+    "header" : {
+      "encrypted" : false,
+      "multi" : false,
+      "required" : false,
+      "type" : "Object",
+      "unique" : false
+    },
+    "message" : {
+      "encrypted" : false,
+      "multi" : false,
+      "required" : false,
+      "type" : "Object",
+      "unique" : false
+    }
+  },
+  "role" : "schema"
+}


### PR DESCRIPTION
Fixes #394 

Adds endpoint config flag (URL param) to ask for "structured' messages.  These are messages have the camel message  & header present, allowing caller to set headers & consumers to see them.

Added tests for same

Some other code cleanup as well.