### PR TITLE
Fix CamelComponent issue with structured messages via Google PubSub (at least)

### DIFF
--- a/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqProducer.java
+++ b/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqProducer.java
@@ -133,8 +133,13 @@ public class VantiqProducer extends DefaultProducer {
             Map<String, Object> fmtMsg = new HashMap<>();
             // the headers are usually implemented as a CaseInsensitiveMap, so we'll have Java walk the list.
             // We walk the list so that we get the original case to send on...
-            Map<String, Object> hdrs =
-                    mapper.convertValue(exchange.getMessage().getHeaders(), new TypeReference<>() {});
+            // Note that we cannot use the Jackson objectMapper here because headers sometimes use Java types it
+            // doesn't understand (e.g., things from google come with Protobuf timestamps or soemthing like that.
+            // Simple .toString() handles it, so we'll copy the map ourselves.
+            Map<String, Object> hdrs = new HashMap<>();
+            exchange.getMessage().getHeaders().forEach( (k, v) -> {
+                hdrs.put(k, v.toString());
+            });
             fmtMsg.put(STRUCTURED_MESSAGE_HEADERS_PROPERTY, hdrs);
             Map<String, Object> m = mapper.convertValue(vMsg, new TypeReference<>() {});
             fmtMsg.put(STRUCTURED_MESSAGE_MESSAGE_PROPERTY, m);

--- a/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqProducer.java
+++ b/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqProducer.java
@@ -138,7 +138,11 @@ public class VantiqProducer extends DefaultProducer {
             // Simple .toString() handles it, so we'll copy the map ourselves.
             Map<String, Object> hdrs = new HashMap<>();
             exchange.getMessage().getHeaders().forEach( (k, v) -> {
-                hdrs.put(k, v.toString());
+                if (v instanceof Integer || v instanceof Map) {
+                    hdrs.put(k, v);
+                } else {
+                    hdrs.put(k, v.toString());
+                }
             });
             fmtMsg.put(STRUCTURED_MESSAGE_HEADERS_PROPERTY, hdrs);
             Map<String, Object> m = mapper.convertValue(vMsg, new TypeReference<>() {});

--- a/camelComponent/src/test/java/io/vantiq/extsrc/camel/VantiqComponentTest.java
+++ b/camelComponent/src/test/java/io/vantiq/extsrc/camel/VantiqComponentTest.java
@@ -285,6 +285,11 @@ public class VantiqComponentTest extends CamelTestSupport {
                 assert expHdrs.size() == hdrs.size();
                 expHdrs.forEach( (key, value) -> {
                     assert hdrs.containsKey(key);
+                    assert hdrs.get(key) != null;
+                    assert expHdrs.get(key) != null;
+                    log.debug("For key {}, comparing value {} ){} with expected {} ({}).",
+                              key, hdrs.get(key), hdrs.get(key).getClass().getName(),
+                              expHdrs.get(key), expHdrs.get(key).getClass().getName());
                     assert hdrs.get(key).equals(expHdrs.get(key));
                 });
             }


### PR DESCRIPTION
Fixes #416

When dealing with (at least) message from google pubsub, the header values are not understood by the Jackson object mapper.  Instead, we'll revert to simply traversing the case insensitive structure given, converting it into a regular hashmap before sending it back to vantiq.  This is only an issue when asking for structured messages.