### PR TITLE
Add configuration & associated tests for duplication of headers

### DIFF
--- a/camelComponent/build.gradle
+++ b/camelComponent/build.gradle
@@ -21,6 +21,10 @@ ext {
     commonsLang3Version = '3.12.0'
 }
 
+configurations {
+    testArtifacts
+}
+
 dependencies {
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
@@ -60,5 +64,15 @@ tasks.withType(Test) {
     }
     // Use the build dir as a base to get our various test artifacts.
     systemProperty "buildDir", "${buildDir}"
+}
+
+
+task testJar (type: Jar) {
+    baseName = "${project.name}-test"
+    from sourceSets.test.output
+}
+
+artifacts {
+    testArtifacts testJar
 }
 

--- a/camelConnector/build.gradle
+++ b/camelConnector/build.gradle
@@ -72,6 +72,7 @@ dependencies {
     implementation "org.apache.camel:camel-yaml-dsl:${camelVersion}"
     // End of DSL-specific inclusions.
 
+    testImplementation project(path: ":camelComponent", configuration: "testArtifacts")
     testImplementation "org.apache.logging.log4j:log4j-slf4j-impl:${log4JVersion}"
     testImplementation "org.apache.camel:camel-test:${camelVersion}"
     testImplementation "io.vantiq:vantiq-sdk:${vantiqSDKVersion}"

--- a/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/connector/CamelHandleConfiguration.java
+++ b/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/connector/CamelHandleConfiguration.java
@@ -395,7 +395,7 @@ public class CamelHandleConfiguration extends Handler<ExtensionServiceMessage> {
             // The connector (or this method, when things are reconfigured -- see a few lines up) will handle closing
             // things as appropriate.
             CamelRunner runner =
-                         new CamelRunner(appName, Objects.requireNonNull(routeSpec).get(ROUTES_LIST),
+                    createCamelRunner(appName, Objects.requireNonNull(routeSpec).get(ROUTES_LIST),
                                          routeSpec.get(ROUTES_FORMAT), repoList,
                                          componentCache, componentLib, componentProperties, propVals,
                                          headerBeanName, headerDuplications);
@@ -413,6 +413,31 @@ public class CamelHandleConfiguration extends Handler<ExtensionServiceMessage> {
         return true;
     }
     
+    /**
+     * Create a CamelRunner instance
+     *
+     * @param appName String Name for this instance
+     * @param routeSpecification String specification for the route(s) to run.  Syntax must match
+     *         routeSpecificationType
+     * @param routeSpecificationType String the type of specification provided
+     * @param repos List<URI> The list of repos to search for libraries needed by the route(s)
+     * @param cacheDirectory String Directory path to use to cache downloaded libraries
+     * @param loadedLibDir String Directory path into which to put the libraries needed at run time.
+     * @param initComponents List<Map<String, Object>> List of component names that need initialization using
+     *         the properties included herein
+     * @param camelProperties Properties set of general property values that Camel can use for property
+     *         resolution
+     * @param headerBeanName String Name of bean to use generate.  Should match what's in route & be unique to this
+     *         camel instance
+     * @param headerDuplications Map<String, String> directed set of header names to duplicate
+     */
+    protected CamelRunner createCamelRunner(String appName, String routeSpecification, String routeSpecificationType,
+                               List<URI> repos,
+                       String cacheDirectory, String loadedLibDir, List<Map<String, Object>> initComponents,
+                       Properties camelProperties, String headerBeanName, Map<String, String> headerDuplications) {
+        return new CamelRunner(appName, routeSpecification, routeSpecificationType, repos, cacheDirectory,
+                                loadedLibDir, initComponents, camelProperties, headerBeanName, headerDuplications);
+    }
     private Map<String, String> fetchDocument(String docName) {
         String token = source.authToken;
         String url = source.targetVantiqServer;

--- a/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelResolver.java
+++ b/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelResolver.java
@@ -58,7 +58,7 @@ public class CamelResolver {
      * Create resolver for necessary artifacts
      *
      * @param name String name of resolver.  Primarily for logging & debugging
-     * @param repos URI repos from which to fetch.  If null, use maven central
+     * @param repo URI repos from which to fetch.  If null, use maven central
      * @param cache File Specification of directory for ivy's cache.  If null, take Ivy's defaults.
      * @param destination File Specification of directory to which to copy files
      * @throws IllegalArgumentException for invalid parameters
@@ -102,7 +102,6 @@ public class CamelResolver {
                     String repoUrl = repo.toURL().toExternalForm();
                     aResolver.setRoot(repoUrl);
                     aResolver.setName(name + "::" + repoUrl);
-    
                 } catch (MalformedURLException mue) {
                     throw new IllegalArgumentException("Malformed repos URL: " + repo.toString(), mue);
                 }

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/HandleConfigurationWithOverrides.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/HandleConfigurationWithOverrides.java
@@ -1,0 +1,2 @@
+package io.vantiq.extsrc.camelconn.connector;public class TestHandleConfiguration {
+}

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/HandleConfigurationWithOverrides.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/HandleConfigurationWithOverrides.java
@@ -1,2 +1,50 @@
-package io.vantiq.extsrc.camelconn.connector;public class TestHandleConfiguration {
+/*
+ * Copyright (c) 2023 Vantiq, Inc.
+ *
+ * All rights reserved.
+ *
+ * SPDX: MIT
+ */
+
+package io.vantiq.extsrc.camelconn.connector;
+
+import io.vantiq.extsrc.camelconn.discover.CamelRunner;
+import io.vantiq.extsrc.camelconn.discover.CamelRunnerWithComponentSubs;
+import org.apache.camel.Component;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Test version of CamelHandleConfiguration.
+ * </p>
+ * This provides a type-safe, test only, mechanism to allow component type overrides for testing.  We do this to
+ * handle, amongst other things, Vantiq-server-less implementation of the Vantiq Camel Component for use in unit tests.
+ */
+public class HandleConfigurationWithOverrides extends CamelHandleConfiguration {
+    
+    Map<String, Component> overrides = null;
+    
+    public HandleConfigurationWithOverrides(CamelCore source) {
+        super(source);
+    }
+    
+    public HandleConfigurationWithOverrides(CamelCore source, Map<String, Component> overrides) {
+        super(source);
+        this.overrides = overrides;
+    }
+    
+    @Override
+    protected CamelRunner createCamelRunner(String appName, String routeSpecification, String routeSpecificationType,
+                                            List<URI> repos, String cacheDirectory, String loadedLibDir,
+                                            List<Map<String, Object>> initComponents, Properties camelProperties,
+                                            String headerBeanName, Map<String, String> headerDuplications) {
+        CamelRunnerWithComponentSubs cr =
+                new CamelRunnerWithComponentSubs(appName, routeSpecification, routeSpecificationType,
+                                                 repos, cacheDirectory, loadedLibDir, initComponents, camelProperties,
+                                                 headerBeanName, headerDuplications, overrides);
+        return cr;
+    }
 }

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/VantiqConfigurationTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/VantiqConfigurationTest.java
@@ -81,8 +81,6 @@ public class VantiqConfigurationTest extends CamelTestSupport {
     private final String CACHE_DIR = CAMEL_BASE_PATH + "cacheDir";
     private final String LOADED_LIBRARIES = CAMEL_BASE_PATH + "loadedLib";
     
-    String testBeanName = null;
-    
     // Interface to use in declaration.  We'll pass lambda's in to do the actual verification work
     interface Verifier {
         void doVerify(CamelContext runnerContext);

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/VantiqConfigurationTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/VantiqConfigurationTest.java
@@ -1,5 +1,7 @@
 package io.vantiq.extsrc.camelconn.connector;
 
+import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.HEADER_BEAN_NAME;
+import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.HEADER_DUPLICATION;
 import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.NO_RAW_REQUEST;
 import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.RAW_END;
 import static io.vantiq.extsrc.camelconn.connector.CamelHandleConfiguration.RAW_END_ALT;
@@ -49,8 +51,6 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 public class VantiqConfigurationTest {
-    
-    
     @Rule
     public TestName name = new TestName();
     
@@ -67,11 +67,11 @@ public class VantiqConfigurationTest {
     
     void performConfigTest(String appName, String route, String routeFormat,
                            List<Map<String, Object>> compInitProps, Properties propertyValues, Verifier vfy) {
-        performConfigTest(appName, route, routeFormat, compInitProps, propertyValues, vfy, null);
+        performConfigTest(appName, route, routeFormat, compInitProps, propertyValues, vfy, null, null, null);
     }
     void performConfigTest(String appName, String route, String routeFormat,
                            List<Map<String, Object>> compInitProps, Properties propertyValues, Verifier vfy,
-                           List<String> rawReq) {
+                           List<String> rawReq, String headerBeanName, Map<String, String> headerDuplications) {
         Map<String, Object> simpleConfig = new HashMap<>();
         Map<String, Object> camelConfig = new HashMap<>();
         simpleConfig.put(CAMEL_CONFIG, camelConfig);
@@ -97,6 +97,11 @@ public class VantiqConfigurationTest {
             
             rawReqMap.put(DISCOVERED_RAW, rawReq);
             camelAppConfig.put(RAW_REQUIRED, rawReqMap);
+        }
+        
+        if (headerBeanName != null) {
+            camelAppConfig.put(HEADER_BEAN_NAME, headerBeanName);
+            camelAppConfig.put(HEADER_DUPLICATION, headerDuplications);
         }
 
         String fauxVantiqUrl = "http://someVantiqServer";
@@ -194,7 +199,7 @@ public class VantiqConfigurationTest {
                                       assert s.equals(RAW_START + val + RAW_END);
                                   }
                               });
-                          }, raws);
+                          }, raws, null, null);
     }
     
     @Test
@@ -223,7 +228,7 @@ public class VantiqConfigurationTest {
                                       assert s.equals(val);
                                   }
                               });
-                         }, raws);
+                         }, raws, null, null);
     }
     
     @Test
