### PR TITLE
Streamline JDBC source tests (live)

### DIFF
--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCBase.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCBase.java
@@ -38,6 +38,7 @@ public class TestJDBCBase {
     static String testVantiqServer;
     static String jdbcDriverLoc;
     static String testSourceName;
+    static String testSourceNameAsynch;
     static String testTypeName;
     static String testProcedureName;
     static String testRuleName;
@@ -52,6 +53,7 @@ public class TestJDBCBase {
         testVantiqServer = System.getProperty("TestVantiqServer", null);
         jdbcDriverLoc = System.getenv("JDBC_DRIVER_LOC");
         testSourceName = System.getProperty("EntConTestSourceName", "testSourceName");
+        testSourceNameAsynch = testSourceName + "_Asynch";
         testTypeName = System.getProperty("EntConTestTypeName", "testTypeName");
         testProcedureName = System.getProperty("EntConTestProcedureName", "testProcedureName");
         testRuleName = System.getProperty("EntConTestRuleName", "testRuleName");

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetTestBase.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/NeuralNetTestBase.java
@@ -127,6 +127,7 @@ public class NeuralNetTestBase extends ObjRecTestBase {
                     done = false;
                     Thread.sleep(50);
                 } else {
+                    done = true;
                     List<VantiqError> errors = vantiqResponse.getErrors();
                     for (int i = 0; i < errors.size(); i++) {
                         if (errors.get(i).getCode().equals(NOT_FOUND_CODE)) {


### PR DESCRIPTION
Fixes #437 

No need to constantly recreate the source & session.  Speeds up tests, etc.