### PR TITLE
Stream output from consumerOutputJson -- for Kinesis & other support

### DIFF
--- a/camelComponent/README.md
+++ b/camelComponent/README.md
@@ -1,7 +1,8 @@
 # Overview
 
-This document outlines how to incorporate a Vantiq Camel Component Source into your project. The Camel Component source allows a user to construct Apache Camel applications that interoperate with the Vantiq system. The Camel Component uses the Apache Camel
-mechanism to specify the Vantiq connection details.
+This document outlines how to incorporate a Vantiq Camel Component Source into your project. The Camel Component 
+source allows a user to construct Apache Camel applications that interoperate with the Vantiq system. The Camel
+Component uses the Apache Camel mechanism to specify the Vantiq connection details.
 
 The documentation has been split into two parts, [Setting Up Your Machine](#machine)
 and [Setting Up Your Vantiq](#vantiq).
@@ -45,13 +46,16 @@ The Vantiq Camel Connector simplifies the configuration and construction of an A
 See the [Vantiq Camel Connector documentation](../camelConnector/README.md) for information.
 
 ## Logging
-To change the logging settings, edit the logging config file `<install location>/camelComponent/src/main/resources/log4j2.xml`,
-which is an [Apache Log4j configuration file.](https://logging.apache.org/log4j/2.x/manual/configuration.html). The logger 
-name for each class is the class's fully qualified class name, *e.g.* "io.vantiq.extjsdk.ExtensionWebSocketClient".  
+To change the logging settings, edit the logging config file 
+`<install location>/camelComponent/src/main/resources/log4j2.xml`,
+which is an [Apache Log4j configuration file.](https://logging.apache.org/log4j/2.x/manual/configuration.html). The 
+logger name for each class is the class's fully qualified class name, *e.g.* "io.vantiq.extjsdk.
+ExtensionWebSocketClient".  
 
 # Setting Up Vantiq <a name="vantiq" id="vantiq"></a>
 
-An understanding of the Vantiq Extension Source SDK is assumed. Please read the [Extension Source README.md](../README.md) for more information.
+An understanding of the Vantiq Extension Source SDK is assumed. Please read the 
+[Extension Source README.md](../README.md) for more information.
 
 In order to incorporate this Extension Source, you will need to create the Source Implementation in the Vantiq system.
 
@@ -82,7 +86,7 @@ your Source Implementation) as the Source Type. No configuration information is 
 
 Messages that are sent to the component will arrive in a Camel Exchange as a Java Map, where the keys in the map
 correspond to the property names in the object sent from Vantiq. If desired, you change this behavior
-by adding the `consumerOutputJson` component endpoint option (see below) with a value of `true`.
+by adding the `consumerOutputJsonStream` component endpoint option (see below) with a value of `true`.
 When so specified, messages sent to a Vantiq consumer will arrive in a Camel Exchange as a JSON string.
 
 Messages sent to Vantiq from the component will
@@ -94,9 +98,15 @@ The underlying communication is JSON, so binary data must be Base64 encoded.
 
 ### Structured Headers and Messages
 
-By adding the `structuredMessageHeader` component endpoint option with a value of `true` (see below), you can set or access the Camel message headers.  When this option is set to `true`, messages sent to or received from the Camel Component will have two properties: `headers` and `message`, both containing Vail objects. The `message` property will contain a Vail object where each property corresponds to same-named property in the underlying message.  The `headers` property will contain a Vail object where each property contains the value of the named message header. If no headers are present in the underlying Camel message, no `headers` property will be present.
+By adding the `structuredMessageHeader` component endpoint option with a value of `true` (see below), you can set or 
+access the Camel message headers.  When this option is set to `true`, messages sent to or received from the
+Camel Component will have two properties: `headers` and `message`, both containing Vail objects. The `message`
+property will contain a Vail object where each property corresponds to same-named property in the underlying message.
+The `headers` property will contain a Vail object where each property contains the value of the named message header.
+If no headers are present in the underlying Camel message, no `headers` property will be present.
 
-A schema type definition for this message structure is available in `src/main/resources/types/com/vantiq/extsrc/camelcomp/message.json`.
+A schema type definition for this message structure is available in
+`src/main/resources/types/com/vantiq/extsrc/camelcomp/message.json`.
 
 #### Header Duplication
 
@@ -158,7 +168,8 @@ in Json format will be accepted as well.
 The URI for the Vantiq connection takes the following form:
 
 ```
-    vantiq://host[:port]?sourceName=<source name>&accessToken=<access token>[&sendPings=<boolean>][&failedMessageQueueSize=<int>][&consumerOutputJson=<boolean>][&structuredMessageHeader=<boolean>]
+    vantiq://host[:port]?sourceName=<source name>&accessToken=<access token>[&sendPings=<boolean>] \
+    [&failedMessageQueueSize=<int>][&consumerOutputJsonStream=<boolean>][&structuredMessageHeader=<boolean>]
 ```
 
 ### Component Endpoint Options
@@ -170,9 +181,17 @@ The endpoint options apply to producer and consumer endpoints.  The following ar
 * **sourceName** is the name of the Camel component source to which to connect
 * **accessToken** is the access token used for the connection
 * **sendPings** [optional] a boolean value indicating whether to periodically ping the Vantiq server (default is false)
-* **failedMessageQueueSize** [optional] an integer value indicating how many messages to hold for sending when the connection to the Vantiq server fails.
-* **consumerOutputJson** [optional] a boolean value indicating whether messages sent from Vantiq to the Vantiq component (_i.e._, a Vantiq Consumer) should be put into an Apache Camel Exchange as a JSON message.  If false, messages are put into an exchange as a Java Map.
-* **structuredMessageHeader** [optional] a boolean value indicating whether messages sent to and from the Vantiq component (Vantiq Consumers and Producers) should be structured as
+* **failedMessageQueueSize** [optional] an integer value indicating how many messages to hold for sending when the 
+  connection to the Vantiq server fails.
+* **consumerOutputJsonStream** [optional] a boolean value indicating whether messages sent from Vantiq to the Vantiq 
+  component (_i.e._, a Vantiq Consumer) should be put into an Apache Camel Exchange as a JSON message.  If 
+  false, messages are put into an exchange as a Java Map. Note that these Json messages are wrapped in a Camel 
+  _StreamCache_. This matches what adding a _marshal_ step to the route would do, which tends to improve the 
+  interoperability with other Camel components.
+* **consumerOutputJson** [DEPRECATED, optional] same as **componentOutputJsonStream** but does not wrap the output 
+  in a Camel _StreamCache_. Use is strongly discouraged. Instances where this is necessary should be reported.
+* **structuredMessageHeader** [optional] a boolean value indicating whether messages sent to and from the Vantiq 
+  component (Vantiq Consumers and Producers) should be structured as
 
     ```json
     {

--- a/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqConsumer.java
+++ b/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqConsumer.java
@@ -13,7 +13,6 @@ import static io.vantiq.extsrc.camel.VantiqEndpoint.STRUCTURED_MESSAGE_MESSAGE_P
 import static org.apache.camel.ExchangePattern.InOnly;
 import static org.apache.camel.ExchangePattern.InOut;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vantiq.extjsdk.ExtensionServiceMessage;
@@ -30,8 +29,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.Processor;
-import org.apache.camel.converter.stream.InputStreamCache;
-import org.apache.camel.spi.Tracer;
 import org.apache.camel.support.DefaultConsumer;
 import org.apache.camel.support.builder.OutputStreamBuilder;
 
@@ -124,7 +121,7 @@ public class VantiqConsumer extends DefaultConsumer {
                 log.debug("Structured message -- hdrs: {}, message: {}", camelHdrs, camelBody);
             }
             Object output = msgBody;
-            if (endpoint.isConsumerOutputJson()) {
+            if (endpoint.isConsumerOutputJson() || endpoint.isConsumerOutputJsonStream()) {
                 // Convert to JSON output
                 // Things coming from Vantiq will be Strings or a Vail objects/Maps.  This should be
                 // sufficient for those conversions.
@@ -135,10 +132,7 @@ public class VantiqConsumer extends DefaultConsumer {
                     Object resValueDbg = jnode != null ? (jnode.isTextual() ? jnode.asText() : jnode) : null;
                     log.debug("ConsumerOutputJson: msgBody out: {}", resValueDbg);
                 }
-                // FIXME -- we need to see if we need to have this as a separate setup property.
-                //  It's a semantic change, but it's not clear that anyone's using it (or that it really works as
-                //  intended), so converting things to a output stream may very well be better anyway.
-                convertToStream = true;
+                convertToStream =  endpoint.isConsumerOutputJsonStream();
             }
     
             // Create an exchange to move our message along.  In the publish case,

--- a/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqEndpoint.java
+++ b/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqEndpoint.java
@@ -81,10 +81,18 @@ public class VantiqEndpoint extends DefaultEndpoint {
     private boolean noSsl;
     
     public static final String CONSUMER_OUTPUT_JSON_PARAM = "consumerOutputJson";
-    @UriParam(defaultValue = "false")
+    @Deprecated
+    @UriParam(defaultValue = "false") @Metadata(deprecationNote = "Use (replaced by) consumerOutputJsonStream which " +
+            "emulates a marshal step more closely.")
     @Getter
     @Setter
     private boolean consumerOutputJson;
+    
+    public static final String CONSUMER_OUTPUT_JSON_STREAM_PARAM = "consumerOutputJsonStream";
+    @UriParam(defaultValue = "false")
+    @Getter
+    @Setter
+    private boolean consumerOutputJsonStream;
     
     public static final String FAILED_MESSAGE_QUEUE_SIZE_PARAM = "failedMessageQueueSize";
     @UriParam(defaultValue = "25")

--- a/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqProducer.java
+++ b/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqProducer.java
@@ -12,7 +12,6 @@ import static io.vantiq.extsrc.camel.VantiqEndpoint.STRUCTURED_MESSAGE_HEADERS_P
 import static io.vantiq.extsrc.camel.VantiqEndpoint.STRUCTURED_MESSAGE_MESSAGE_PROPERTY;
 
 import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DatabindException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -21,6 +20,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.BinaryNode;
 import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.ContainerNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.vantiq.extjsdk.ExtensionServiceMessage;
@@ -34,13 +34,13 @@ import org.apache.camel.InvalidPayloadException;
 import org.apache.camel.support.DefaultProducer;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.net.HttpURLConnection;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.StandardCharsets;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -69,25 +69,58 @@ public class VantiqProducer extends DefaultProducer {
             log.trace("Type converter count: {}", exchange.getContext().getTypeConverterRegistry().size());
         }
         
-        Object msg = exchange.getIn().getBody();
-        Map<String, Object> vMsg;
-        if (!(msg instanceof StreamCache)) {
-            vMsg = exchange.getIn().getBody(HashMap.class);
-            // Jackson converts to json nodes but not to map.  Have to hunt for that or convert json node.
+        Map<String, Object> vMsg = exchange.getIn().getBody(HashMap.class);
+    
+        if (vMsg == null) {
+            Object msg = exchange.getIn().getBody();
             if (log.isDebugEnabled()) {
                 log.debug("Camel converted body is {}, msg type: {}, msg: {}", vMsg, msg.getClass().getName(), msg);
             }
-     
-            if (vMsg == null) {
-                // Then Camel couldn't convert on its own.  Let's see if we can help things along...
-                if (msg instanceof String) {
-                    // Then we must be fetching a JSON string.
-                    String strMsg = (String) msg;
-                    vMsg = mapper.readValue(strMsg, new TypeReference<>() {});
-                } else if (msg instanceof byte[]) {
-                    // See if we can get Jackson to do the deserialization for us.
-                    byte[] ba = (byte[]) msg;
     
+            // If we have a stream, extract the bytes before attempting to convert them
+            if (msg instanceof StreamCache) {
+                // First, let's extract the data from the stream
+                byte[] ba = null;
+                if (msg instanceof InputStreamCache) {
+                    // Here, we have an input stream cache to attempt to process
+                    InputStreamCache isc = (InputStreamCache) msg;
+                    isc.reset();
+                    ba = isc.readAllBytes();
+                } else if (msg instanceof ByteArrayInputStreamCache) {
+                    // Here, we have an input stream cache to attempt to process
+                    ByteArrayInputStreamCache basc = (ByteArrayInputStreamCache) msg;
+                    basc.reset();
+                    ba = basc.readAllBytes();
+                } else {
+                    log.error("Unexpected type: {}.  Unable to convert to Map to send to Vantiq.",
+                              msg.getClass().getName());
+                    throw new InvalidPayloadException(exchange, Map.class);
+                }
+                msg = ba;
+            }
+    
+            // Jackson converts to json nodes but not to map.  Have to hunt for that or convert json node.
+            // Then Camel couldn't convert on its own.  Let's see if we can help things along...
+            if (msg instanceof String) {
+                // Then we must be fetching a JSON string.
+                String strMsg = (String) msg;
+                vMsg = mapper.readValue(strMsg, new TypeReference<>() {});
+            } else if (msg instanceof byte[]) {
+                // See if we can get Jackson to do the deserialization for us.
+                byte[] ba = (byte[]) msg;
+    
+                try {
+                    msg = mapper.readTree( ba);
+                    if (msg instanceof TextNode) {
+                        msg = ((TextNode) msg).asText();
+                    } else if (msg instanceof ContainerNode) {
+                        msg = mapper.convertValue(msg, Object.class);
+                        log.debug("Decoded ObjectNode into {}: {}", msg.getClass().getName(), msg);
+                    }
+                } catch (IOException e) {
+                    // Ignore -- we'll sort it out downstream
+                }
+                if (msg instanceof byte[]) {
                     try {
                         msg = mapper.readValue(ba, new TypeReference<>() {});
                         log.trace("Tried readValue() -- got a {}", msg.getClass().getName());
@@ -99,29 +132,29 @@ public class VantiqProducer extends DefaultProducer {
                             ByteArrayInputStream baStream = new ByteArrayInputStream(
                                     (byte[]) exchange.getIn().getBody());
                             ObjectInputStream objFromByte = new ObjectInputStream(baStream);
-    
                             msg = objFromByte.readObject();
                         } catch (Exception e) {
                             // Guess not...
                             log.trace("Trapped after Java deserialization", e);
                         }
                     }
-                    // If these both fail, msg will still be a byte array. Guess that's what there is...
-                    if (msg instanceof byte[]) {
-                        // Then we might be fetching a JSON string.
-                        if (checkUTF8(ba)) {
-                            String strMsg = new String((byte[]) msg, StandardCharsets.UTF_8);
-                            try {
-                                vMsg = mapper.readValue(strMsg, new TypeReference<>() {});
-                            } catch (Exception e) {
-                                String strVal = mapper.writeValueAsString(strMsg);
-                                vMsg = Map.of("stringVal", strVal);
-                            }
-                        } else {
-                            // But, maybe it's just a byte array...
-                            String strVal = mapper.writeValueAsString(ba);
-                            vMsg = Map.of("byteVal", strVal);
+                }
+                // If these both fail, msg will still be a byte array. Guess that's what there is...
+                if (msg instanceof byte[]) {
+                    // Then we might be fetching a JSON string.
+                    if (checkUTF8(ba)) {
+                        String strMsg = new String((byte[]) msg, StandardCharsets.UTF_8);
+                        try {
+                            vMsg = mapper.readValue(strMsg, new TypeReference<>() {
+                            });
+                        } catch (Exception e) {
+                            String strVal = mapper.writeValueAsString(strMsg);
+                            vMsg = Map.of("stringVal", strVal);
                         }
+                    } else {
+                        // But, maybe it's just a byte array...
+                        String strVal = mapper.writeValueAsString(ba);
+                        vMsg = Map.of("byteVal", strVal);
                     }
                 }
             }
@@ -137,46 +170,6 @@ public class VantiqProducer extends DefaultProducer {
                               msg.getClass().getName());
                     throw new InvalidPayloadException(exchange, Map.class);
                 }
-            }
-        } else {
-            if (msg instanceof InputStreamCache) {
-                // Here, we have an input stream cache to attempt to process
-                InputStreamCache isc = (InputStreamCache) msg;
-                isc.reset();
-                String str = new String(isc.readAllBytes());
-                if (str.charAt(0) == '"') {
-                    // Then strip leading & trailing quotes
-                    str = str.substring(1, str.length() - 1);
-                }
-                if (log.isTraceEnabled()) {
-                    log.trace("JSON String as input is: {}", str);
-                }
-                
-                vMsg = mapper.readValue(isc.readAllBytes(), new TypeReference<>() {});
-            } else if (msg instanceof ByteArrayInputStreamCache) {
-                // Here, we have an input stream cache to attempt to process
-                ByteArrayInputStreamCache basc = (ByteArrayInputStreamCache) msg;
-                basc.reset();
-                String str = new String(basc.readAllBytes());
-                if (str.charAt(0) == '"') {
-                    // Then strip leading & trailing quotes
-                    str = str.substring(1, str.length() - 1);
-                }
-                if (log.isTraceEnabled()) {
-                    log.trace("JSON String as input is: {}", str);
-                }
-    
-                try {
-                    vMsg = mapper.readValue(str, new TypeReference<>() {});
-                } catch (JsonProcessingException jpe) {
-                    log.trace("Trapped normal/ignored JsonProcessingException handling string:  {}", str, jpe);
-                    // Then this string wasn't a json msg.  We'll just turn it into a stringVal map
-                    vMsg = Map.of("stringVal", str);
-                }
-            } else {
-                log.error("Unexpected type: {}.  Unable to convert to Map to send to Vantiq.",
-                          msg.getClass().getName());
-                throw new InvalidPayloadException(exchange, Map.class);
             }
         }
         if (log.isTraceEnabled()) {

--- a/camelComponent/src/test/resources/log4j2.properties
+++ b/camelComponent/src/test/resources/log4j2.properties
@@ -8,5 +8,5 @@ rootLogger.appenderRef.out.ref = out
 
 logger.vantiqcamel.name = io.vantiq.extsrc.camel
 logger.vantiqcamel.level = DEBUG
-logger.vantiqcamel.appenderRef = Console
+logger.vantiqcamel.appenderRef = out
 

--- a/camelConnector/src/main/resources/log4j2.properties
+++ b/camelConnector/src/main/resources/log4j2.properties
@@ -8,5 +8,12 @@ rootLogger.appenderRef.out.ref = out
 
 logger.vantiqcamelconn.name = io.vantiq.extsrc.camelconn
 logger.vantiqcamelconn.level = DEBUG
-logger.vantiqcamelconn.appenderRef = Console
+logger.vantiqcamelconn.appenderRef = out
 
+logger.vantiqcamel.name = io.vantiq.extsrc.camel
+logger.vantiqcamel.level = DEBUG
+logger.vantiqcamel.appenderRef = out
+
+logger.cameltrace.name = org.apache.camel.Tracing
+logger.cameltrace.level = DEBUG
+logger.cameltrace.appenderRef = out

--- a/camelConnector/src/test/resources/log4j2.properties
+++ b/camelConnector/src/test/resources/log4j2.properties
@@ -8,5 +8,12 @@ rootLogger.appenderRef.out.ref = out
 
 logger.vantiqcamelconn.name = io.vantiq.extsrc.camelconn
 logger.vantiqcamelconn.level = DEBUG
-logger.vantiqcamelconn.appenderRef = Console
+logger.vantiqcamelconn.appenderRef = out
 
+logger.vantiqcamel.name = io.vantiq.extsrc.camel
+logger.vantiqcamel.level = DEBUG
+logger.vantiqcamel.appenderRef = out
+
+logger.cameltrace.name = org.apache.camel.Tracing
+logger.cameltrace.level = DEBUG
+logger.cameltrace.appenderRef = out


### PR DESCRIPTION
Merge to staging branch.  No issue reported.

AWS Kinesis seems to function better when it gets StreamCache input.  As it turns out, this is what a `marshal` step  does (to Json via Jackson, but it's at a higher level so somewhat independent).  Since the purpose of our `consumerOutputJson` is to mimic the `marshal` step function (primarily for use in kamelets), we adopt this behavior.

However, since `consumerOutputJson` has been out there a bit (though probably very little use), we'll deprecate that and use `consumerOutputJsonStream` as the flag going forward.  The old one stays for now, still working the same way.  Backward compatibility and all that.

Add tests for same, verifying that the information is properly encoded in the `InputCacheStream` (or `ByteArrayInputStreamCache`) where appropriate.