### PR TITLE
Synchronize Camel versions across subprojects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,11 +33,6 @@ private Map getHostInfo() {
 }
 
 group 'io.vantiq'
-// version scmVersion.version
-
-// scmVersion {
-//    versionIncrementer 'incrementMinor'
-// }
 
 ext {
     slf4jApiVersion = '1.7.25'
@@ -45,6 +40,7 @@ ext {
     vantiqSDKVersion = '1.1.1'
     log4jVersion = '2.17.0'
     lombokVersion = '1.18.24'
+    camelVersion = '3.18.3'
 }
 
 

--- a/camelComponent/build.gradle
+++ b/camelComponent/build.gradle
@@ -14,7 +14,6 @@ repositories {
 }
 
 ext {
-    camelVersion='3.18.1'
     log4JVersion='2.17.2'
     extjsdkVersion='1.0'
     jacksonVersion = '2.14.2'

--- a/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqEndpoint.java
+++ b/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqEndpoint.java
@@ -359,7 +359,7 @@ public class VantiqEndpoint extends DefaultEndpoint {
             } else {
                 correctedUrl = baseUrl;
             }
-            log.trace("Adjusted Vantiq URL: {} (from {})", correctedUrl, baseUrl);
+            log.debug("Adjusted Vantiq URL: {} (from {})", correctedUrl, baseUrl);
         } catch (URISyntaxException uriSE) {
             throw new CamelException("Unable to connect to provided URI: " + baseUrl +
                                              " (adjusted: " + correctedUrl + ")", uriSE);

--- a/camelConnector/build.gradle
+++ b/camelConnector/build.gradle
@@ -35,7 +35,6 @@ repositories {
 
 ext {
     apacheCommonsLangVersion = '3.12.0'
-    camelVersion='3.18.3'
     dnsJavaVersion = '3.4.2'
     extjsdkVersion='1.0'
     gsonVersion = '2.9.1'

--- a/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/connector/CamelHandleConfiguration.java
+++ b/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/connector/CamelHandleConfiguration.java
@@ -94,6 +94,7 @@ public class CamelHandleConfiguration extends Handler<ExtensionServiceMessage> {
         Map<String, Object> camelConfig;
         Map<String, Object> general;
         
+        log.debug("Connector got configuration: {}", configObject);
         // Obtain entire config from the message object
         if ( !(configObject.get(CAMEL_CONFIG) instanceof Map)) {
             log.error("Configuration failed. No configuration suitable for Camel Source.");
@@ -146,9 +147,8 @@ public class CamelHandleConfiguration extends Handler<ExtensionServiceMessage> {
             } else {
                 // It's coming from JSON, so the key must be a string...
                 Map<String, Object> input = (Map<String, Object>) target;
-                Properties propVals = new Properties(input.size());
                 input.forEach( (k, v) -> {
-                    if (!(k != null && v instanceof String)) {
+                    if (v == null) {
                         String kclass = "null";
                         String vclass = "null";
                         if (k != null) {
@@ -257,13 +257,16 @@ public class CamelHandleConfiguration extends Handler<ExtensionServiceMessage> {
     
             // This is checked in the caller
             //noinspection unchecked
-            Map<String, String> input = (Map<String, String>) camelConfig.get(PROPERTY_VALUES);
+            Map<String, Object> input = (Map<String, Object>) camelConfig.get(PROPERTY_VALUES);
             // Camel wants these as a Java Properties object, so perform the conversion as required.
             Properties propVals = null;
             if (input != null) {
                 propVals = new Properties(input.size());
-                input.forEach(propVals::setProperty);
+                for (Map.Entry<String, Object> p : input.entrySet()) {
+                    propVals.setProperty(p.getKey(), p.getValue().toString());
+                }
             }
+            log.debug("Properties provided: {}", propVals);
     
             // If we get this far, then we're ready to run start from the new configuration.  If we have an old
             // configuration running, we'll need to shut it down first.


### PR DESCRIPTION
Fixes #399

Synchronized Camel versions across various subprojects that use Camel.  We should use exactly one Camel version (in practice, only one is used, but there's no reason to defining it 2-3 times).

Also, add some extra error handling and tracing for source startup in the connector