### PR TITLE
Partial attempt to reduce OR failures in extension sources

### DIFF
--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/ObjRecTestBase.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/ObjRecTestBase.java
@@ -46,7 +46,8 @@ public class ObjRecTestBase {
     // Keeping old around to swap back sometime.
 //    public static final String IP_CAMERA_URL = "https://wzmedia.dot.ca.gov/D4/N680_JSO_JCT_242.stream/playlist.m3u8";
 //    public static final String IP_CAMERA_URL = "https://wzmedia.dot.ca.gov/D3/80_reed.stream/playlist.m3u8";
-    public static final String IP_CAMERA_URL = "http://166.143.31.94/cgi-bin/camera?resolution=640&amp;quality=1&amp;Language=0&amp;1666639808";
+    public static final String IP_CAMERA_URL = "http://166.143.31.94/cgi-bin/camera?resolution=640&amp;" +
+            "quality=1&amp;Language=0&amp;1666639808";
     @BeforeClass
     public static void getProps() {
         testAuthToken = System.getProperty("TestAuthToken", null);
@@ -85,6 +86,27 @@ public class ObjRecTestBase {
             Files.deleteIfExists(d.toPath());
         } catch (Exception e) {
             throw new RuntimeException("Error deleting directory " + d.getAbsolutePath(), e);
+        }
+    }
+    
+    public static boolean isIpAccessible(String url) {
+        URL img;
+        
+        // Override schema to make sure something exists at the other end.  The URL class doesn't necessarily
+        // grok all the scheme's used by camera URLs, so we'll convert to a common version just so we can
+        // test the connection.
+        String schemeFreeURL = url.substring(url.indexOf(':'));
+        url = "http" + schemeFreeURL;
+        try {
+            img = new URL(url);
+            InputStream s = img.openStream();
+            byte[] b = new byte[256];
+            s.read(b);
+            String str = new String(b);
+            s.close();
+            return true;
+        } catch (java.io.IOException e) {
+            return false;
         }
     }
 }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/ObjRecTestBase.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/ObjRecTestBase.java
@@ -41,13 +41,13 @@ public class ObjRecTestBase {
 
     // Camera with some recognizable objects in it.
     // Use camera "close to home" -- CalTrans camera close to the office...
-//    public static final String IP_CAMERA_URL = "https://wzmedia.dot.ca.gov/D4/S680_at_N_Main_St.stream/playlist.m3u8";
+    public static final String IP_CAMERA_URL = "https://wzmedia.dot.ca.gov/D4/S680_at_N_Main_St.stream/playlist.m3u8";
     // Walnut Creek/North Main camera (above) currently malfunctioning.  Swapping to Hwy 242 Junction for now.
     // Keeping old around to swap back sometime.
 //    public static final String IP_CAMERA_URL = "https://wzmedia.dot.ca.gov/D4/N680_JSO_JCT_242.stream/playlist.m3u8";
 //    public static final String IP_CAMERA_URL = "https://wzmedia.dot.ca.gov/D3/80_reed.stream/playlist.m3u8";
-    public static final String IP_CAMERA_URL = "http://166.143.31.94/cgi-bin/camera?resolution=640&amp;" +
-            "quality=1&amp;Language=0&amp;1666639808";
+//    public static final String IP_CAMERA_URL = "http://166.143.31.94/cgi-bin/camera?resolution=640&amp;" +
+//            "quality=1&amp;Language=0&amp;1666639808";
     @BeforeClass
     public static void getProps() {
         testAuthToken = System.getProperty("TestAuthToken", null);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestNetworkStreamRetriever.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestNetworkStreamRetriever.java
@@ -3,8 +3,6 @@ package io.vantiq.extsrc.objectRecognition.imageRetriever;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
-import java.io.InputStream;
-import java.net.URL;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -84,30 +82,6 @@ public class TestNetworkStreamRetriever extends ObjRecTestBase {
             assert data.length > 0;
         } catch (ImageAcquisitionException e) {
             fail("Exception occurred when requesting frame from camera: " + e.toString());
-        }
-    }
-    
-    
-// ================================================= Helper functions =================================================
-    public boolean isIpAccessible(String url) {
-        URL img;
-
-        // Override schema to make sure something exists at the other end.  The URL class doesn't necessarily
-        // grok all the scheme's used by camera URLs, so we'll convert to a common version just so we can
-        // test the connection.
-        String schemeFreeURL = url.substring(url.indexOf(':'));
-        url = "http" + schemeFreeURL;
-        try {
-            img = new URL(url);
-            InputStream s = img.openStream();
-            byte[] b = new byte[256];
-            s.read(b);
-            String str = new String(b);
-            System.out.println(str);
-            s.close();
-            return true;
-        } catch (java.io.IOException e) {
-            return false;
         }
     }
 }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
