### PR TITLE
Use consumerOutputJsonStream header in generated assemblies

### DIFF
--- a/buildSrc/src/main/groovy/io/vantiq/extsrc/assy/tasks/AssemblyResourceGeneration.groovy
+++ b/buildSrc/src/main/groovy/io/vantiq/extsrc/assy/tasks/AssemblyResourceGeneration.groovy
@@ -40,7 +40,7 @@ import java.util.regex.Pattern
 @Slf4j
 class AssemblyResourceGeneration extends DefaultTask {
     public static final String VANTIQ_SERVER_CONFIG = 'vantiq://server.config'
-    public static final String VANTIQ_SERVER_CONFIG_JSON = VANTIQ_SERVER_CONFIG + '?consumerOutputJson=true'
+    public static final String VANTIQ_SERVER_CONFIG_JSON = VANTIQ_SERVER_CONFIG + '?consumerOutputJsonStream=true'
     public static final String VANTIQ_SERVER_CONFIG_STRUCTURED = VANTIQ_SERVER_CONFIG + '?structuredMessageHeader=true'
     public static final String VANTIQ_SERVER_CONFIG_JSON_STRUCTURED = VANTIQ_SERVER_CONFIG_JSON +
         '&structuredMessageHeader=true'


### PR DESCRIPTION
No issue reported, merging to staging branch

Change `consumerOutputJson` EP option to `consumerOutputJsonStream`.

This conforms with the usage in the `VantiqConsumer` & better mimics the  _marshal/json..._ step we endeavor to replace (since it makes constructing assemblies much easier).