@@ -253,7 +258,7 @@ public class VantiqConfigurationTest {
                                       assert s.equals(val);
                                   }
                               });
-                          }, raws);
+                          }, raws, null, null);
     }
     @Test
     public void testRawSuppressed() {
@@ -282,7 +287,7 @@ public class VantiqConfigurationTest {
                                       assert s.equals(val);
                                   }
                               });
-                          }, raws);
+                          }, raws, null, null);
     }
     
     @Test
@@ -310,7 +315,7 @@ public class VantiqConfigurationTest {
                                       assert s.equals(val);
                                   }
                               });
-                          }, raws);
+                          }, raws, null, null);
     
     }
     @Test

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/CamelRunnerWithComponentSubs.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/CamelRunnerWithComponentSubs.java
@@ -1,0 +1,2 @@
+package io.vantiq.extsrc.camelconn;public class CamelRunnerWithComponentSubs {
+}

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/CamelRunnerWithComponentSubs.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/CamelRunnerWithComponentSubs.java
@@ -1,2 +1,67 @@
-package io.vantiq.extsrc.camelconn;public class CamelRunnerWithComponentSubs {
+/*
+ * Copyright (c) 2023 Vantiq, Inc.
+ *
+ * All rights reserved.
+ *
+ * SPDX: MIT
+ */
+
+package io.vantiq.extsrc.camelconn.discover;
+
+import org.apache.camel.Component;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Test version of CamelRunner.
+ * </p>
+ * This provides a type-safe, test only, mechanism to allow component type overrides for testing.  We do this to
+ * handle, amongst other things, Vantiq-server-less implementation of the Vantiq Camel Component for use in unit tests.
+ */
+public class CamelRunnerWithComponentSubs extends CamelRunner {
+    /**
+     * Create a CamelRunner instance
+     *
+     * @param appName String Name for this instance
+     * @param routeSpecification String specification for the route(s) to run.  Syntax must match
+     *         routeSpecificationType
+     * @param routeSpecificationType String the type of specification provided
+     * @param repos List<URI> The list of repos to search for libraries needed by the route(s)
+     * @param cacheDirectory String Directory path to use to cache downloaded libraries
+     * @param loadedLibDir String Directory path into which to put the libraries needed at run time.
+     * @param initComponents List<Map<String, Object>> List of component names that need initialization using the
+     *         properties included herein
+     * @param camelProperties Properties set of general property values that Camel can use for property resolution
+     * @param headerBeanName String Name of bean to use generate.  Should match what's in route & be unique to this
+     *         camel instance
+     * @param headerDuplications Map<String, String> directed set of header names to duplicate
+     */
+    public CamelRunnerWithComponentSubs(String appName, String routeSpecification, String routeSpecificationType,
+                                        List<URI> repos, String cacheDirectory, String loadedLibDir,
+                                        List<Map<String, Object>> initComponents,
+                                        Properties camelProperties,
+                                        String headerBeanName, Map<String, String> headerDuplications) {
+        
+        super(appName, routeSpecification, routeSpecificationType, repos, cacheDirectory, loadedLibDir, initComponents,
+              camelProperties, headerBeanName, headerDuplications);
+    }
+    
+    public CamelRunnerWithComponentSubs(String appName, String routeSpecification, String routeSpecificationType,
+                                        List<URI> repos, String cacheDirectory, String loadedLibDir,
+                                        List<Map<String, Object>> initComponents,
+                                        Properties camelProperties,
+                                        String headerBeanName, Map<String, String> headerDuplications,
+                                        Map<String, Component> componentOverrides) {
+        super(appName, routeSpecification, routeSpecificationType, repos, cacheDirectory, loadedLibDir, initComponents,
+              camelProperties, headerBeanName, headerDuplications);
+        this.setComponentOverrides(componentOverrides);
+    }
+    
+    public void overrideComponents(Map<String, Component> compOverrides) {
+        this.setComponentOverrides(compOverrides);
+    }
+    
 }

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/CamelRunnerWithComponentSubs.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/CamelRunnerWithComponentSubs.java
@@ -59,9 +59,4 @@ public class CamelRunnerWithComponentSubs extends CamelRunner {
               camelProperties, headerBeanName, headerDuplications);
         this.setComponentOverrides(componentOverrides);
     }