@@ -32,6 +32,8 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         put("name", QUERY_FILENAME);
     }};
     
+    static final String ipCameraInUse = IP_CAMERA_URL;
+    static boolean cameraOperational = false;
     @BeforeClass
     public static void setup() {
         if (testVantiqServer != null && testAuthToken != null) {
@@ -45,7 +47,10 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
                 fail("Trapped exception creating source impl: " + e);
             }
 
-            setupSource(createSourceDef());
+            cameraOperational = isIpAccessible(ipCameraInUse);
+            if (cameraOperational) {
+                setupSource(createSourceDef());
+            }
         }
     }
 
@@ -76,6 +81,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
     public void testProcessNextFrameLocal() {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
+        assumeTrue(cameraOperational);
         
         // Make sure that output directory has not yet been created
         File outputDir = new File(OUTPUT_DIR);
@@ -144,7 +150,8 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
     public void testProcessNextFrameVantiq() throws InterruptedException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-        
+        assumeTrue(cameraOperational);
+    
         // Run query without setting "operation":"processNextFrame"
         Map<String,Object> params = new LinkedHashMap<String,Object>();
         params.put("NNsaveImage", "vantiq");
@@ -186,7 +193,8 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
     public void testProcessNextFrameBoth() throws InterruptedException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-        
+        assumeTrue(cameraOperational);
+    
         // Make sure that output directory has not yet been created
         File outputDir = new File(OUTPUT_DIR);
         assert !outputDir.exists();
@@ -275,6 +283,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
     public void testUploadAsImage() throws InterruptedException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
+        assumeTrue(cameraOperational);
 
         // Run query without setting "operation":"processNextFrame"
         Map<String,Object> params = new LinkedHashMap<String,Object>();
@@ -314,7 +323,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         Map<String,Object> neuralNet = new LinkedHashMap<String,Object>();
         
         // Setting up dataSource config options
-        dataSource.put("camera", IP_CAMERA_URL);
+        dataSource.put("camera", ipCameraInUse);
         dataSource.put("type", "network");
         
         // Setting up general config options

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -8,6 +8,7 @@
 
 package io.vantiq.extsrc.objectRecognition.neuralNet;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
@@ -118,7 +119,9 @@ public class TestYoloQueries extends NeuralNetTestBase {
     static final int PRECROP_TOP_LEFT_Y_COORDINATE = 50;
     static final int CROPPED_WIDTH = 200;
     static final int CROPPED_HEIGHT = 150;
-
+    
+    static final String ipCameraToUse = IP_CAMERA_URL;
+    static boolean cameraOperational = false;
     @BeforeClass
     public static void setup() throws Exception {
         if (testAuthToken != null && testVantiqServer != null) {
@@ -141,6 +144,8 @@ public class TestYoloQueries extends NeuralNetTestBase {
             } catch (Exception e) {
                 fail("Trapped exception creating source impl: " + e);
             }
+            
+            cameraOperational = isIpAccessible(ipCameraToUse);
             createServerConfig();
             setupSource(createSourceDef());
         }
@@ -206,7 +211,8 @@ public class TestYoloQueries extends NeuralNetTestBase {
     public void testProcessNextFrameLocal() {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-        
+        assumeTrue(cameraOperational);
+    
         // Make sure that output directory has not yet been created
         File outputDir = new File(OUTPUT_DIR);
         assert !outputDir.exists();
@@ -274,7 +280,8 @@ public class TestYoloQueries extends NeuralNetTestBase {
     public void testProcessNextFrameVantiq() throws InterruptedException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-        
+        assumeTrue(cameraOperational);
+    
         // Run query without setting "operation":"processNextFrame"
         Map<String, Object> params = new LinkedHashMap<>();
         params.put("NNsaveImage", "vantiq");
@@ -316,7 +323,8 @@ public class TestYoloQueries extends NeuralNetTestBase {
     public void testProcessNextFrameBoth() throws InterruptedException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-        
+        assumeTrue(cameraOperational);
+
         // Make sure that output directory has not yet been created
         File outputDir = new File(OUTPUT_DIR);
         assert !outputDir.exists();
@@ -706,6 +714,13 @@ public class TestYoloQueries extends NeuralNetTestBase {
     }
     
     @Test
+    public void ranCameraBasedTests() {
+        // This test will fail when all the others are skipped.  This is there to simply alert us that a public
+        // camera on which we depend is currently not working.  IF this continues for a while, it's time to find
+        // a new public camera.
+        assertTrue("Public camera is not working: " + ipCameraToUse, cameraOperational);
+    }
+    @Test
     public void testImageDateDeleteAfter() throws IOException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
@@ -767,7 +782,8 @@ public class TestYoloQueries extends NeuralNetTestBase {
     public void testInvalidPreCroppingQuery() throws IOException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-        
+        assumeTrue(cameraOperational);
+    
         // Make sure that output directory has not yet been created
         File outputDir = new File(OUTPUT_DIR);
         assert !outputDir.exists();
@@ -897,7 +913,8 @@ public class TestYoloQueries extends NeuralNetTestBase {
     public void doLabelTest(boolean localLabelRequest, boolean includeEncoded, boolean saveImage) throws IOException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-        
+        assumeTrue(cameraOperational);
+    
         // Make sure that output directory has not yet been created
         File outputDir = new File(OUTPUT_DIR);
         assert !outputDir.exists();
@@ -980,7 +997,8 @@ public class TestYoloQueries extends NeuralNetTestBase {
     public void testPreCroppingQuery() throws IOException {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
-        
+        assumeTrue(cameraOperational);
+    
         // Make sure that output directory has not yet been created
         File outputDir = new File(OUTPUT_DIR);
         assert !outputDir.exists();
@@ -1164,7 +1182,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
         Map<String, Object> neuralNet = new LinkedHashMap<>();
         
         // Setting up dataSource config options
-        dataSource.put("camera", IP_CAMERA_URL);
+        dataSource.put("camera", ipCameraToUse);
         dataSource.put("type", "network");
         
         // Setting up general config options


### PR DESCRIPTION
In the object recognition tests, we use some semi-public (_i.e._, unsecured) cameras to verify camera reading operations.  These occasionally go offline.  When that happens, the tests fail, and we have to track down what's going on.

This PR adds a generic test that the camera in use is online. If not, that test fails, but the other tests that use it will just cause themselves to be skipped.  This should make tracking the issues down a bit easier.

With our current camera issue, this worked for a bit.  Then, the camera was put back online, but it now points somewhere else, so we don't find objects in the images retrieved.  At some point, should these sorts of things continue, we may want to enhance our camera check to verify that we see something identifiable in the image.  But that's not in this PR.

Also, changed the camera to one previously in use that seems to have come back online (thanks, CalTrans).

[Jenkins run](https://jenkins.vantiq.com/jenkins/job/vantiq-extension-sources-branch/203/)