### PR TITLE
Automate import & publish of kamelet-based assemblies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 wrapper {
-    gradleVersion = '5.0'
+    gradleVersion = '7.3.1'
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 

--- a/camelAssemblies/README.md
+++ b/camelAssemblies/README.md
@@ -193,7 +193,8 @@ The actions required to perform the deployment are the same as those described f
 
 1) The service and procedure to use varies from assembly to assembly
   (they are named and packaged as per the assembly), and
-2) The source name value is not (cannot) be provided.  It is provided by the assembly and the specialized service 
+2) The source name value should not (cannot) be provided.  It is provided by the assembly and the specialized 
+   service 
    contained therein.
 
 So, using the same assembly as an example, assembly installation will provide the service definition
@@ -211,6 +212,10 @@ which will present you with a set of parameter values to provide.
 As with the underlying Camel Connector (on which these assemblies are based), the `clusterName` and 
 `installationName` values are required, but the remainder are optional.  They will take their defaults from the 
 Camel Connector assembly installation or from the system.
+
+Note:  The K8sInstallation created by this deployment procedure will pull the Camel Connector source image
+from a repository at quay.io.  The image is made available in a public
+repository, so no credentials are required.
 
 # Development using this Git Repo
 

--- a/camelAssemblies/README.md
+++ b/camelAssemblies/README.md
@@ -248,7 +248,7 @@ However, if importing many projects, use `../gradlew publishAssemblies -PcamelAs
 In addition to the gradle properties used for import, you can define the following.
 
 * **<profileName>_camelAssembliesCatalog** -- the name of the catalog to which to publish the assemblies.  This is 
-  required, and may be specfied on the command line or in the `gradle.properties` file.
+  required, and may be specified on the command line or in the `gradle.properties` file.
 * **changeLog** -- change log entry to include.  A very short (no spaces) description of what this upload entails.
 
 ## Use of the Gradle Properties

--- a/camelAssemblies/build.gradle
+++ b/camelAssemblies/build.gradle
@@ -19,10 +19,6 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
-//test {
-//    useJUnitPlatform()
-//}
-
 tasks.register('zipAssemblies') {
     outputs.upToDateWhen { false }
     def assyCount = 0

--- a/camelAssemblies/build.gradle
+++ b/camelAssemblies/build.gradle
@@ -1,4 +1,5 @@
 import io.vantiq.extsrc.assy.tasks.AssemblyResourceGeneration
+import groovy.json.JsonSlurper
 
 repositories {
     mavenCentral()
@@ -11,15 +12,16 @@ dependencies {
 ext {
     generatedResourceBase = 'vantiqGeneratedResources'
     distributionsDir = 'distributions'
+    camVersionString = 'v' + camelVersion.replace('.', '_')
 }
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
-test {
-    useJUnitPlatform()
-}
+//test {
+//    useJUnitPlatform()
+//}
 
 tasks.register('zipAssemblies') {
     outputs.upToDateWhen { false }
@@ -47,3 +49,114 @@ tasks.register('generateAssemblyResources', AssemblyResourceGeneration)
 assemble.finalizedBy('generateAssemblyResources')
 generateAssemblyResources.finalizedBy('zipAssemblies')
 zipAssemblies.mustRunAfter( 'generateAssemblyResources' )
+
+tasks.register('importAssemblies') {
+    outputs.upToDateWhen { false }
+    def importCount = 0
+    def skipCount = 0
+    String catalogProfile = project.rootProject.findProperty('camelAssembliesProfile') as String
+    logger.lifecycle('Found profile: {}', catalogProfile as String)
+    if (!catalogProfile?.trim()) {
+        throw new GradleException('Project property "camelAssembliesProfile" was missing or empty')
+    }
+
+    def catalogProjectList = project.rootProject.findProperty("${catalogProfile}_camelAssembliesList")
+    def catalogVantiqCommand = project.rootProject.findProperty("${catalogProfile}_camelAssembliesVantiq")
+    if (!catalogVantiqCommand?.trim()) {
+        catalogVantiqCommand = 'vantiq'
+        logger.lifecycle('Using {} as the "vantiq" command', catalogVantiqCommand)
+    }
+    doLast {
+        File genProjects = new File(project.buildDir, "${generatedResourceBase}")
+        genProjects.eachDir { projectDir ->
+            def assemblyName = projectDir.name
+            def assyParts = assemblyName.split('\\.')
+            logger.debug('Cam Version String: {}, Assy parts: {}', camVersionString, assyParts)
+
+            def simpleAssemblyName = assyParts[-1] - ('_' + camVersionString)
+            logger.debug('Simple Assembly Name for {}: {}', assemblyName, simpleAssemblyName)
+
+            if (!catalogProjectList?.trim() || catalogProjectList.contains(assemblyName) ||
+                    catalogProjectList.contains(simpleAssemblyName)) {
+                logger.lifecycle('Importing project from {}', projectDir)
+                exec {
+                    commandLine catalogVantiqCommand, '-s', catalogProfile, 'import', 'data', '-d', projectDir
+                }
+                exec {
+                    commandLine catalogVantiqCommand, '-s', catalogProfile, 'import', 'metadata', '-d', projectDir
+                }
+
+                importCount += 1
+            } else {
+                skipCount += 1
+                logger.debug('Skipping {} as it is not in our list of things to import', assemblyName)
+            }
+        }
+        logger.lifecycle('Total projects imported via profile {}: {}, skipped: {}', catalogProfile, importCount,
+            skipCount)
+    }
+}
+
+tasks.register('publishAssemblies') {
+    outputs.upToDateWhen { false }
+    def importCount = 0
+    def skipCount = 0
+    String catalogProfile = project.rootProject.findProperty('camelAssembliesProfile') as String
+    logger.lifecycle('Found profile: {}', catalogProfile as String)
+    if (!catalogProfile?.trim()) {
+        throw new GradleException('Project property "camelAssembliesProfile" was missing or empty')
+    }
+
+    def catalogProjectList = project.rootProject.findProperty("${catalogProfile}_camelAssembliesList")
+    def catalogVantiqCommand = project.rootProject.findProperty("${catalogProfile}_camelAssembliesVantiq")
+    if (!catalogVantiqCommand?.trim()) {
+        catalogVantiqCommand = 'vantiq'
+        logger.lifecycle('Using {} as the "vantiq" command', catalogVantiqCommand)
+    }
+    def catalogName = project.rootProject.findProperty("${catalogProfile}_camelAssembliesCatalog")
+    if (!catalogName?.trim()) {
+        throw new GradleException("Project property '${camelAssembliesProfile}_camelAssembliesCatalog' was " +
+            "missing" + " or empty")
+    }
+    def changeLog = project.rootProject.findProperty('changeLog')
+    if (!changeLog?.trim()) {
+        changeLog = ''
+    } else {
+        changeLog = changeLog.replace(' ', '\\ ')
+    }
+
+    doLast {
+        File genProjects = new File(project.buildDir, "${generatedResourceBase}")
+        def projectFiles= project.fileTree(dir: genProjects, include: '**/projects/*.json')
+        logger.debug('Project files: {}', projectFiles.asList())
+        projectFiles.each { projectFile ->
+            logger.debug("Processing project file: {}", projectFile.absolutePath)
+            def projDef = new JsonSlurper().parse(projectFile)
+            def assemblyName = projDef.name
+            def assyParts = assemblyName.split('\\.')
+            logger.debug('Cam Version String: {}, Assy parts: {}', camVersionString, assyParts)
+
+            def simpleAssemblyName = assyParts[-1]
+            logger.debug('Simple Assembly Name: {}', simpleAssemblyName)
+            logger.info('Looking at assembly {}', assemblyName, projectFile.absolutePath)
+            logger.debug('     ...from project file {}', projectFile.absolutePath)
+            if (!catalogProjectList?.trim() || catalogProjectList.contains(assemblyName) ||
+                catalogProjectList.contains(simpleAssemblyName)) {
+                logger.lifecycle('Publishing assembly {} :: {}', simpleAssemblyName, assemblyName)
+                logger.debug('Publishing project from {}', projectFile)
+                exec {
+                    commandLine catalogVantiqCommand, '-s', catalogProfile, 'run', 'procedure', 'Publisher.' +
+                        'publishAssembly', 'assemblyName:' + assemblyName, 'catalogName:' + catalogName,
+                        'changeLog:' + '"' + changeLog + '"'
+                }
+                importCount += 1
+            } else {
+                skipCount += 1
+                logger.debug('Skipping {} as it is not in our list of things to import', assemblyName)
+            }
+        }
+        logger.lifecycle('Total projects imported via profile {}: {}, skipped: {}', catalogProfile, importCount,
+            skipCount)
+    }
+}
+

--- a/camelAssemblies/build.gradle
+++ b/camelAssemblies/build.gradle
@@ -119,10 +119,9 @@ tasks.register('publishAssemblies') {
             "missing" + " or empty")
     }
     def changeLog = project.rootProject.findProperty('changeLog')
-    if (!changeLog?.trim()) {
-        changeLog = ''
-    } else {
-        changeLog = changeLog.replace(' ', '\\ ')
+    if (changeLog?.trim()) {
+        // space -> _ -- passing thru many layers of scripts always turns out not quite right.
+        changeLog = changeLog.replace(' ', '_')
     }
 
     doLast {
@@ -144,10 +143,17 @@ tasks.register('publishAssemblies') {
                 catalogProjectList.contains(simpleAssemblyName)) {
                 logger.lifecycle('Publishing assembly {} :: {}', simpleAssemblyName, assemblyName)
                 logger.debug('Publishing project from {}', projectFile)
-                exec {
-                    commandLine catalogVantiqCommand, '-s', catalogProfile, 'run', 'procedure', 'Publisher.' +
-                        'publishAssembly', 'assemblyName:' + assemblyName, 'catalogName:' + catalogName,
-                        'changeLog:' + '"' + changeLog + '"'
+                if (!changeLog?.trim()) {
+                    exec {
+                        commandLine catalogVantiqCommand, '-s', catalogProfile, 'run', 'procedure', 'Publisher.' +
+                            'publishAssembly', 'assemblyName:' + assemblyName, 'catalogName:' + catalogName
+                    }
+                } else {
+                    exec {
+                        commandLine catalogVantiqCommand, '-s', catalogProfile, 'run', 'procedure', 'Publisher.' +
+                            'publishAssembly', 'assemblyName:' + assemblyName, 'catalogName:' + catalogName,
+                            'changeLog:' + changeLog
+                    }
                 }
                 importCount += 1
             } else {

--- a/camelConnector/README.md
+++ b/camelConnector/README.md
@@ -395,6 +395,9 @@ Optional Values:
 Once you run the `ConnectorDeployment.deployToK8s()` procedure, the Vantiq system will arrange for the deployment of 
 the installation. Information about this process is available as part of your Vantiq documentation.
 
+Note that the deployment will pull the Camel Connector image from quay.io.  The image is made available in a public 
+repository, so no credentials are required.
+
 ## Licensing
 
 The source code uses the [MIT License](https://opensource.org/licenses/MIT).  


### PR DESCRIPTION
Fixes #455 

Simply too many possible assemblies to do the import/publish manually.

Adds support for `importAssemblies` and `publishAssemblies` tasks.  These, respectively, import & publish the assembles generated in the camelAssemblies subproject. Both of these tasks are driven by a set of gradle properties, many of which use the value of the `camelAssembliesProfile` in their name.  So, for example, if you set `camelAssembliesProfile` to `fred`, the set of things to import or publish is taken from the `fred_camelAssembliesList` gradle property.  This allows one to have separate collections of these properties (as required) driven by the profile selected.  This is probably of value only to me at the moment :-).

The imports & publish are performed using the Vantiq CLI.  No internal magic employed.

Updated the READMEs to explain how this works and added or clarified information about how the deployment procedures are invoked.

Whilst doing the import & publish work, found that the generated projects were missing some data in the `resources` section, so added that (thanks @mjswan). 


