### PR TITLE
Camel Component: time and byte handling

### DIFF
--- a/camelComponent/build.gradle
+++ b/camelComponent/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation "org.projectlombok:lombok:${lombokVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
     implementation "com.google.code.gson:gson:${gsonVersion}"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:{jacksonVersion}"
 
     testImplementation "org.apache.logging.log4j:log4j-slf4j-impl:${log4JVersion}"
     testImplementation "org.apache.camel:camel-test:${camelVersion}"

--- a/camelComponent/src/test/java/io/vantiq/extsrc/camel/VantiqComponentTest.java
+++ b/camelComponent/src/test/java/io/vantiq/extsrc/camel/VantiqComponentTest.java
@@ -28,6 +28,7 @@ import io.vantiq.extjsdk.Response;
 import io.vantiq.extjsdk.TestListener;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -181,6 +182,14 @@ public class VantiqComponentTest extends CamelTestSupport {
         sendBody(routeStartUri, testBytes);
         lastMsg = fc.getLastMessageAsMap();
         validateExtensionMsg(lastMsg, false, null, new String[] { "stringVal"}, testMsg);
+    
+        Instant rightNow = Instant.now();
+        Map timeMsg = Map.of("time", rightNow);
+        sendBody(routeStartUri, timeMsg);
+    
+        //noinspection rawtypes
+        lastMsg = fc.getLastMessageAsMap();
+        validateExtensionMsg(lastMsg, false, null, new String[] {"time"}, rightNow.toString());
     }
     
     @Test

--- a/camelComponent/src/test/java/io/vantiq/extsrc/camel/VantiqComponentTest.java
+++ b/camelComponent/src/test/java/io/vantiq/extsrc/camel/VantiqComponentTest.java
@@ -26,6 +26,8 @@ import io.vantiq.extjsdk.FalseClient;
 import io.vantiq.extjsdk.FalseWebSocket;
 import io.vantiq.extjsdk.Response;
 import io.vantiq.extjsdk.TestListener;
+
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -173,6 +175,12 @@ public class VantiqComponentTest extends CamelTestSupport {
         //noinspection rawtypes
         Map lastMsg = fc.getLastMessageAsMap();
         validateExtensionMsg(lastMsg, false, null, new String[] {"bye"}, "mom");
+        
+        String testMsg = "I am a test message";
+        byte[] testBytes = testMsg.getBytes(StandardCharsets.UTF_8);
+        sendBody(routeStartUri, testBytes);
+        lastMsg = fc.getLastMessageAsMap();
+        validateExtensionMsg(lastMsg, false, null, new String[] { "stringVal"}, testMsg);
     }
     
     @Test
@@ -278,7 +286,7 @@ public class VantiqComponentTest extends CamelTestSupport {
         }
         for (String key: msgKeys) {
             assert msg.containsKey(key);
-            assert ((String) msg.get(key)).contains(msgPreamble);
+            assert msgPreamble == null || ((String) msg.get(key)).contains(msgPreamble);
         }
     }
     


### PR DESCRIPTION
Corrects issue noticed while testing against aws s3.

When byte stream is given to the component, it fails -- not knowing what to do.  It's been enhanced to check the byte stream -- if it's convertible to a map, we'll do that.  If it's a valid String, we'll convert to that, other wise we leave it as byte array.  In the cases of a byte array or String, we send back a message that's a Map with one key -- byteVal or stringVal.

Over time, we're likely to try, in some circumstances, to make note of what's going on & upload a document or whatever.  However, the component itself doesn't really have that knowledge, so that'll be a longer-term plan.

Also -- dates, instants, and their ilk are not currently passed up very well.   So, we now convert any of these to their equivalent strings.

Added associated tests.