### PR TITLE
Fix issue with Camel routes using choice stmts and/or properties references

### DIFF
--- a/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelDiscovery.java
+++ b/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelDiscovery.java
@@ -131,7 +131,7 @@ public class CamelDiscovery {
                 log.error("Unable to stop all discovery routes:", e);
             }
             ctx.getRoutes().forEach(ctx::removeRoute);
-            ;
+            
             List<RouteDefinition> rds = new ArrayList<>(ctx.getRouteDefinitions());
             rds.forEach( (rd) -> {
                 try {

--- a/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelDiscovery.java
+++ b/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelDiscovery.java
@@ -14,10 +14,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.ExtendedCamelContext;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.model.RouteDefinition;
+import org.apache.camel.reifier.ProcessorReifier;
+import org.apache.camel.reifier.language.ExpressionReifier;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -58,8 +63,15 @@ public class CamelDiscovery {
      */
     Map<String, Set<String>> performComponentDiscovery(RouteBuilder rb, Properties propertyValues)
             throws DiscoveryException {
+        // When the context used here gets closed, the type converter is removed/nulled out.  Later, when
+        // running in "real life," we try & use that expression predicate that we find and it fails (NPE due to
+        // typeconverter being null).  For this reason, to make things work (for the cases where this matters),
+        // we simply don't close the CamelContext in use.  I'm still looking for a better way.
         
-        try (DefaultCamelContext ctx = new DefaultCamelContext()) {
+        //noinspection resource
+        DefaultCamelContext ctx = new DefaultCamelContext();
+    
+        try  {
             ExtendedCamelContext ectx = ctx.adapt(ExtendedCamelContext.class);
             EnumeratingComponentResolver ecr = new EnumeratingComponentResolver(ectx.getComponentResolver());
             ectx.setComponentResolver(ecr);
@@ -98,22 +110,47 @@ public class CamelDiscovery {
     
             }
             Map<String, Set<String>> retVal = new HashMap<>();
+    
             retVal.put(SYSTEM_COMPONENTS, ecr.getSystemComponentsUsed());
             retVal.put(COMPONENTS_TO_LOAD, ecr.getComponentsToLoad());
             retVal.put(SYSTEM_DATAFORMATS, edfr.getSystemDataFormatsUsed());
             retVal.put(DATAFORMATS_TO_LOAD, edfr.getDataFormatsToLoad());
             return retVal;
-            // Note that ectx will be closed via the try-with-resources construct
         } catch (Exception e) {
             log.error("Trapped exception preparing or completing component discovery", e);
             throw new DiscoveryException("Exception preparing or completing component discovery processing", e);
+        } finally {
+            // The following is aimed at reducing the resource overhead that discovery may introduce.  The ctx.close()
+            // call claims to remove all stuff used, but it doesn't, leaving bits of expressions around that refer to
+            // the camel context under which they were built.  Consequently, we cannot close the context, so we'll do
+            // what we can to get rid of the detritus.
+    
+            try {
+                ctx.stopAllRoutes();
+            } catch (Exception e) {
+                log.error("Unable to stop all discovery routes:", e);
+            }
+            ctx.getRoutes().forEach(ctx::removeRoute);
+            ;
+            List<RouteDefinition> rds = new ArrayList<>(ctx.getRouteDefinitions());
+            rds.forEach( (rd) -> {
+                try {
+                    ctx.removeRouteDefinition(rd);
+                    log.debug("Removed discovery-time route definition: {}", rd.getShortName());
+                } catch (Exception e) {
+                    log.error("Failed to remove discovery-time route definition: {}", rd.getShortName());
+                    throw new RuntimeException(e);
+                }
+            });
+            ExpressionReifier.clearReifiers();
+            ProcessorReifier.clearReifiers();
         }
     }
     
     /**
      * Find the name of the camel component from which it runs these components based on the scheme.
      *
-     * Using the generated artifactsMap (see {@link build.gradle#generateComponentList}), lookup the schema
+     * Using the generated artifactsMap (see build.gradle's generateComponentList task), lookup the schema
      * name and return the component name found.  It (will be) assumed that these are all in org.apache.camel, and
      * that they all share the same camel version as that which we are running.  This is the Apache Camel way.
      *

--- a/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelRunner.java
+++ b/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelRunner.java
@@ -470,18 +470,16 @@ public class CamelRunner extends MainSupport implements Closeable {
                         if (comp != null) {
                             PropertyConfigurer pc = comp.getComponentPropertyConfigurer();
                             for (Map.Entry<String, ?> compProp : props.entrySet()) {
-                                // For each property to be initialized, we'll look for the setter method
-                                // (i.e., set${propertyName}(value) where the parameter's class matches the class of
-                                // the property value passed in).  If that exists, we'll call it.  Otherwise, log a
-                                // warning and ignore it. Things are likely to fail, but there's not much we can do about
-                                // improper specifications
-                                
                                 if (pc != null) {
                                     boolean propExists = pc.configure(camelContext, comp, compProp.getKey(),
                                                               compProp.getValue(), false);
                                     log.debug("PropertyConfigurer for {} (value: {}) succeeded: {}", compProp.getKey(),
                                               compProp.getValue(), propExists);
                                     if (!propExists) {
+                                        // This is only a warning -- we may have been overzealous in our code
+                                        // generation, and not every property may be needed.  If things are required
+                                        // (and we've messed something up), the underlying component will let us know
+                                        // in its own special way.
                                         log.warn("Failed to set property {} (value {}) for component: {}",
                                                  compProp.getKey(), compProp.getValue(), comp.getClass().getName());
                                     }

--- a/camelConnector/src/main/resources/assembly/camelconnector/projects/com.vantiq.extsrc.camelconn.camelConnector.json
+++ b/camelConnector/src/main/resources/assembly/camelconnector/projects/com.vantiq.extsrc.camelconn.camelConnector.json
@@ -107,7 +107,7 @@
         "type" : "String"
       },
       "connectorImageTag" : {
-        "default": "1.2.1",
+        "default": "1.3.1",
         "description" : "The image tag used to pull the Camel Connector image.  Generally, no need to change this. Ignore if not running in Kubernetes.",
         "type" : "String"
       }

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/VantiqConfigurationTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/VantiqConfigurationTest.java
@@ -567,9 +567,9 @@ public class VantiqConfigurationTest extends CamelTestSupport {
     
     // The following is a _modified for test purposes_ version of the route used in the fhir-sink kamelet. Testing
     // that, discovered that the _choice_ statement gets built up at discovery time (which we would expect), but the
-    // expression in generates internally is cached WITH a reference to the camel context used for discovery. Then,
+    // expression it generates internally is cached WITH a reference to the camel context used for discovery. Then,
     // when that context was closed (it no longer is), subsequent evaluations using that context found no
-    // typeConverter in the context (trashed on close), and thru an NPE.  Here, we verify that this basic route
+    // typeConverter in the context (trashed on close), and threw an NPE.  Here, we verify that this basic route
     // work as expected.  It takes a bit of time to set things up, but a reasonable test.
     public static final String FHIR_SINK_ROUTE_YAML = "\n"
             + "-   route-template:\n"

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/VantiqConfigurationTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/VantiqConfigurationTest.java
@@ -377,6 +377,24 @@ public class VantiqConfigurationTest extends CamelTestSupport {
     }
     
     @Test
+    public void testRouteWithChoice() {
+        Properties fhirProps = new Properties();
+        fhirProps.putAll(FHIR_PROPERTIES);
+        performConfigTest(testName, FHIR_SINK_ROUTE_YAML, "yaml",
+                          List.of(
+                                  Map.of(CamelRunner.COMPONENT_NAME, "fhir",
+                                         COMPONENT_PROPERTIES, FHIR_PROPERTIES)),
+                          fhirProps,
+                          (CamelContext runnerContext) -> {
+                              TriFunction<CamelContext, String, Object, Boolean> verifyOperation =
+                                      defineVerifyOperation();
+                              assert verifyOperation.apply(runnerContext, "smith", "smith");
+                              assert verifyOperation.apply(runnerContext, "smithsonian", "\"total\"; 0");
+                              assert verifyOperation.apply(runnerContext, "jackson", "jackson");
+                          });
+    }
+    
+    @Test
     public void testComponentInitConfiguration() {
         assumeTrue(!sfLoginUrl.equals(MISSING_VALUE) && !sfClientId.equals(MISSING_VALUE) &&
                            !sfClientSecret.equals(MISSING_VALUE) && !sfRefreshToken.equals(MISSING_VALUE));
@@ -536,6 +554,71 @@ public class VantiqConfigurationTest extends CamelTestSupport {
                                                          "refreshToken", sfRefreshToken
     );
     
+    public static final Map<String, String> FHIR_PROPERTIES = Map.of (
+            "apiName", "SEARCH",
+            "prettyPrint", "true",
+            "log", "true",
+            "methodName", "searchByUrl",
+            "encoding", "JSON",
+            "lazyStartProducer", "false",
+            "serverUrl", "https://server.fire.ly",
+            "fhirVersion", "R4"//,
+    );
+    
+    // The following is a _modified for test purposes_ version of the route used in the fhir-sink kamelet. Testing
+    // that, discovered that the _choice_ statement gets built up at discovery time (which we would expect), but the
+    // expression in generates internally is cached WITH a reference to the camel context used for discovery. Then,
+    // when that context was closed (it no longer is), subsequent evaluations using that context found no
+    // typeConverter in the context (trashed on close), and thru an NPE.  Here, we verify that this basic route
+    // work as expected.  It takes a bit of time to set things up, but a reasonable test.
+    public static final String FHIR_SINK_ROUTE_YAML = "\n"
+            + "-   route-template:\n"
+            + "       id: Route templates from fhir_sink:v3_21_0\n"
+            + "       from:\n"
+            + "           uri: direct:start\n"
+//            + "           uri: vantiq://server.config?consumerOutputJsonStream=true&structuredMessageHeader=true\n"
+            + "           steps:\n"
+            + "           -   choice:\n"
+            + "                    precondition: true\n"
+            + "                    when:\n"
+            + "                    -   simple: ${properties:encoding} =~ 'JSON'\n"
+            + "                        steps:\n"
+            + "                        -   unmarshal:\n"
+            + "                                fhirJson:\n"
+            + "                                    fhir-version: '{{fhirVersion}}'\n"
+            + "                                    pretty-print: '{{prettyPrint}}'\n"
+            + "                    -   simple: ${properties:encoding} =~ 'XML'\n"
+            + "                        steps:\n"
+            + "                        -   unmarshal:\n"
+            + "                                fhirXml:\n"
+            + "                                    fhir-version: '{{fhirVersion}}'\n"
+            + "                                    pretty-print: '{{prettyPrint}}'\n"
+            + "           -   to:\n"
+            + "                    uri: fhir://{{apiName}}/{{methodName}}\n"
+            + "                    parameters:\n"
+            + "                        serverUrl: '{{serverUrl}}'\n"
+// fhir-sink kamelet says this is there, but it just gets errors about unknown parameter.  Leaving it out to get
+// things to work.  fhir-sink route is similarly overridden.
+//            + "                        inBody: \"resource\" \n"
+            + "                        encoding: '{{encoding}}'\n"
+            + "                        fhirVersion: '{{fhirVersion}}'\n"
+            + "                        log: '{{log}}'\n"
+            + "                        prettyPrint: '{{prettyPrint}}'\n"
+            + "                        lazyStartProducer: '{{lazyStartProducer}}'\n"
+            + "                        proxyHost: '{{?proxyHost}}'\n"
+            + "                        proxyPassword: '{{?proxyPassword}}'\n"
+            + "                        proxyPort: '{{?proxyPort}}'\n"
+            + "                        proxyUser: '{{?proxyUser}}'\n"
+            + "                        accessToken: '{{?accessToken}}'\n"
+            + "                        username: '{{?username}}'\n"
+            + "                        password: '{{?password}}'\n"
+            + "           - marshal:\n"
+            + "               fhirJson:\n"
+            + "                   fhir-version: '{{fhirVersion}}'\n"
+            + "                   pretty-print: '{{prettyPrint}}'\n"
+            + "           - to:\n"
+            + "                  uri: mock:result"; // Send off to mock result so we can verify the output
+
     public static final String SALESFORCETASKS_YAML =  "\n"
         + "- route:\n"
         + "    id: \"Salesforce from yaml-route\"\n"

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/VantiqConfigurationTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/VantiqConfigurationTest.java
@@ -381,9 +381,7 @@ public class VantiqConfigurationTest extends CamelTestSupport {
         Properties fhirProps = new Properties();
         fhirProps.putAll(FHIR_PROPERTIES);
         performConfigTest(testName, FHIR_SINK_ROUTE_YAML, "yaml",
-                          List.of(
-                                  Map.of(CamelRunner.COMPONENT_NAME, "fhir",
-                                         COMPONENT_PROPERTIES, FHIR_PROPERTIES)),
+                          null,
                           fhirProps,
                           (CamelContext runnerContext) -> {
                               TriFunction<CamelContext, String, Object, Boolean> verifyOperation =

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentResolverTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentResolverTest.java
@@ -621,7 +621,7 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
                 } else if (routeId.contains("fhir_sink")) {
                     // For FHIR search by Url, it expects a query parameter of URL that contains the search URL.
                     // However, we don't want to hard code that in the route (and the fhir-sink kamelet, on which the
-                    // route for this test is based) doesn't, so we'll use the header values as detailed in the FHIR
+                    // route for this test is based doesn't), so we'll use the header values as detailed in the FHIR
                     // component.  For those values, we include "CamelFhir.<parameter name>" in the header to get the
                     // value(s) in which we're interested.  Here, we want to look for a patient named "smith", so
                     // we'll use that.


### PR DESCRIPTION
No issue reported -- discovered verifying some FHIR connections via assemblies.

The Camel connector works by changing some of the underlying functions (via supported means) that are used during route building.  So we do that by creating a new Camel Context, overriding some behavior, then instantiating the route (but not really, due to the behavior overrides).  Once we've done that, we ignore that route, go back to the regular Camel context, and do things for real (after using the gathered information to build a special class loader & resolver).

The Camel context advertises the `.close()` & `.stop()` calls as shutting things down & cleaning up the cached information.  Unfortunately, this is not quite true.  Specifically, for some expressions used in `choice` statements, at "real" evaluation time, they use the saved reference to the old, now closed, Camel context to find a type converter. That converter's been disposed of, and things go quickly down hill (NPEs).

This behavior is buried deep in Camel.  Maybe it's fixed in v4, but we're not there yet.  To fix the problem (in a supported way), we no longer close the camel context we use for discovery.  We clean up all the _behind the scenes_ stuff we can, but we leave the context open.  It's only used to get the type converter, so that seems to be OK.

While debugging this (which took the better part of a couple of days), I found that there's a better way to set properties, so upgraded to use that now.

Added test for this situation & updated the version number used in the connector assembly.