### PR TITLE
Handle null-valued Camel headers

### DIFF
--- a/camelComponent/README.md
+++ b/camelComponent/README.md
@@ -90,7 +90,7 @@ arrive as Vail objects, where the property names correspond to the Map keys.
 
 ### Structured Headers and Messages
 
-By adding the `structuredMessageHeader` component endpoint option with a value of `true` (see below), you can set or access the Camel message headers.  When this option is set to `true`, messages sent to or received from the Camel Component will have two properties: `headers` and `message`, both containing Vail objects. The `message` property will contain a Vail object where each property corresponds to same-named property in the underlying message.  The `headers` property will contain a Vail object where each property contains the value of the named message header.
+By adding the `structuredMessageHeader` component endpoint option with a value of `true` (see below), you can set or access the Camel message headers.  When this option is set to `true`, messages sent to or received from the Camel Component will have two properties: `headers` and `message`, both containing Vail objects. The `message` property will contain a Vail object where each property corresponds to same-named property in the underlying message.  The `headers` property will contain a Vail object where each property contains the value of the named message header. If no headers are present in the underlying Camel message, no `headers` property will be present.
 
 A schema type definition for this message structure is available in `src/main/resources/types/com/vantiq/extsrc/camelcomp/message.json`.
 

--- a/camelComponent/src/test/java/io/vantiq/extsrc/camel/VantiqComponentTest.java
+++ b/camelComponent/src/test/java/io/vantiq/extsrc/camel/VantiqComponentTest.java
@@ -286,7 +286,7 @@ public class VantiqComponentTest extends CamelTestSupport {
                 assert hdrs != null;
                 expHdrs.forEach( (key, value) -> {
                     assert hdrs.containsKey(key);
-                    log.debug("For key {}, comparing value {} ){} with expected {} ({}).",
+                    log.debug("For key {}, comparing value {} ({}) with expected {} ({}).",
                               key, hdrs.get(key),
                               hdrs.get(key) != null ? hdrs.get(key).getClass().getName() : hdrs.get(key),
                               expHdrs.get(key),


### PR DESCRIPTION
No issue reported

Some components sent headers with null values.  Handle these cases & improve the streamline the handling of cases where no headers are present.  Clarify this handling in the README