### PR TITLE
Cleanup/testing enhancement: Include all possible modules regardless of driver presence

### DIFF
--- a/jdbcSource/build.gradle
+++ b/jdbcSource/build.gradle
@@ -66,7 +66,9 @@ dependencies {
     implementation "org.apache.logging.log4j:log4j-slf4j-impl:${log4jVersion}"
     
     //  Compiling relevant JDBC Driver .jar file
-    runtimeOnly files("${System.env.JDBC_DRIVER_LOC}")
+    if (System.env.JDBC_DRIVER_LOC != null) {
+        runtimeOnly files("${System.env.JDBC_DRIVER_LOC}")
+    }
     
     // Used in tests that check VANTIQ date format behavior
     testImplementation "io.vantiq:vantiq-sdk:${vantiqSDKVersion}"

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -189,7 +189,6 @@ public class TestJDBC extends TestJDBCBase {
     @Before
     public void setup() {
         if (testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null) {
-    
             jdbc = new JDBC();
             vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
             vantiq.setAccessToken(testAuthToken);
@@ -212,23 +211,25 @@ public class TestJDBC extends TestJDBCBase {
     
     @After
     public void postTestCleanup() {
-        // Delete the Source/Type/Topic/Procedure/Rule from VANTIQ
-        deleteType();
-        deleteTopic();
-        deleteProcedure();
-        deleteRule();
-        if (core != null) {
-            core.close();
-            core = null;
+        if (testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null) {
+            // Delete the Source/Type/Topic/Procedure/Rule from VANTIQ
+            deleteType();
+            deleteTopic();
+            deleteProcedure();
+            deleteRule();
+            if (core != null) {
+                core.close();
+                core = null;
+            }
+    
+            if (jdbc != null) {
+                jdbc.close();
+                jdbc = null;
+            }
+            // Don't delete the source until you've shut down the connector. Otherwise, a bunch of spurious errors appear
+            // in the test log as it tries to reconnect.
+            deleteSource();
         }
-        
-        if (jdbc != null) {
-            jdbc.close();
-            jdbc = null;
-        }
-        // Don't delete the source until you've shut down the connector. Otherwise, a bunch of spurious errors appear
-        // in the test log as it tries to reconnect.
-        deleteSource();
     }
 
     @SuppressWarnings({"PMD.JUnit4TestShouldUseAfterAnnotation", "PMD.CognitiveComplexity", "PMD.EmptyCatchBlock"})

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -188,13 +188,16 @@ public class TestJDBC extends TestJDBCBase {
     
     @Before
     public void setup() {
-        jdbc = new JDBC();
-        vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
-        vantiq.setAccessToken(testAuthToken);
-        try {
-            createSourceImpl(vantiq);
-        } catch (Exception e) {
-            fail("Could not create sourceImpl: " + e.getMessage());
+        if (testDBUsername != null && testDBPassword != null && testDBURL != null && jdbcDriverLoc != null) {
+    
+            jdbc = new JDBC();
+            vantiq = new io.vantiq.client.Vantiq(testVantiqServer);
+            vantiq.setAccessToken(testAuthToken);
+            try {
+                createSourceImpl(vantiq);
+            } catch (Exception e) {
+                fail("Could not create sourceImpl: " + e.getMessage());
+            }
         }
     }
 

--- a/jmsSource/build.gradle
+++ b/jmsSource/build.gradle
@@ -55,8 +55,11 @@ dependencies {
     // Used for for standard JMS utility
     implementation group: 'javax.jms', name: 'javax.jms-api', version: '2.0.1'
 
-    // Compiling relevant JMS Driver .jar file
-    implementation files("${System.env.JMS_DRIVER_LOC}")
+    if (System.env.JMS_DRIVER_LOC != null) {
+
+        // Compiling relevant JMS Driver .jar file
+        runtimeOnly files("${System.env.JMS_DRIVER_LOC}")
+    }
 
     // Used for testing extension source in VANTIQ
     testImplementation "io.vantiq:vantiq-sdk:${vantiqSDKVersion}"

--- a/jmsSource/src/test/java/io/vantiq/extsrc/jmsSource/TestJMS.java
+++ b/jmsSource/src/test/java/io/vantiq/extsrc/jmsSource/TestJMS.java
@@ -56,11 +56,17 @@ public class TestJMS extends TestJMSBase {
     
     @Before
     public void setup() {
-        vantiq = new Vantiq(testVantiqServer);
-        vantiq.setAccessToken(testAuthToken);
-        
-        // Create a subscription to source in order to check if message was received as a notification
-        vantiq.subscribe("sources", testSourceName, null, sourceNotificationCallback);
+        // Only do this setup where feasible.
+        if (jmsDriverLoc != null &&
+                testJMSURL != null &&
+                testJMSConnectionFactory != null &&
+                testJMSInitialContext != null) {
+            vantiq = new Vantiq(testVantiqServer);
+            vantiq.setAccessToken(testAuthToken);
+    
+            // Create a subscription to source in order to check if message was received as a notification
+            vantiq.subscribe("sources", testSourceName, null, sourceNotificationCallback);
+        }
     }
     
     @After

--- a/jmsSource/src/test/java/io/vantiq/extsrc/jmsSource/TestJMS.java
+++ b/jmsSource/src/test/java/io/vantiq/extsrc/jmsSource/TestJMS.java
@@ -71,14 +71,18 @@ public class TestJMS extends TestJMSBase {
     
     @After
     public void unsubscribe() {
-        vantiq.unsubscribeAll();
+        if (jmsDriverLoc != null &&
+                testJMSURL != null &&
+                testJMSConnectionFactory != null &&
+                testJMSInitialContext != null) {
+    
+            vantiq.unsubscribeAll();
+        }
     }
 
     @SuppressWarnings("PMD.JUnit4TestShouldUseAfterAnnotation")
     @AfterClass
     public static void tearDown() {
-        // Delete source from VANTIQ
-        deleteSource();
         
         // Close JMSCore if still open
         if (core != null) {
@@ -90,6 +94,9 @@ public class TestJMS extends TestJMSBase {
             jms.close();
             jms = null;
         }
+        // Delete source from VANTIQ
+        deleteSource();
+    
     }
     
     @Test
@@ -711,9 +718,11 @@ public class TestJMS extends TestJMSBase {
     }
     
     public static void deleteSource() {
-        Map<String,Object> where = new LinkedHashMap<String,Object>();
-        where.put("name", testSourceName);
-        vantiq.delete("system.sources", where);
+        if (vantiq != null && vantiq.isAuthenticated()) {
+            Map<String, Object> where = new LinkedHashMap<String, Object>();
+            where.put("name", testSourceName);
+            vantiq.delete("system.sources", where);
+        }
     }
     
     public class StandardOutputCallback implements SubscriptionCallback {

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,12 +9,8 @@ include 'udpSource'
 include 'CSVSource'
 include 'testConnector'
 include 'objectRecognitionSource'
+include 'jdbcSource'
+include 'jmsSource'
 if (System.env.EASY_MODBUS_LOC) {
     include 'EasyModbusSource' 
-}
-if (System.env.JDBC_DRIVER_LOC) {
-    include 'jdbcSource'
-}
-if (System.env.JMS_DRIVER_LOC) {
-    include 'jmsSource'
 }


### PR DESCRIPTION
Fixes #404 

Allows for a bit more verification when used in generalized testing scenarios.  Previously, we had ignored entire modules if the associated driver definitions (JDBC, JMS) were not present.  This PR changes that so that we'll include the module, build it, and do whatever testing is possible (often not much, but some isolated unit tests are feasible).  This may allow us to detect broken things earlier.

At present, this affects only the JDBC & JMS sources -- as these are based on general interfaces at compile tile.  The EasyModBus source requires the jar file for compilation of the sources, so without the "driver" file, this can't proceed.