### PR TITLE
Improve deserialization in Vantiq component producer

### DIFF
--- a/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqConsumer.java
+++ b/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqConsumer.java
@@ -98,7 +98,7 @@ public class VantiqConsumer extends DefaultConsumer {
             Map<String, Object> camelHdrs = null;
             Object camelBody = null;
             if (endpoint.isStructuredMessageHeader() && msgBody instanceof Map) {
-                camelHdrs = new HashMap<>();
+                camelHdrs = null;
                 Map<?,?> msgAsMap = (Map<?,?>) msgBody;
                 if (msgAsMap.get(STRUCTURED_MESSAGE_HEADERS_PROPERTY) instanceof Map) {
                     Map<?,?> hdrMap = (Map<?,?>) msgAsMap.get(VantiqEndpoint.STRUCTURED_MESSAGE_HEADERS_PROPERTY);

--- a/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqProducer.java
+++ b/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqProducer.java
@@ -61,8 +61,6 @@ public class VantiqProducer extends DefaultProducer {
         }
         
         Object msg = exchange.getIn().getBody();
-        Map<String, Object> msgHdrs = exchange.getIn().getHeaders();
-        Object attsRaw = msgHdrs.get("CamelGooglePubSubAttributes");
         Map<String, Object> vMsg;
         if (!(msg instanceof StreamCache)) {
             vMsg = exchange.getIn().getBody(HashMap.class);


### PR DESCRIPTION
(No issue reported)

Adds handling for getting byte arrays that really represent other things.  GooglePubSub seems to like to just pass things around as byte arrays. When we get a byte array, rather than only returning it as a byte array (since Vantiq, generally, can't do much with those), try a few ways to deserialize it. In the future, we may be able to use hints from media type (to figure out that, _e.g._, it's an image and do something other than sending a connector _notify),_ but for now (and when there's little/no information in the media type), try using Jackson to convert things, or, in the worst case, Java basic deserialization.

These extensions allow us to send & interpret message from Google Pubsub as a Vantiq system would send them (and in a manner that a Vantiq system can deal with them).