### PR TITLE
Add support for route overrides -- and use one for the fair-sink

### DIFF
--- a/buildSrc/src/main/groovy/io/vantiq/extsrc/assy/tasks/AssemblyResourceGeneration.groovy
+++ b/buildSrc/src/main/groovy/io/vantiq/extsrc/assy/tasks/AssemblyResourceGeneration.groovy
@@ -256,7 +256,7 @@ class AssemblyResourceGeneration extends DefaultTask {
     public static String rawCamelVersion
     public static final String RESOURCE_BASE_DIRECTORY = 'src/main/resources'
     public static final String VANTIQ_NOTES_DIRECTORY = 'vantiqNotes'
-    public static final String ROUTES_OVERRIDE_DIREcTORY = 'routeOverrides'
+    public static final String ROUTES_OVERRIDE_DIRECTORY = 'routeOverrides'
 
     public static final String ASSEMBLY_RESOURCE_BASE_PROPERTY = 'generatedResourceBase'
 
@@ -479,7 +479,7 @@ class AssemblyResourceGeneration extends DefaultTask {
         // If we have an override for the routes document, pick that up & use it instead.  This is sometimes required
         // when there are flaws or enhancements to the route provided in the Kamelet.
 
-        File routesFile = project.file(RESOURCE_BASE_DIRECTORY + File.separator + ROUTES_OVERRIDE_DIREcTORY +
+        File routesFile = project.file(RESOURCE_BASE_DIRECTORY + File.separator + ROUTES_OVERRIDE_DIRECTORY +
             File.separator + kamName + File.separator + packageSafeCamelVersion + File.separator +  kamName +
             YAML_ROUTE_SUFFIX)
         log.debug('For {}, checking for replacement routes document found at {}', kamName, routesFile.absolutePath)

--- a/buildSrc/src/main/groovy/io/vantiq/extsrc/assy/tasks/AssemblyResourceGeneration.groovy
+++ b/buildSrc/src/main/groovy/io/vantiq/extsrc/assy/tasks/AssemblyResourceGeneration.groovy
@@ -256,6 +256,7 @@ class AssemblyResourceGeneration extends DefaultTask {
     public static String rawCamelVersion
     public static final String RESOURCE_BASE_DIRECTORY = 'src/main/resources'
     public static final String VANTIQ_NOTES_DIRECTORY = 'vantiqNotes'
+    public static final String ROUTES_OVERRIDE_DIREcTORY = 'routeOverrides'
 
     public static final String ASSEMBLY_RESOURCE_BASE_PROPERTY = 'generatedResourceBase'
 
@@ -475,6 +476,28 @@ class AssemblyResourceGeneration extends DefaultTask {
         }
         String routesDocumentString = yamlDumper.dumpToString(routeSpec)
 
+        // If we have an override for the routes document, pick that up & use it instead.  This is sometimes required
+        // when there are flaws or enhancements to the route provided in the Kamelet.
+
+        File routesFile = project.file(RESOURCE_BASE_DIRECTORY + File.separator + ROUTES_OVERRIDE_DIREcTORY +
+            File.separator + kamName + File.separator + packageSafeCamelVersion + File.separator +  kamName +
+            YAML_ROUTE_SUFFIX)
+        log.debug('For {}, checking for replacement routes document found at {}', kamName, routesFile.absolutePath)
+        if (routesFile?.exists()) {
+            log.debug('For {}, using replacement routes document found at {}', kamName, routesFile.absolutePath)
+            String newRoutesDocString = ''
+
+            routesFile.readLines().each { aLine ->
+                newRoutesDocString += aLine + '\n'
+            }
+            if (!newRoutesDocString) {
+                log.error("Ignoring prebuilt routes document {} as it contains no content.", routesFile.absolutePath)
+            } else {
+                routesDocumentString = newRoutesDocString
+            }
+        } else {
+            log.debug('No replacement routes document found for {}', kamName)
+        }
         if (log.isDebugEnabled()) {
             log.debug('\nResults for Kamelet: {}', kamName)
             log.debug('\n>>>   Properties:')

--- a/camelAssemblies/build.gradle
+++ b/camelAssemblies/build.gradle
@@ -48,21 +48,22 @@ zipAssemblies.mustRunAfter( 'generateAssemblyResources' )
 
 tasks.register('importAssemblies') {
     outputs.upToDateWhen { false }
-    def importCount = 0
-    def skipCount = 0
-    String catalogProfile = project.rootProject.findProperty('camelAssembliesProfile') as String
-    logger.lifecycle('Found profile: {}', catalogProfile as String)
-    if (!catalogProfile?.trim()) {
-        throw new GradleException('Project property "camelAssembliesProfile" was missing or empty')
-    }
-
-    def catalogProjectList = project.rootProject.findProperty("${catalogProfile}_camelAssembliesList")
-    def catalogVantiqCommand = project.rootProject.findProperty("${catalogProfile}_camelAssembliesVantiq")
-    if (!catalogVantiqCommand?.trim()) {
-        catalogVantiqCommand = 'vantiq'
-        logger.lifecycle('Using {} as the "vantiq" command', catalogVantiqCommand)
-    }
     doLast {
+        def importCount = 0
+        def skipCount = 0
+        String catalogProfile = project.rootProject.findProperty('camelAssembliesProfile') as String
+        logger.debug('Found profile: {}', catalogProfile as String)
+        if (!catalogProfile?.trim()) {
+            throw new GradleException('Project property "camelAssembliesProfile" was missing or empty')
+        }
+
+        def catalogProjectList = project.rootProject.findProperty("${catalogProfile}_camelAssembliesList")
+        def catalogVantiqCommand = project.rootProject.findProperty("${catalogProfile}_camelAssembliesVantiq")
+        if (!catalogVantiqCommand?.trim()) {
+            catalogVantiqCommand = 'vantiq'
+            logger.lifecycle('Using {} as the "vantiq" command', catalogVantiqCommand)
+        }
+
         File genProjects = new File(project.buildDir, "${generatedResourceBase}")
         genProjects.eachDir { projectDir ->
             def assemblyName = projectDir.name
@@ -95,32 +96,34 @@ tasks.register('importAssemblies') {
 
 tasks.register('publishAssemblies') {
     outputs.upToDateWhen { false }
-    def importCount = 0
-    def skipCount = 0
-    String catalogProfile = project.rootProject.findProperty('camelAssembliesProfile') as String
-    logger.lifecycle('Found profile: {}', catalogProfile as String)
-    if (!catalogProfile?.trim()) {
-        throw new GradleException('Project property "camelAssembliesProfile" was missing or empty')
-    }
-
-    def catalogProjectList = project.rootProject.findProperty("${catalogProfile}_camelAssembliesList")
-    def catalogVantiqCommand = project.rootProject.findProperty("${catalogProfile}_camelAssembliesVantiq")
-    if (!catalogVantiqCommand?.trim()) {
-        catalogVantiqCommand = 'vantiq'
-        logger.lifecycle('Using {} as the "vantiq" command', catalogVantiqCommand)
-    }
-    def catalogName = project.rootProject.findProperty("${catalogProfile}_camelAssembliesCatalog")
-    if (!catalogName?.trim()) {
-        throw new GradleException("Project property '${camelAssembliesProfile}_camelAssembliesCatalog' was " +
-            "missing" + " or empty")
-    }
-    def changeLog = project.rootProject.findProperty('changeLog')
-    if (changeLog?.trim()) {
-        // space -> _ -- passing thru many layers of scripts always turns out not quite right.
-        changeLog = changeLog.replace(' ', '_')
-    }
 
     doLast {
+        def importCount = 0
+        def skipCount = 0
+        String catalogProfile = project.rootProject.findProperty('camelAssembliesProfile') as String
+        logger.debug('Found profile: {}', catalogProfile as String)
+
+        if (!catalogProfile?.trim()) {
+            throw new GradleException('Project property "camelAssembliesProfile" was missing or empty')
+        }
+
+        def catalogProjectList = project.rootProject.findProperty("${catalogProfile}_camelAssembliesList")
+        def catalogVantiqCommand = project.rootProject.findProperty("${catalogProfile}_camelAssembliesVantiq")
+        if (!catalogVantiqCommand?.trim()) {
+            catalogVantiqCommand = 'vantiq'
+            logger.lifecycle('Using {} as the "vantiq" command', catalogVantiqCommand)
+        }
+        def catalogName = project.rootProject.findProperty("${catalogProfile}_camelAssembliesCatalog")
+        if (!catalogName?.trim()) {
+            throw new GradleException("Project property '${camelAssembliesProfile}_camelAssembliesCatalog' was " +
+                "missing" + " or empty")
+        }
+        def changeLog = project.rootProject.findProperty('changeLog')
+        if (changeLog?.trim()) {
+            // space -> _ -- passing thru many layers of scripts always turns out not quite right.
+            changeLog = changeLog.replace(' ', '_')
+        }
+
         File genProjects = new File(project.buildDir, "${generatedResourceBase}")
         def projectFiles= project.fileTree(dir: genProjects, include: '**/projects/*.json')
         logger.debug('Project files: {}', projectFiles.asList())

--- a/camelAssemblies/build.gradle
+++ b/camelAssemblies/build.gradle
@@ -162,3 +162,6 @@ tasks.register('publishAssemblies') {
     }
 }
 
+importAssemblies.mustRunAfter( 'generateAssemblyResources' )
+publishAssemblies.mustRunAfter('importAssemblies')
+

--- a/camelAssemblies/src/main/resources/routeOverrides/fhir_sink/v3_21_0/fhir_sink.routes.yaml
+++ b/camelAssemblies/src/main/resources/routeOverrides/fhir_sink/v3_21_0/fhir_sink.routes.yaml
@@ -34,3 +34,10 @@
                         accessToken: '{{?accessToken}}'
                         username: '{{?username}}'
                         password: '{{?password}}'
+            - marshal:
+                    fhirJson:
+                        fhir-version: '{{fhirVersion}}'
+                        pretty-print: '{{prettyPrint}}'
+            - to:
+                    uri: vantiq://server.config?consumerOutputJsonStream=true&structuredMessageHeader=true
+

--- a/camelAssemblies/src/main/resources/routeOverrides/fhir_sink/v3_21_0/fhir_sink.routes.yaml
+++ b/camelAssemblies/src/main/resources/routeOverrides/fhir_sink/v3_21_0/fhir_sink.routes.yaml
@@ -1,0 +1,36 @@
+-   route-template:
+        id: Route templates from fhir_sink:v3_21_0 (modified)
+        from:
+            uri: vantiq://server.config?consumerOutputJsonStream=true&structuredMessageHeader=true
+            steps:
+            -   choice:
+                    precondition: true
+                    when:
+                    -   simple: ${properties:encoding} =~ 'JSON'
+                        steps:
+                        -   unmarshal:
+                                fhirJson:
+                                    fhir-version: '{{fhirVersion}}'
+                                    pretty-print: '{{prettyPrint}}'
+                    -   simple: ${properties:encoding} =~ 'XML'
+                        steps:
+                        -   unmarshal:
+                                fhirXml:
+                                    fhir-version: '{{fhirVersion}}'
+                                    pretty-print: '{{prettyPrint}}'
+            -   to:
+                    uri: fhir://{{apiName}}/{{methodName}}
+                    parameters:
+                        serverUrl: '{{serverUrl}}'
+                        encoding: '{{encoding}}'
+                        fhirVersion: '{{fhirVersion}}'
+                        log: '{{log}}'
+                        prettyPrint: '{{prettyPrint}}'
+                        lazyStartProducer: '{{lazyStartProducer}}'
+                        proxyHost: '{{?proxyHost}}'
+                        proxyPassword: '{{?proxyPassword}}'
+                        proxyPort: '{{?proxyPort}}'
+                        proxyUser: '{{?proxyUser}}'
+                        accessToken: '{{?accessToken}}'
+                        username: '{{?username}}'
+                        password: '{{?password}}'

--- a/camelAssemblies/src/main/resources/vantiqNotes/fhir_sink.md
+++ b/camelAssemblies/src/main/resources/vantiqNotes/fhir_sink.md
@@ -1,0 +1,239 @@
+# FHIR&reg; Sink Operation
+
+## Sending and Receiving Messages
+
+The Vantiq component, which is the entry to the FHIR&reg; Component, accepts messages with `header` and `message` 
+values. These are translated into JSON for the FHIR Component.
+
+For example, for the `SEARCH` API, using the `searhByUrl` method, 
+the `header` should contain properties specifying the search criteria in the `url` parameter.  The way the FHIR 
+component works, it expects the header-resident parameters to be specified as `CamelFhir.<paramName>`.  This means 
+that the `url` parameter will be included in the header as `CamelFhir.url=`.  For example, to look for information 
+about a Patient named _smith_, we'd use `CamelFhir.url=Patient?name=smith`. 
+
+The FHIR Component's `search` operation also wants the resource type required to be specified as the body of the 
+message, in a property named `resourceType`.
+Please see the FHIR Component in the Apache Camel documentation for details.
+
+Putting this all together, we can send messages using standard Vail code using the FHIR-sink assembly.  The 
+following is a simple procedure that sends a search query to the FHIR Server.
+
+```js
+package io.test.fhir
+PROCEDURE doFhirSearch(urlParam String, resourceType String): Object
+
+var msg = { resourceType: resourceType }
+var headers = {CamelFhir.url = urlParam }
+
+publish {headers: headers, message: msg } to SERVICE EVENT  "com.vantiq.extsrc.camel.kamelets.v3_21_0.fhir_sink.fhir_sink_service/fhir_sink_serviceEvent"
+
+return null
+```
+
+And this can be invoked using "Patient" as the resourceType, and "Patient?name=smith".
+
+However, this paradigm is not really very useful. We would like to see the result of the operation (especially for a 
+search).  To do this, we'll need to interact with the source that underlies the service & associated event seen above.
+
+To do this, we'll use something like the following Vail procedure:
+
+```js
+package io.test.fhir
+PROCEDURE returnFhirSearch(urlParam String, resourceType String): Object array
+
+var msg = { resourceType: resourceType }
+var headers = {CamelFhir.url = urlParam }
+
+var res = select * from source com.vantiq.extsrc.camel.kamelets.v3_21_0.fhir_sink.fhir_sink_source 
+	with message = msg, headers = headers
+return res
+```
+
+using the same parameters. Operated in this fashion, we get a result that looks something like the following (which 
+has been abbreviated):
+
+```
+[
+   {
+      "headers": {
+         "CamelFhir.url": "Patient?name=smith",
+         "Content-Type": "application/fhir+json"
+      },
+      "message": {
+         "resourceType": "Bundle",
+         "meta": {
+            "versionId": "c1a8968d-8be5-451b-af72-2e9e2addffa5",
+            "lastUpdated": "2024-03-06T21:44:21.168+00:00"
+         },
+         "type": "searchset",
+         "timestamp": "2024-03-06T21:44:21.168+00:00",
+         "total": 100,
+         "link": [
+            {
+               "relation": "self",
+               "url": "https://server.fire.ly/Patient?name=smith&_format=json&_total=accurate&_count=10&_skip=0"
+            },
+            {
+               "relation": "next",
+               "url": "https://server.fire.ly/95e51b3d-b13e-4f5e-9f4d-a24d57290517"
+            },
+            {
+               "relation": "last",
+               "url": "https://server.fire.ly/a16cd3c9-8e75-4319-99e6-b64052a1fe89"
+            }
+         ],
+         "entry": [
+            {
+               "fullUrl": "https://server.fire.ly/Patient/def57a80-2d3e-4fe5-bcfb-661d98ce4579",
+               "resource": {
+                  "resourceType": "Patient",
+                  "id": "def57a80-2d3e-4fe5-bcfb-661d98ce4579",
+                  "meta": {
+                     "versionId": "e5738b3c-2e2f-451b-a096-fc796b3475fc",
+                     "lastUpdated": "2024-03-04T17:10:06.121+00:00",
+                     "tag": [
+                        {
+                           "system": "http://www.alpha.alp/use-case",
+                           "code": "EX20"
+                        }
+                     ]
+                  },
+                  "extension": [
+                     {
+                        "url": "http://hl7.org/fhir/StructureDefinition/patient-birthPlace",
+                        "valueAddress": {
+                           "city": "Bath",
+                           "country": "UK"
+                        }
+                     },
+                     {
+                        "url": "http://hl7.org/fhir/StructureDefinition/patient-disability",
+                        "valueCodeableConcept": {
+                           "coding": [
+                              {
+                                 "system": "http://snomed.info/sct",
+                                 "code": "232424232424",
+                                 "display": "Amputation of foot"
+                              }
+                           ]
+                        }
+                     }
+                  ],
+                  "identifier": [
+                     {
+                        "system": "http://www.miniaf.alp/citreg",
+                        "value": "232424232424"
+                     },
+                     {
+                        "system": "http://www.alpha-hospital.alp/patient-id",
+                        "value": "232424232424"
+                     }
+                  ],
+                  "name": [
+                     {
+                        "family": "Tucker-Shimanuki",
+                        "given": [
+                           "Alfonso"
+                        ],
+                        "prefix": [
+                           "Mr."
+                        ]
+                     },
+                     {
+                        "use": "old",
+                        "family": "Smith-Jones"
+                     }
+                  ],
+                  "telecom": [
+                     {
+                        "system": "phone",
+                        "value": "020 824 322",
+                        "use": "home"
+                     }
+                  ],
+                  "gender": "male",
+                  "birthDate": "1970-01-01",
+                  "address": [
+                     {
+                        "line": [
+                           "Southlands, Forest View"
+                        ],
+                        "city": "North-East Forest",
+                        "postalCode": "BA3 1AT"
+                     }
+                  ],
+                  "communication": [
+                     {
+                        "language": {
+                           "coding": [
+                              {
+                                 "system": "urn:ietf:bcp:47",
+                                 "code": "en",
+                                 "display": "English"
+                              }
+                           ]
+                        }
+                     },
+                     {
+                        "language": {
+                           "coding": [
+                              {
+                                 "system": "urn:ietf:bcp:47",
+                                 "code": "JP",
+                                 "display": "Japanese"
+                              }
+                           ]
+                        },
+                        "preferred": true
+                     }
+                  ]
+               },
+               "search": {
+                  "mode": "match"
+               }
+            },
+            {
+               "fullUrl": "https://server.fire.ly/Patient/7b1bee01-7c8b-44ae-b410-02b5cd7854e0",
+               "resource": {
+                  "resourceType": "Patient",
+                  "id": "7b1bee01-7c8b-44ae-b410-02b5cd7854e0",
+                  "meta": {
+                     "versionId": "ce803181-15c4-4793-8887-dedbd8796185",
+                     "lastUpdated": "2024-03-02T13:19:10.130+00:00"
+                  },
+                  "identifier": [
+                     {
+                        "system": "http://testpatient.id/mrn",
+                        "value": "99999999"
+                     }
+                  ],
+                  "name": [
+                     {
+                        "family": "Smith",
+                        "given": [
+                           "Alan"
+                        ]
+                     }
+                  ],
+                  "gender": "male",
+                  "birthDate": "1965-05-06"
+               },
+               "search": {
+                  "mode": "match"
+               }
+            },
+            ...
+```
+
+(This is using sample data from one of the many FHIR test servers.)
+
+# Legal
+
+Apache Camel, Camel, and Apache are trademarks of The Apache Software Foundation.
+
+FHIR&reg; is the registered trademark of HL7&reg; and is used with the permission of Health Level Seven 
+International (HL7&).
+
+Vantiq is a trademark of Vantiq, Inc.
+
+All other trademarks mentioned are trademarks or registered trademarks of their respective owners.

--- a/camelAssemblies/src/main/resources/vantiqNotes/fhir_sink.md
+++ b/camelAssemblies/src/main/resources/vantiqNotes/fhir_sink.md
@@ -5,7 +5,7 @@
 The Vantiq component, which is the entry to the FHIR&reg; Component, accepts messages with `header` and `message` 
 values. These are translated into JSON for the FHIR Component.
 
-For example, for the `SEARCH` API, using the `searhByUrl` method, 
+For example, for the `SEARCH` API, using the `searchByUrl` method, 
 the `header` should contain properties specifying the search criteria in the `url` parameter.  The way the FHIR 
 component works, it expects the header-resident parameters to be specified as `CamelFhir.<paramName>`.  This means 
 that the `url` parameter will be included in the header as `CamelFhir.url=`.  For example, to look for information 


### PR DESCRIPTION
It will occasionally be the case (hopefully not often) that we'll need to override the route generated from the kamelet.  This may be due to errors contained therein (which may just be because of our interactions) or may be cases where we'd like to enhance things.

The `AssemblyResourceGeneration` task now looks in `resources/routeOverrides` and will use the route there when present in lieu of the generated version.

For the FHIR sink, we find that one of the endpoint parameters does not appear to be accepted, so we'll remove it.  Also, since this _sink_ is really a request/response thing, we add a Vantiq Note that describes how to make use of that.  Using the usual PUBLISH to SERVICE EVENT mechanism, you can successfully send operations (once you decode their spec!), but a _write only_ operation for, for example, a search, isn't terribly useful.  So we add to the route to return the result.  And the note describes how to get at that.  Unfortunately, this requires working against the underlying source (which is somewhat ghostly since 1) sources can't be visible, but 2) they show up in the _active resource control_ and in the drop downs in the Vail editor.

Also, as a matter of convenience to me, the `build.gradle` file has ordering directives relating _assemble_, _importAssemblies_, and _publishAssemblies_.  Just makes it easier locally to _fire & forget_.