### PR TITLE
Add option for Vantiq notes for generated assemblies

### DIFF
--- a/buildSrc/src/main/groovy/io/vantiq/extsrc/assy/tasks/AssemblyResourceGeneration.groovy
+++ b/buildSrc/src/main/groovy/io/vantiq/extsrc/assy/tasks/AssemblyResourceGeneration.groovy
@@ -755,7 +755,7 @@ class AssemblyResourceGeneration extends DefaultTask {
         File notesFile = project.file(RESOURCE_BASE_DIRECTORY + File.separator + VANTIQ_NOTES_DIRECTORY
             + File.separator + kamName + '.md')
         if (!notesFile || !notesFile.exists()) {
-            log.trace('No Vaatiq Notes document found for {}', notesFile.absolutePath)
+            log.trace('No Vantiq Notes document found for {}', notesFile.absolutePath)
             return null
         }
         log.debug('Found VantiqNotes doc for assembly {}: {}', kamName, notesFile.getAbsolutePath())

--- a/camelAssemblies/src/main/resources/vantiqNotes/azure_servicebus_sink.md
+++ b/camelAssemblies/src/main/resources/vantiqNotes/azure_servicebus_sink.md
@@ -34,7 +34,7 @@ ignored.  For example, if you send a message such as the following:
 }
 ```
 
-the message send across the Azure Service Bus will contain the `headers` as specfied, but the message body will be 
+the message send across the Azure Service Bus will contain the `headers` as specified, but the message body will be 
 the string _I am a property value_. The property name `someProp` will not be present.
 
 If you were to send the same message, but it had two properties:

--- a/camelAssemblies/src/main/resources/vantiqNotes/azure_servicebus_sink.md
+++ b/camelAssemblies/src/main/resources/vantiqNotes/azure_servicebus_sink.md
@@ -51,7 +51,7 @@ If you were to send the same message, but it had two properties:
 }
 ```
 
-two (2) messages would be placed sent across the Azure Service Bus:  both would have the `headers` as specfied, one 
+two (2) messages would be placed sent across the Azure Service Bus:  both would have the `headers` as specified, one 
 with the message value _I am a property value_, and the second with the message value _A different property value_.
 
 # Legal

--- a/camelAssemblies/src/main/resources/vantiqNotes/azure_servicebus_sink.md
+++ b/camelAssemblies/src/main/resources/vantiqNotes/azure_servicebus_sink.md
@@ -1,0 +1,65 @@
+## Message Paradigms
+
+The Azure Service Bus operates using messages consisting of headers (standard Apache Camel operations) and String
+content. This String content can take the form of a single String or a list of Strings.  In the latter case,
+each String in the list is sent as a separate Service Bus message.
+
+Moreover, of the Service Bus sees a messages that is not a String, it will try and interpret it as a list of Strings,
+each of which is sent as a separate Service Bus message.
+
+The Vantiq system, and specifically these assemblies, exchanges messages with the underlying source using Vail Objects.
+
+## Sending Messages
+
+The combination of these two operational paradigms results in the following interpretation.
+
+The Vantiq system will send a Vail Object (specifically, an object with`headers` and `message` property). The 
+`headers` property is placed into the Camel Exchange headers, and the `message` property is placed into the Camel 
+Exchange body.
+
+Once the Azure Service Bus receives the message, it will look at the message body.  Generally, it will see a Vail 
+Object (which appears as a JSON Object), and, since that's not a String, it will interpret it as a list of Strings.
+
+The result of this is that each property in the `message` is sent as a separate String, and the property name is
+ignored.  For example, if you send a message such as the following:
+
+```js
+{
+    headers: {
+        myHeader: "my header value"
+    },
+    message: {
+        someProp: "I am a property value"
+    }
+}
+```
+
+the message send across the Azure Service Bus will contain the `headers` as specfied, but the message body will be 
+the string _I am a property value_. The property name `someProp` will not be present.
+
+If you were to send the same message, but it had two properties:
+
+```js
+{
+    headers: {
+        myHeader: "my header value"
+    },
+    message: {
+        someProp: "I am a property value",
+        someOtherProp: "A different property value"
+    }
+}
+```
+
+two (2) messages would be placed sent across the Azure Service Bus:  both would have the `headers` as specfied, one 
+with the message value _I am a property value_, and the second with the message value _A different property value_.
+
+# Legal
+
+Apache Camel, Camel, and Apache are trademarks of The Apache Software Foundation.
+
+Azure Service Bus is a trademark of Microsoft Corporation.
+
+Vantiq is a trademark of Vantiq, Inc.
+
+All other trademarks mentioned are trademarks or registered trademarks of their respective owners.

