### PR TITLE
Create camel connector assembly when building the system.

### DIFF
--- a/camelConnector/README.md
+++ b/camelConnector/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-The following documentation outlines how to incorporate an Apache Camel Connector Source into part of your project.
+The following documentation outlines how to incorporate an Apache Camel Connector and associated Vantiq SOURCE into part of your project.
 This allows a user to 
 construct Apache Camel applications that interact with Vantiq.
 
@@ -113,7 +113,7 @@ name for each class is the class's fully qualified class name, *e.g.* "io.vantiq
 
 To set up the Source in the VANTIQ Modelo IDE, you will need to add a Source to your project. Please check the [Prerequisites](#pre) 
 to make sure you have properly added a Source Definition to VANTIQ Modelo. Once this is complete,
-you can select CAMEL_CONNECTOR
+you can select CAMEL
 (or whatever you named your Source Definition) as the Source Type. You will then need to provide the
 Source Configuration Document.
 
@@ -287,7 +287,6 @@ PROCEDURE publishToCamel(valueToSend Integer)
 
 Query errors originating from the source will include the code and error message.
 They may also include the cause (the underlying exception).
-
 
 ## Testing <a name="testing" id="testing"></a>
 

--- a/camelConnector/build.gradle
+++ b/camelConnector/build.gradle
@@ -35,6 +35,7 @@ repositories {
 
 ext {
     apacheCommonsLangVersion = '3.12.0'
+    camelVersion='3.18.3'
     dnsJavaVersion = '3.4.2'
     extjsdkVersion='1.0'
     gsonVersion = '2.9.1'
@@ -99,6 +100,31 @@ version = 'unspecified'
 description = 'Vantiq Camel Connector'
 java.sourceCompatibility = 1.11
 java.targetCompatibility = JavaVersion.VERSION_11
+
+/**
+ * The following task builds an assembly project zip file to make the CAMEL_CONNECTOR source implementation type
+ * known to the Vantiq system.  It also provides a schema type for the structured message & header for use
+ * with the Vantiq component when the appropriate endpoint flag is specified.
+ */
+
+task zipAssembly(type: Zip) {
+    def inFiles =  project.fileTree('src/main/resources/assembly/camelconnector')
+    logger.debug('Infiles: {}', inFiles)
+
+    project(':camelComponent').fileTree('src/main/resources/types').each { f ->
+        it.inputs.file( f )
+    }
+    from(inFiles) {
+        include '**/*'
+    }
+    from (project(':camelComponent').fileTree('src/main/resources')) {
+        include 'types/**/*'
+    }
+    into "${project.name}"
+    archiveName "${project.name}-assembly.zip"
+}
+
+jar.finalizedBy zipAssembly
 
 publishing {
     publications {

--- a/camelConnector/build.gradle
+++ b/camelConnector/build.gradle
@@ -101,7 +101,7 @@ java.sourceCompatibility = 1.11
 java.targetCompatibility = JavaVersion.VERSION_11
 
 /**
- * The following task builds an assembly project zip file to make the CAMEL_CONNECTOR source implementation type
+ * The following task builds an assembly project zip file to make the CAMEL source implementation type
  * known to the Vantiq system.  It also provides a schema type for the structured message & header for use
  * with the Vantiq component when the appropriate endpoint flag is specified.
  */

--- a/camelConnector/build.gradle
+++ b/camelConnector/build.gradle
@@ -35,7 +35,6 @@ repositories {
 
 ext {
     apacheCommonsLangVersion = '3.12.0'
-    camelVersion='3.18.3'
     dnsJavaVersion = '3.4.2'
     extjsdkVersion='1.0'
     gsonVersion = '2.9.1'

--- a/camelConnector/src/main/resources/assembly/camelconnector/projects/com.vantiq.extsrc.camelconn.camelConnector.json
+++ b/camelConnector/src/main/resources/assembly/camelconnector/projects/com.vantiq.extsrc.camelconn.camelConnector.json
@@ -1,0 +1,52 @@
+{
+    "name": "com.vantiq.extsrc.camelconn.camelConnector",
+    "type": "dev",
+    "ars_relationships": [
+        
+    ],
+    "links": [
+        
+    ],
+    "tools": [
+        
+    ],
+    "views": [
+        
+    ],
+    "partitions": [
+        
+    ],
+    "isAssembly": true,
+    "options": {
+        "description": "Camel Connector Definition",
+        "filterBitArray": "ffffffffffffffffffffffffffffffff",
+        "type": "dev",
+        "v": 5,
+        "isModeloProject": true
+    },
+    "resources": [
+      {
+        "label": "CAMEL",
+        "name" : "CAMEL",
+        "resourceReference": "/sourceimpls/CAMEL",
+        "type" : 69
+      },
+      {
+        "label" : "com.vantiq.extsrc.camelcomp.message",
+        "name" : "com.vantiq.extsrc.camelcomp.message",
+        "resourceReference": "/types/com.vantiq.extsrc.camelcomp.message",
+        "type": 1
+      }
+    ],
+    "visibleResources": [
+      {
+        "resourceReference": "/types/com.vantiq.extsrc.camelcomp.message"
+      }
+    ],
+    "configurationMappings": {
+
+    },
+    "configurationProperties": {
+
+    }
+}

--- a/camelConnector/src/main/resources/assembly/camelconnector/sourceimpls/CAMEL.json
+++ b/camelConnector/src/main/resources/assembly/camelconnector/sourceimpls/CAMEL.json
@@ -3,6 +3,7 @@
   "baseType" : "EXTENSION",
   "verticle" : "service:extensionSource",
   "config" : {},
+  "operations" : [ "publish", "query", "notification" ],
   "baseConfigProperties": [
   ]
 }


### PR DESCRIPTION
Fixes #396 

While creating, changed name of source type (sourceimpl) to CAMEL -- _plainer_ name matches existing conventions for source types.

Also, fix version confusion in build files -- not really an issue but looks confusing in the files. 