### PR TITLE
Camel Component: Use correct mechanism to output the JSON nodes

### DIFF
--- a/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqConsumer.java
+++ b/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqConsumer.java
@@ -32,7 +32,6 @@ import org.apache.camel.support.DefaultConsumer;
 @Slf4j
 public class VantiqConsumer extends DefaultConsumer {
     private final VantiqEndpoint endpoint;
-    private ExtensionWebSocketClient vantiqClient;
 
     private ExecutorService executorService;
     
@@ -47,7 +46,7 @@ public class VantiqConsumer extends DefaultConsumer {
     protected void doStart() throws Exception {
         super.doStart();
         endpoint.startup();
-        vantiqClient = endpoint.getVantiqClient();
+        ExtensionWebSocketClient vantiqClient = endpoint.getVantiqClient();
         vantiqClient.setPublishHandler(publishHandler);
         vantiqClient.setQueryHandler(queryHandler);
 
@@ -64,9 +63,6 @@ public class VantiqConsumer extends DefaultConsumer {
 
         // shutdown the thread pool gracefully
         getEndpoint().getCamelContext().getExecutorServiceManager().shutdownGraceful(executorService);
-        if (vantiqClient != null) {
-            vantiqClient.close();
-        }
     }
     
     /**
@@ -118,10 +114,15 @@ public class VantiqConsumer extends DefaultConsumer {
                 msgBody = camelBody;
                 log.debug("Structured message -- hdrs: {}, message: {}", camelHdrs, camelBody);
             }
+            Object output = msgBody;
             if (endpoint.isConsumerOutputJson()) {
                 // Convert to JSON output
-               JsonNode jnode =  mapper.convertValue(msgBody, JsonNode.class);
-               msgBody = jnode.toPrettyString();
+                JsonNode jnode =  mapper.convertValue(msgBody, JsonNode.class);
+                output = jnode;
+                if (log.isDebugEnabled()) {
+                    Object resValueDbg = jnode.isTextual() ? jnode.asText() : jnode;
+                    log.debug("ConsumerOutputJson: msgBody out: {}", resValueDbg);
+                }
             }
     
             // Create an exchange to move our message along.  In the publish case,
@@ -130,7 +131,7 @@ public class VantiqConsumer extends DefaultConsumer {
             // result, so we'll deal with those separately.
             final Exchange exchange = createExchange(false);
             exchange.setPattern(pattern);
-            exchange.getIn().setBody(msgBody);
+            exchange.getIn().setBody(output);
             if (camelHdrs != null) {
                 exchange.getIn().setHeaders(camelHdrs);
             }


### PR DESCRIPTION
Fixes #408

W/o fix, json output of strings was "some string" rather than `some string` which was incorrect.

Also fixes issue with `vantiq://server.config` style cases being closed when they shouldn't.  In that case, the client is under control of the Camel connector & the closing thereof should be left to said connector.