### PR TITLE
Camel Connector: Add support for wrapping prop values in RAW().

### DIFF
--- a/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/connector/CamelHandleConfiguration.java
+++ b/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/connector/CamelHandleConfiguration.java
@@ -254,9 +254,11 @@ public class CamelHandleConfiguration extends Handler<ExtensionServiceMessage> {
             Map<String, List<String>> raw = (Map<String, List<String>>) camelConfig.get(RAW_REQUIRED);
             List<String> rawRequired = new ArrayList<>();
             // Create a list from the various categories that may be in this set...
-            raw.forEach( (k, v) -> {
-                rawRequired.addAll(v);
-            });
+            if (raw != null) {
+                raw.forEach((k, v) -> {
+                    rawRequired.addAll(v);
+                });
+            }
             // Camel wants these as a Java Properties object, so perform the conversion as required.
             Properties propVals = null;
             if (input != null) {

--- a/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/connector/CamelHandleConfiguration.java
+++ b/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/connector/CamelHandleConfiguration.java
@@ -63,7 +63,7 @@ public class CamelHandleConfiguration extends Handler<ExtensionServiceMessage> {
     public static final String PROPERTY_VALUES = "propertyValues";
     public static final String RAW_REQUIRED = "rawValuesRequired";
     public static final String DISCOVERED_RAW = "discovered";
-    public static final String CONFIGGURED_RAW = "configured";
+    public static final String CONFIGURED_RAW = "configured";
     
     public static final String VANTIQ = "vantiq";
     public static final String GENERAL = "general";
@@ -280,7 +280,7 @@ public class CamelHandleConfiguration extends Handler<ExtensionServiceMessage> {
                                 }
                                 propVals.setProperty(p.getKey(), startRaw + val + endRaw);
                             } else {
-                                // If we're suppressing or we havwe a value with both ) & }, leave things alone
+                                // If we're suppressing or we have a value with both ) & }, leave things alone
                                 propVals.setProperty(p.getKey(), p.getValue().toString());
                             }
                         } else {

--- a/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelRunner.java
+++ b/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelRunner.java
@@ -143,6 +143,10 @@ public class CamelRunner extends MainSupport implements Closeable {
         createCamelContext();
     }
     
+    public Properties getCamelProperties() {
+        return camelProperties;
+    }
+    
     /**
      * Build the application classloader we will use.
      *
@@ -397,7 +401,7 @@ public class CamelRunner extends MainSupport implements Closeable {
                     }
                 }
             }
-    
+
             // Some routes may have components (e.g., Salesforce) that need specific configuration.
             // If that's the case, do that now before we start our route(s).
             if (initComponents != null && initComponents.size() > 0) {

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/VantiqConfigurationTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/VantiqConfigurationTest.java
@@ -1,5 +1,11 @@
 package io.vantiq.extsrc.camelconn.connector;
 
+import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.NO_RAW_REQUEST;
+import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.RAW_END;
+import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.RAW_END_ALT;
+import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.RAW_START;
+import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.RAW_START_ALT;
+
 import static io.vantiq.extjsdk.ExtensionServiceMessage.OP_CONFIGURE_EXTENSION;
 import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.APP_NAME;
 import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.CAMEL_APP;
@@ -7,8 +13,10 @@ import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.CAME
 import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.COMPONENT_CACHE;
 import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.COMPONENT_LIB;
 import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.COMPONENT_PROPERTIES;
+import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.DISCOVERED_RAW;
 import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.GENERAL;
 import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.PROPERTY_VALUES;
+import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.RAW_REQUIRED;
 import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.ROUTES_FORMAT;
 import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.ROUTES_LIST;
 import static io.vantiq.extsrc.camelconn.discover.VantiqComponentResolverTest.MISSING_VALUE;
@@ -52,13 +60,19 @@ public class VantiqConfigurationTest {
     
     // Interface to use in declaration.  We'll pass lambda's in to do the actual verification work
     interface Verifier {
-        void doVerify(CamelContext runnerContext);
+        void doVerify(CamelContext runnerContext, Properties props);
     }
     
     void performConfigTest(String appName, String route, String routeFormat,
                            List<Map<String, Object>> compInitProps, Properties propertyValues, Verifier vfy) {
+        performConfigTest(appName, route, routeFormat, compInitProps, propertyValues, vfy, null);
+    }
+    void performConfigTest(String appName, String route, String routeFormat,
+                           List<Map<String, Object>> compInitProps, Properties propertyValues, Verifier vfy,
+                           List<String> rawReq) {
         assumeTrue(!sfLoginUrl.equals(MISSING_VALUE) && !sfClientId.equals(MISSING_VALUE) &&
                            !sfClientSecret.equals(MISSING_VALUE) && !sfRefreshToken.equals(MISSING_VALUE));
+        
         Map<String, Object> simpleConfig = new HashMap<>();
         Map<String, Object> camelConfig = new HashMap<>();
         simpleConfig.put(CAMEL_CONFIG, camelConfig);
@@ -66,10 +80,10 @@ public class VantiqConfigurationTest {
         camelConfig.put(CAMEL_APP, camelAppConfig);
         Map<String, String> generalConfig = new HashMap<>();
         camelConfig.put(GENERAL, generalConfig);
-        
+
         generalConfig.put(COMPONENT_CACHE, CACHE_DIR);
         generalConfig.put(COMPONENT_LIB, LOADED_LIBRARIES);
-        
+
         camelAppConfig.put(ROUTES_LIST, route);
         camelAppConfig.put(ROUTES_FORMAT, routeFormat);
         camelAppConfig.put(APP_NAME, appName);
@@ -79,16 +93,22 @@ public class VantiqConfigurationTest {
         if (propertyValues != null) {
             camelAppConfig.put(PROPERTY_VALUES, propertyValues);
         }
-        
+        if (rawReq != null) {
+            Map<String, Object> rawReqMap = new HashMap<>();
+            
+            rawReqMap.put(DISCOVERED_RAW, rawReq);
+            camelAppConfig.put(RAW_REQUIRED, rawReqMap);
+        }
+
         String fauxVantiqUrl = "http://someVantiqServer";
         ExtensionServiceMessage esm = new ExtensionServiceMessage(fauxVantiqUrl);
         esm.op = OP_CONFIGURE_EXTENSION;
         esm.object = simpleConfig;
-        
+
         CamelCore core = new CamelCore("testComponentInitConfiguration",
                                        "someAccessToken", fauxVantiqUrl);
         CamelHandleConfiguration handler = new CamelHandleConfiguration(core);
-        
+
         handler.handleMessage(esm);
         assertTrue("handler completed", handler.isComplete());
         assertNotNull("Camel Runner", handler.getCurrentCamelRunner());
@@ -100,8 +120,12 @@ public class VantiqConfigurationTest {
         
         CamelContext runnerContext = handler.getCurrentCamelRunner().getCamelContext();
         assertTrue("Context Running", runnerContext.isStarted());
-        
-        vfy.doVerify(runnerContext);
+
+        try {
+            vfy.doVerify(runnerContext, handler.getCurrentCamelRunner().getCamelProperties());
+        } finally {
+            handler.getCurrentCamelRunner().close();
+        }
     
         handler.getCurrentCamelRunner().close();
         try {
@@ -111,11 +135,154 @@ public class VantiqConfigurationTest {
         }
     }
     
+    public static final String ROUTE_NOT_USED = ""
+            + "- route:\n"
+            + "    id: \"YAML route just there for existence\"\n"
+            + "    from:\n"
+            + "      uri: \"direct:start\"\n"
+            + "      steps:\n"
+            + "        - to:\n"
+            + "            uri: \"log:simplelog\"\n";
+    
+    @Test
+    public void testRawNoRaw() {
+        Map<String, Object> propValues = Map.of("prop1", "prop1Value",
+                                                "prop2", "prop2Value",
+                                                "prop3", "prop3Value");
+        Properties props = new Properties(propValues.size());
+        // Though officially frowned upon, Properties.putAll here from a Map<String, String> is safe as it cannot put
+        // non-String keys or values into the Properties base map.
+        props.putAll(propValues);
+    
+        performConfigTest(name.getMethodName(), ROUTE_NOT_USED, "yaml",
+                          null, props,
+                          (CamelContext runnerContext, Properties lclProps) -> {
+                                assert lclProps != null;
+                                assert propValues.size() == lclProps.size();
+                                propValues.forEach( (name, val) -> {
+                                    assert lclProps.containsKey(name);
+                                    assert lclProps.getProperty(name).equals(val);
+                              });
+                          });
+    }
+    
+    @Test
+    public void testRawRequired() {
+        Map<String, Object> propValues = Map.of("prop1", "prop1Value",
+                                                "prop2", "prop2Value",
+                                                "prop3", "prop3Value");
+        Properties props = new Properties(propValues.size());
+        // Though officially frowned upon, Properties.putAll here from a Map<String, String> is safe as it cannot put
+        // non-String keys or values into the Properties base map.
+        props.putAll(propValues);
+        List<String> raws = List.of("prop1", "prop3");
+    
+        performConfigTest(name.getMethodName(), ROUTE_NOT_USED, "yaml",
+                          null, props,
+                          (CamelContext runnerContext, Properties lclProps) -> {
+                              assert lclProps != null;
+                              assert propValues.size() == lclProps.size();
+                              propValues.forEach( (name, val) -> {
+                                  assert lclProps.containsKey(name);
+                                  if (raws.contains(name)) {
+                                      assert lclProps.getProperty(name).equals(CamelHandleConfiguration.RAW_START +
+                                              val + CamelHandleConfiguration.RAW_END);
+                                  } else {
+                                      assert lclProps.getProperty(name).equals(val);
+                                  }
+                              });
+                          }, raws);
+    }
+    
+    @Test
+    public void testRawAltRequired() {
+        Map<String, Object> propValues = Map.of("prop1", "prop1)Value",
+                                                "prop2", "prop2Value",
+                                                "prop3", "prop3Value");
+        Properties props = new Properties(propValues.size());
+        // Though officially frowned upon, Properties.putAll here from a Map<String, String> is safe as it cannot put
+        // non-String keys or values into the Properties base map.
+        props.putAll(propValues);
+        List<String> raws = List.of("prop1", "prop3");
+        
+        performConfigTest(name.getMethodName(), ROUTE_NOT_USED, "yaml",
+                          null, props,
+                          (CamelContext runnerContext, Properties lclProps) -> {
+                              assert lclProps != null;
+                              assert propValues.size() == lclProps.size();
+                              propValues.forEach( (name, val) -> {
+                                  assert lclProps.containsKey(name);
+                                  if (name.equals("prop1")) {
+                                      assert lclProps.getProperty(name).equals(CamelHandleConfiguration.RAW_START_ALT +
+                                                                                       val + CamelHandleConfiguration.RAW_END_ALT);
+                                  } else if (name.equals("prop3")) {
+                                      assert lclProps.getProperty(name).equals(CamelHandleConfiguration.RAW_START +
+                                                                                       val + CamelHandleConfiguration.RAW_END);
+                                  } else {
+                                      assert lclProps.getProperty(name).equals(val);
+                                  }
+                              });
+                          }, raws);
+    }
+    @Test
+    public void testRawSuppressed() {
+        Map<String, Object> propValues = Map.of("prop1", "prop1Value",
+                                                "prop2", NO_RAW_REQUEST + "prop2Value",
+                                                "prop3", "prop3Value");
+        Properties props = new Properties(propValues.size());
+        // Though officially frowned upon, Properties.putAll here from a Map<String, String> is safe as it cannot put
+        // non-String keys or values into the Properties base map.
+        props.putAll(propValues);
+        List<String> raws = List.of("prop2");
+    
+        performConfigTest(name.getMethodName(), ROUTE_NOT_USED, "yaml",
+                          null, props,
+                          (CamelContext runnerContext, Properties lclProps) -> {
+                              assert lclProps != null;
+                              assert propValues.size() == lclProps.size();
+                              propValues.forEach( (name, val) -> {
+                                  assert lclProps.containsKey(name);
+                                  if (raws.contains(name)) {
+                                      String newVal = ((String) propValues.get(name))
+                                              .substring(NO_RAW_REQUEST.length());
+                                      assert lclProps.getProperty(name).equals(newVal);
+                                  }
+                              });
+                          }, raws);
+    }
+    
+    @Test
+    public void testCannotWrap() {
+        Map<String, Object> propValues = Map.of("prop1", "prop1Value",
+                                                "prop2", "prop2Value",
+                                                "prop3", "prop3}Value)Value");
+        Properties props = new Properties(propValues.size());
+        // Though officially frowned upon, Properties.putAll here from a Map<String, String> is safe as it cannot put
+        // non-String keys or values into the Properties base map.
+        props.putAll(propValues);
+        List<String> raws = List.of("prop1", "prop3");
+    
+        performConfigTest(name.getMethodName(), ROUTE_NOT_USED, "yaml",
+                          null, props,
+                          (CamelContext runnerContext, Properties lclProps) -> {
+                              assert lclProps != null;
+                              assert propValues.size() == lclProps.size();
+                              propValues.forEach( (name, val) -> {
+                                  assert lclProps.containsKey(name);
+                                  if (name.equals("prop1")) {
+                                      assert lclProps.getProperty(name).equals(RAW_START + val + RAW_END);
+                                  } else {
+                                      assert lclProps.getProperty(name).equals(val);
+                                  }
+                              });
+                          }, raws);
+    
+    }
     @Test
     public void testSimpleConfiguration() {
         performConfigTest(name.getMethodName(), XML_ROUTE, "xml",
                           null, null,
-                          (CamelContext runnerContext) -> {
+                          (CamelContext runnerContext, Properties props) -> {
                               TriFunction<CamelContext, String, Object, Boolean> verifyOperation =
                                       defineVerifyOperation();
                               assert verifyOperation.apply(runnerContext, QUERY_MONKEY, RESPONSE_MONKEY);
@@ -127,7 +294,7 @@ public class VantiqConfigurationTest {
     public void testComponentInitConfiguration() {
         performConfigTest(name.getMethodName(), SALESFORCETASKS_YAML, "yaml",
                           getComponentsToInit(), null,
-                          (CamelContext runnerContext) -> {
+                          (CamelContext runnerContext, Properties props) -> {
                               TriFunction<CamelContext, String, Object, Boolean> verifyOperation =
                                       defineVerifyOperation();
                             assert verifyOperation.apply(runnerContext, "not used", Map.of("done", true));
@@ -143,7 +310,7 @@ public class VantiqConfigurationTest {
         props.putAll(pValues);
         performConfigTest(name.getMethodName(), PARAMETERIZED_SALESFORCE_ROUTE, "yaml",
                           getComponentsToInit(), props,
-                          (CamelContext runnerContext) -> {
+                          (CamelContext runnerContext, Properties pros) -> {
                               TriFunction<CamelContext, String, Object, Boolean> verifyOperation =
                                       defineVerifyOperation();
                               assert verifyOperation.apply(runnerContext, "not used", Map.of("done", true));


### PR DESCRIPTION
Adds config parameter which is a set of named lists for property names whose values should be wrapped with RAW() (or RAW{}).  This allows users configuring things to skip this step of the Camel connector is so configured.

Fixes #409