### PR TITLE
More work on the way to assembly generation from Kamelets

### DIFF
--- a/buildSrc/src/main/groovy/io/vantiq/extsrc/assy/tasks/AssemblyResourceGeneration.groovy
+++ b/buildSrc/src/main/groovy/io/vantiq/extsrc/assy/tasks/AssemblyResourceGeneration.groovy
@@ -415,7 +415,7 @@ class AssemblyResourceGeneration extends DefaultTask {
         // However, if we did that, on installation, the user would have to provide an object with the various lower
         // level items & their values.  And any descriptive information provided by the kamelet definition would be
         // lost.  Consequently, it seems preferable for each source to define the set it needs and let the assembly
-        // installation and configuration mechanism take it's course.
+        // installation and configuration mechanism take its course.
         props.each { aProp ->
             log.debug('Creating prop value stub for {}', aProp)
             propValStubs[aProp.key] = aProp.key + PROPERTY_PLACEHOLDER_SUFFIX

--- a/camelAssemblies/build.gradle
+++ b/camelAssemblies/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
 ext {
     generatedResourceBase = 'vantiqGeneratedResources'
-    zippedAssemblies = 'vantiqAssemblies'
+    distributionsDir = 'distributions'
 }
 
 tasks.withType(JavaCompile) {
@@ -26,13 +26,15 @@ tasks.register('zipAssemblies') {
     def assyCount = 0
     doLast {
         File vtqResources = new File(project.buildDir, "${generatedResourceBase}")
-        def assemblies = new File(project.buildDir, "${zippedAssemblies}")
-        mkdir(assemblies)
+        def distributions = new File(project.buildDir, "${distributionsDir}")
+        mkdir(distributions)
         vtqResources.eachDir { resourceDir ->
             def projName = resourceDir.name
             logger.info('Processing {}', projName)
-            project.ant.zip(destfile: new File(assemblies, projName + '.zip')) {
-                fileSet(dir: resourceDir)
+            project.ant.zip(destfile: new File(distributions, projName + '.zip')) {
+                // Here, we use the project name (projName) as the base directory within the zip file
+                // This is the required format for projects
+                zipfileset(dir: resourceDir, prefix: projName)
             }
             assyCount += 1
         }

--- a/camelAssemblies/build.gradle
+++ b/camelAssemblies/build.gradle
@@ -43,5 +43,5 @@ tasks.register('zipAssemblies') {
 tasks.register('generateAssemblyResources', AssemblyResourceGeneration)
 
 assemble.finalizedBy('generateAssemblyResources')
-assemble.finalizedBy('zipAssemblies')
+generateAssemblyResources.finalizedBy('zipAssemblies')
 zipAssemblies.mustRunAfter( 'generateAssemblyResources' )


### PR DESCRIPTION
(part of bigger issue)

Correct generation of assembly projects so that routes are correct, naming is correct, and the things work from generation to install & operation (for one simple case).

Added Camel version used into package names & assembly name.  This will allow us to support > 1 camel version in our catalog (once we do that).  Kamelets are Camel version specific -- there's an issue in the current state because our connector & component predate kamelets, and there was a change to (at least) the logging component in the minor versions in between.  Will correct that versioning overall in a subsequent PR.  Separate PR up to unify the versioning, so it'll be easier to change.