### PR TITLE
Fix parameter name for k8s namespace

### DIFF
--- a/camelConnector/src/main/resources/assembly/camelconnector/procedures/com/vantiq/extsrc/camelconn/ConnectorDeployment_deployToK8s.vail
+++ b/camelConnector/src/main/resources/assembly/camelconnector/procedures/com/vantiq/extsrc/camelconn/ConnectorDeployment_deployToK8s.vail
@@ -67,6 +67,6 @@ execute ResourceAPI.executeOp({
     op: "deploy",
     resourceName: "system.k8sclusters",
     resourceId: clusterName,
-    object: { name: installationName, namespace: k8sNamespace, clusterName: clusterName, config: k8sConfig}
+    object: { name: installationName, k8sNamespace: k8sNamespace, clusterName: clusterName, config: k8sConfig}
     //parameters: { name: "else" }
 })


### PR DESCRIPTION
Fixes #461 

Used wrong parameter name when specifying a Kubernetes namespace into which to deploy. Correct that.