-    
-    public void overrideComponents(Map<String, Component> compOverrides) {
-        this.setComponentOverrides(compOverrides);
-    }
-    
 }

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentResolverTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentResolverTest.java
@@ -56,7 +56,6 @@ import java.util.stream.Collectors;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class VantiqComponentResolverTest extends CamelTestSupport {
     public final static String MISSING_VALUE = "<missing>";
-    
     @Rule
     public TestName testName = new TestName();
     
@@ -171,10 +170,8 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
         assertTrue("Identity check:", cr.identity().contains(dest.getAbsolutePath()));
     
         try {
-            cr.resolve("org.apache.camel",
-                                                         "camel" + "-horse-designed-by-committee",
-                                                         context.getVersion(),
-                                                         testName.getMethodName());
+            cr.resolve("org.apache.camel", "camel" + "-horse-designed-by-committee",
+                       context.getVersion(), testName.getMethodName());
         } catch (ResolutionException re) {
             assert re.getMessage().contains("Error(s) encountered during resolution: ");
             assert re.getMessage().contains("org.apache.camel#camel-horse-designed-by-committee;");
@@ -201,8 +198,7 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
         }
     
         try {
-            cr.resolve("somegroup", null,
-                             "someVersion", testName.getMethodName());
+            cr.resolve("somegroup", null, "someVersion", testName.getMethodName());
             fail("Null name should not work");
         } catch (IllegalArgumentException iae) {
             assert iae.getMessage().contains("The parameters organization, name, and revision must be non-null");
@@ -235,7 +231,7 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
         URI s3Repo = new URI("https://vantiqmaven.s3.amazonaws.com/");
         CamelResolver cr = new CamelResolver(this.getTestMethodName(), s3Repo, cache, dest);
         Collection<File> resolved = cr.resolve("vantiq.models", "coco", "1.1", "meta",
-                                                       testName.getMethodName());
+                                               testName.getMethodName());
         assertEquals("Resolved file count: " + resolved.size(), 1, resolved.size());
         File[] files = resolved.toArray(new File[0]);
         assertEquals("File name match", "coco-1.1.meta", files[0].getName());
@@ -364,7 +360,7 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
             VantiqEndpoint ve = (VantiqEndpoint) ves.get(0);
             assert Objects.equals(ve.getHeaderDuplicationBeanName(), headerBeanName);
             // Component tests verify that the map makes it thru, assuming the bean was created correctly.  Since we
-            // aren't guaranteed to have enough context here to make the real connection, this is far as we can
+            // aren't guaranteed to have enough context here to make the real connection, this is as far as we can
             // effectively test.
         } catch (Exception e) {
             fail("Trapped exception during test: " + e.getMessage() +

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentResolverTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentResolverTest.java
@@ -142,7 +142,12 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
     @Test
     public void testResolutionSimpleCamelCached() throws Exception {
         // Here, we leave the cache alone
-        CamelResolver cr = new CamelResolver(this.getTestMethodName(), (URI) null,
+        
+        // Use same app name to avoid spurious Ivy errors about unknown resolvers.  Necessary since we didn't clear
+        // the cache, and Ivy keeps resolver names in the cache records.
+        String nameOfPreviousTest = this.getTestMethodName().substring(0, this.getTestMethodName().lastIndexOf(
+                "Cached"));
+        CamelResolver cr = new CamelResolver(nameOfPreviousTest, (URI) null,
                                              cache, dest);
         Collection<File> resolved = cr.resolve("org.apache.camel", "camel" + "-salesforce",
                                                context.getVersion(), testName.getMethodName());


### PR DESCRIPTION
Fixes #423 

Add configuration & associated tests for duplication of headers.  Duplication of headers useful for copying Camel component specific headers into generic places -- for common things like contentType.

Previous PR added capability to Vantiq Component;  this allows configuration of the connector to set up the component appropriately. 