### PR TITLE
Rename message type's package to com.vantiq...

### DIFF
--- a/camelComponent/README.md
+++ b/camelComponent/README.md
@@ -92,7 +92,7 @@ arrive as Vail objects, where the property names correspond to the Map keys.
 
 By adding the `structuredMessageHeader` component endpoint option with a value of `true` (see below), you can set or access the Camel message headers.  When this option is set to `true`, messages sent to or received from the Camel Component will have two properties: `headers` and `message`, both containing Vail objects. The `message` property will contain a Vail object where each property corresponds to same-named property in the underlying message.  The `headers` property will contain a Vail object where each property contains the value of the named message header.
 
-A schema type definition for this message structure is available in `src/main/resources/types/io/vantiq/extsrc/camelcomp/message.json`.
+A schema type definition for this message structure is available in `src/main/resources/types/com/vantiq/extsrc/camelcomp/message.json`.
 
 ## Exchanges to Vantiq
 

--- a/camelComponent/src/main/resources/types/com/vantiq/extsrc/camelcomp/message.json
+++ b/camelComponent/src/main/resources/types/com/vantiq/extsrc/camelcomp/message.json
@@ -1,6 +1,6 @@
 {
   "ars_relationships" : [ ],
-  "name" : "io.vantiq.extsrc.camelcomp.message",
+  "name" : "com.vantiq.extsrc.camelcomp.message",
   "properties" : {
     "headers" : {
       "encrypted" : false,


### PR DESCRIPTION
Fixeds #397

Rename message type's package to com.vantiq... because io.vantiq... is reserved.