### PR TITLE
Improve string handling when string is no JSON.

### DIFF
--- a/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqProducer.java
+++ b/camelComponent/src/main/java/io/vantiq/extsrc/camel/VantiqProducer.java
@@ -104,7 +104,13 @@ public class VantiqProducer extends DefaultProducer {
             if (msg instanceof String) {
                 // Then we must be fetching a JSON string.
                 String strMsg = (String) msg;
-                vMsg = mapper.readValue(strMsg, new TypeReference<>() {});
+                try {
+                    vMsg = mapper.readValue(strMsg, new TypeReference<>() {});
+                } catch (Exception e) {
+                    // Not valid JSON here, so we'll assume it's just a plain old string
+                    String strVal = mapper.writeValueAsString(strMsg);
+                    vMsg = Map.of("stringVal", strVal);
+                }
             } else if (msg instanceof byte[]) {
                 // See if we can get Jackson to do the deserialization for us.
                 byte[] ba = (byte[]) msg;

--- a/camelComponent/src/test/java/io/vantiq/extsrc/camel/VantiqComponentTest.java
+++ b/camelComponent/src/test/java/io/vantiq/extsrc/camel/VantiqComponentTest.java
@@ -246,6 +246,36 @@ public class VantiqComponentTest extends CamelTestSupport {
     }
     
     @Test
+    public void testVantiqProducerFromString() {
+        
+        // First, grab our test environment.
+        FauxVantiqComponent vc = (FauxVantiqComponent) context.getComponent("vantiq");
+        assert vc != null;
+        // Note that we need to fetch the endpoints by URI since there are more than one of them.
+        FauxVantiqEndpoint ep = (FauxVantiqEndpoint) context.getEndpoint(vantiqEndpointUri);
+        FalseClient fc = ep.myClient;
+        
+        ArrayList<String> msgs =new ArrayList<>();
+        int itemCount = 10;
+        for (int i = 0; i < itemCount; i++) {
+            msgs.add("hi mom " + i);
+        }
+        
+        // Verify that when then producer gets a pure string message, that it turns it a Vail object (aka Map) with
+        // a single key "stringVal" and the test string as the value.
+        for (Object item: msgs) {
+            log.info("Sending msg: " + item);
+            
+            assert item != null;
+            sendBody(routeStartUri, item);
+            //noinspection rawtypes
+            Map lastMsg = fc.getLastMessageAsMap();
+            validateExtensionMsg(lastMsg, false, null, new String[] {"stringVal"}, "hi mom");
+        }
+    }
+    
+    
+    @Test
     public void testVantiqProducerStructuredJson() {
         
         // First, grab our test environment.


### PR DESCRIPTION
No issue reported

Return as JSON { stringVal: <value> } as we do with bytes, etc.
