### PR TITLE
Add test for handling of non-object structured non-UTF8 data

### DIFF
--- a/camelComponent/README.md
+++ b/camelComponent/README.md
@@ -86,7 +86,11 @@ by adding the `consumerOutputJson` component endpoint option (see below) with a 
 When so specified, messages sent to a Vantiq consumer will arrive in a Camel Exchange as a JSON string.
 
 Messages sent to Vantiq from the component will
-arrive as Vail objects, where the property names correspond to the Map keys.
+arrive as Vail objects, where the property names correspond to the Map keys. For cases where the message to be sent
+to Vantiq is not structured as a Vail Object (or Java Map), the component will use the property name `stringVal` for
+data that can be naturally encoded as a string, and `byteVal` for binary data. In the case of
+binary data, the actual data will be a Base64 encoded string.
+The underlying communication is JSON, so binary data must be Base64 encoded.
 
 ### Structured Headers and Messages
 

--- a/camelComponent/src/test/java/io/vantiq/extsrc/camel/VantiqComponentTest.java
+++ b/camelComponent/src/test/java/io/vantiq/extsrc/camel/VantiqComponentTest.java
@@ -30,6 +30,8 @@ import io.vantiq.extjsdk.TestListener;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -190,6 +192,11 @@ public class VantiqComponentTest extends CamelTestSupport {
         //noinspection rawtypes
         lastMsg = fc.getLastMessageAsMap();
         validateExtensionMsg(lastMsg, false, null, new String[] {"time"}, rightNow.toString());
+    
+        testBytes = new byte[] { (byte) 0xf8, (byte) 0xfa, (byte) 0xfb, (byte) 0xff };
+        sendBody(routeStartUri, testBytes);
+        lastMsg = fc.getLastMessageAsMap();
+        validateExtensionMsg(lastMsg, false, null, new String[] { "byteVal"}, testBytes);
     }
     
     @Test
@@ -267,7 +274,7 @@ public class VantiqComponentTest extends CamelTestSupport {
     }
     
     void validateExtensionMsg(Map<?,?> lastMsg, Boolean isStructured, Map<String, Object> expHdrs,
-                              String[] msgKeys, String msgPreamble) {
+                              String[] msgKeys, Object msgPreamble) {
         assert lastMsg.containsKey("op");
         assert "notification".equals(lastMsg.get("op"));
         assert lastMsg.containsKey("sourceName");
@@ -300,7 +307,30 @@ public class VantiqComponentTest extends CamelTestSupport {
         }
         for (String key: msgKeys) {
             assert msg.containsKey(key);
-            assert msgPreamble == null || ((String) msg.get(key)).contains(msgPreamble);
+            if (msgPreamble != null) {
+                if (msgPreamble instanceof String) {
+                    assert ((String) msg.get(key)).contains((String) msgPreamble);
+                } else if (msgPreamble instanceof byte[]) {
+                    Object o = msg.get(key);
+                    assert o != null;
+                    log.debug("{} value is a {}", key, o.getClass().getName());
+                    // Message goes as JSON, so any byte array is Base64 encoded.  Also, it may be quoted (as per
+                    // JSON), so we may have to deal with that.
+                    if (o instanceof String) {
+                        log.debug("{} value is {}", key, o);
+                        String s = (String) o;
+                        if (((String) o).startsWith("\"")) {
+                            s = ((String) o).substring(1, ((String) o).length() - 1);
+                        }
+                        o = Base64.getDecoder().decode(s);
+                        log.debug("{} decoded value is {}", key, s);
+                    }
+                    assert o instanceof byte[];
+                    assert Arrays.equals((byte[]) o, (byte[]) msgPreamble);
+                } else {
+                    fail("msgPreamble was of unexpected type: " + msgPreamble.getClass().getName());
+                }
+            }
         }
     }
     


### PR DESCRIPTION
Fixes #426 

Add test for messages that contain only UTF8 data (not in object form).

Also, noticed that this wasn't documented, so did so.