--- a/camelAssemblies/src/main/resources/vantiqNotes/azure_servicebus_source.md
+++ b/camelAssemblies/src/main/resources/vantiqNotes/azure_servicebus_source.md
@@ -24,7 +24,7 @@ value delivered in the Camel Exchange message body.
 
 
 The result of this is that each property in the `message` is sent as a separate String, and the property name is
-ignored.  For example, if a Camel Exchange containing the header `myHeader: "my header value" and the body `I am a 
+ignored.  For example, if a Camel Exchange containing the header `myHeader: "my header value"` and the body `I am a 
 property value` is received, the resulting Vantiq message will be the following:
 
 ```js

--- a/camelAssemblies/src/main/resources/vantiqNotes/azure_servicebus_source.md
+++ b/camelAssemblies/src/main/resources/vantiqNotes/azure_servicebus_source.md
@@ -1,0 +1,49 @@
+## Message Paradigms
+
+The Azure Service Bus operates using messages consisting of headers (standard Apache Camel operations) and String
+content. This String content can take the form of a single String or a list of Strings.  In the latter case,
+each String in the list is sent as a separate service bus message.
+
+Moreover, of the service bus sees a messages that is not a String, it will try and interpret it as a list of Strings,
+each of which is sent as a separate service bus message.
+
+The Vantiq system, and specifically these assemblies, exchanges messages with the underlying source using Vail Objects.
+
+## Receiving Messages
+
+The combination of these two operational paradigms results in the following interpretation.
+
+When a message is delivered to the Vantiq Camel Component, that message, in the form of a Camel Exchange, contains 
+headers and the message body. The message body will contain only a String.
+
+The Vantiq system will send a Vail Object (specifically, an object with`headers` and `message` property. The 
+`headers` property will contain the headers specified by the Camel Exchange headers, and the `message` property will 
+contain the message body (a String).  Since the Vail Object is a set of properties and their values, the property 
+name used here will be `stringVal` (no property name is otherwise delivered), and that property value will be the 
+value delivered in the Camel Exchange message body.
+
+
+The result of this is that each property in the `message` is sent as a separate String, and the property name is
+ignored.  For example, if a Camel Exchange containing the header `myHeader: "my header value" and the body `I am a 
+property value` is received, the resulting Vantiq message will be the following:
+
+```js
+{
+    headers: {
+        myHeader: "my header value"
+    },
+    message: {
+        stringVal: "I am a property value"
+    }
+}
+```
+
+# Legal
+
+Apache Camel, Camel, and Apache are trademarks of The Apache Software Foundation.
+
+Azure Service Bus is a trademark of Microsoft Corporation.
+
+Vantiq is a trademark of Vantiq, Inc.
+
+All other trademarks mentioned are trademarks or registered trademarks of their respective owners.


### PR DESCRIPTION
No issue reported -- merge into staging branch...

Add ability to add (manually generated) Vantiq Notes to generated assemblies.  Based on the assembly name, we had a src/main/resources/vantiqNotes directory.  The assembly generation, while generating, queries this directory looking for files named with the assembly name.  If found, it added an appropriate title and includes that in the assembly.

Also, add first two (2) notes describing how messages to/from Vantiq to the Azure Service Bus are sent/received.  The service bus sends String messages, so everything it gets is either a String OR it will attempt to interpret as a List<String>.  This leads to a bit of confusion (since we send object only, they deal with Strings only), so we describe how the impedance mismatch is manifest.

Not sure there's much other option that this point...