### PR TITLE
Add verified support for Camel JIRA assemblies

### DIFF
--- a/buildSrc/src/main/groovy/io/vantiq/extsrc/assy/tasks/AssemblyResourceGeneration.groovy
+++ b/buildSrc/src/main/groovy/io/vantiq/extsrc/assy/tasks/AssemblyResourceGeneration.groovy
@@ -792,9 +792,9 @@ class AssemblyResourceGeneration extends DefaultTask {
             JSON_SUFFIX)
 
         if (configOverrideFile.exists()) {
-            log.lifecycle('Taking config defaults from {}', configOverrideFile.absolutePath)
+            log.debug('Taking config defaults from {}', configOverrideFile.absolutePath)
             Map<String, Object> configDefault = new JsonSlurper().parse(configOverrideFile) as Map<String, Object>
-            log.lifecycle('Source config defaults for {}: {}', kamName, configDefault)
+            log.debug('Source config defaults for {}: {}', kamName, configDefault)
             camelAppConfig << configDefault.get(CONFIG_CAMEL_RUNTIME)
             generalConfig << configDefault.get(CONFIG_CAMEL_GENERAL)
         } else {

--- a/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_add_comment_sink/v3_21_0/jira_add_comment_sink.json
+++ b/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_add_comment_sink/v3_21_0/jira_add_comment_sink.json
@@ -1,0 +1,10 @@
+{
+  "camelRuntime": {
+  },
+  "general": {
+    "repoList": [
+      "https://packages.atlassian.com/mvn/maven-external/",
+      "https://repo.maven.apache.org/maven2/"
+    ]
+  }
+}

--- a/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_add_issue_sink/v3_21_0/jira_add_issue_sink.json
+++ b/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_add_issue_sink/v3_21_0/jira_add_issue_sink.json
@@ -1,0 +1,10 @@
+{
+  "camelRuntime": {
+  },
+  "general": {
+    "repoList": [
+      "https://packages.atlassian.com/mvn/maven-external/",
+      "https://repo.maven.apache.org/maven2/"
+    ]
+  }
+}

--- a/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_oauth_source/v3_21_0/jira_oauth_source.json
+++ b/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_oauth_source/v3_21_0/jira_oauth_source.json
@@ -1,0 +1,10 @@
+{
+  "camelRuntime": {
+  },
+  "general": {
+    "repoList": [
+      "https://packages.atlassian.com/mvn/maven-external/",
+      "https://repo.maven.apache.org/maven2/"
+    ]
+  }
+}

--- a/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_source/v3_21_0/jira_source.json
+++ b/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_source/v3_21_0/jira_source.json
@@ -1,0 +1,11 @@
+{
+  "camelRuntime": {
+  },
+  "general": {
+    "repoList": [
+      "https://maven.atlassian.com/repository/public/",
+      "https://packages.atlassian.com/artifactory/maven-external/",
+      "https://repo.maven.apache.org/maven2/"
+    ]
+  }
+}

--- a/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_source/v3_21_0/jira_source.json
+++ b/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_source/v3_21_0/jira_source.json
@@ -3,8 +3,7 @@
   },
   "general": {
     "repoList": [
-      "https://maven.atlassian.com/repository/public/",
-      "https://packages.atlassian.com/artifactory/maven-external/",
+      "https://packages.atlassian.com/mvn/maven-external/",
       "https://repo.maven.apache.org/maven2/"
     ]
   }

--- a/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_transition_issue_sink/v3_21_0/jira_transition_issue_sink.json
+++ b/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_transition_issue_sink/v3_21_0/jira_transition_issue_sink.json
@@ -1,0 +1,10 @@
+{
+  "camelRuntime": {
+  },
+  "general": {
+    "repoList": [
+      "https://packages.atlassian.com/mvn/maven-external/",
+      "https://repo.maven.apache.org/maven2/"
+    ]
+  }
+}

--- a/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_update_issue_sink/v3_21_0/jira_update_issue_sink.json
+++ b/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_update_issue_sink/v3_21_0/jira_update_issue_sink.json
@@ -1,0 +1,10 @@
+{
+  "camelRuntime": {
+  },
+  "general": {
+    "repoList": [
+      "https://packages.atlassian.com/mvn/maven-external/",
+      "https://repo.maven.apache.org/maven2/"
+    ]
+  }
+}

--- a/camelConnector/build.gradle
+++ b/camelConnector/build.gradle
@@ -323,6 +323,22 @@ tasks.withType(Test) {
         systemProperty "camel-salesforce-refreshToken",
             rootProject.findProperty("camel-salesforce-refreshToken") ?: "empty"
     }
+    if (rootProject.hasProperty("io.vantiq.camel.test.jiraApiToken")) {
+        systemProperty "io.vantiq.camel.test.jiraApiToken",
+            rootProject.findProperty("io.vantiq.camel.test.jiraApiToken") ?: "empty"
+    }
+    if (rootProject.hasProperty("io.vantiq.camel.test.jiraUsername")) {
+        systemProperty "io.vantiq.camel.test.jiraUsername",
+            rootProject.findProperty("io.vantiq.camel.test.jiraUsername") ?: "empty"
+    }
+    if (rootProject.hasProperty("io.vantiq.camel.test.jiraJql")) {
+        systemProperty "io.vantiq.camel.test.jiraJql",
+            rootProject.findProperty("io.vantiq.camel.test.jiraJql") ?: "empty"
+    }
+    if (rootProject.hasProperty("io.vantiq.camel.test.jiraUrl")) {
+        systemProperty "io.vantiq.camel.test.jiraUrl",
+            rootProject.findProperty("io.vantiq.camel.test.jiraUrl") ?: "empty"
+    }
 }
 
 test {

--- a/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelResolver.java
+++ b/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelResolver.java
@@ -18,6 +18,8 @@ import org.apache.ivy.core.module.descriptor.DefaultDependencyArtifactDescriptor
 import org.apache.ivy.core.module.descriptor.DefaultDependencyDescriptor;
 import org.apache.ivy.core.module.descriptor.DefaultModuleDescriptor;
 import org.apache.ivy.core.module.descriptor.DependencyArtifactDescriptor;
+import org.apache.ivy.core.module.descriptor.DependencyDescriptorMediator;
+import org.apache.ivy.core.module.id.ModuleId;
 import org.apache.ivy.core.module.id.ModuleRevisionId;
 import org.apache.ivy.core.report.ArtifactDownloadReport;
 import org.apache.ivy.core.report.ResolveReport;
@@ -25,6 +27,8 @@ import org.apache.ivy.core.resolve.ResolveOptions;
 import org.apache.ivy.core.retrieve.RetrieveOptions;
 import org.apache.ivy.core.retrieve.RetrieveReport;
 import org.apache.ivy.core.settings.IvySettings;
+import org.apache.ivy.plugins.matcher.ExactPatternMatcher;
+import org.apache.ivy.plugins.namespace.NamespaceTransformer;
 import org.apache.ivy.plugins.resolver.ChainResolver;
 import org.apache.ivy.plugins.resolver.IBiblioResolver;
 import org.apache.ivy.util.DefaultMessageLogger;
@@ -38,7 +42,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 @Slf4j
 public class CamelResolver {
@@ -55,6 +58,7 @@ public class CamelResolver {
     
     private static int unnamedResolverCount = 0;
     private static final String DEFAULT_CONFIGURATION = "default";
+    private static final String ANY_CONFIGURATION = "*";
     
     private static final Map<String, String> typeOverrides = Map.of(
             "com.atlassian.sal:sal-api:4.4.2", "jar"
@@ -93,7 +97,7 @@ public class CamelResolver {
             // Disable voluminous Ivy output that's not really helpful.
             Message.setDefaultLogger(new DefaultMessageLogger(Message.MSG_WARN));
         } else {
-            // Disable voluminous Ivy output that's not really helpful.
+            // Turn on voluminous Ivy output in trace case....
             Message.setDefaultLogger(new DefaultMessageLogger(Message.MSG_VERBOSE));
         }
         //creates clear ivy settings
@@ -112,7 +116,7 @@ public class CamelResolver {
                     aResolver.setRoot(repoUrl);
                     aResolver.setName(name + "::" + repoUrl);
                 } catch (MalformedURLException mue) {
-                    throw new IllegalArgumentException("Malformed repos URL: " + repo.toString(), mue);
+                    throw new IllegalArgumentException("Malformed repos URL: " + repo, mue);
                 }
                 
                 aResolver.setM2compatible(true);
@@ -153,8 +157,9 @@ public class CamelResolver {
         if (!log.isTraceEnabled()) {
             // Reduce the volume of output from Ivy unless we really need/want it.
             retrieveOptions.setLog(LogOptions.LOG_QUIET);
+        } else {
+            retrieveOptions.setLog(LogOptions.LOG_DEFAULT);
         }
-    
         //creates an Ivy instance with settings
         ivy = Ivy.newInstance(ivySettings);
     }
@@ -205,36 +210,94 @@ public class CamelResolver {
                                                                          false,
                                                                          false,
                                                                          true);
-        dd.addDependencyConfiguration("default", "default");
-        if (type == null) {
-            log.trace(">>>> Checking for artifact type override for {}:{}:{}", organization, name, revision);
-            String key = String.join(":", organization, name, revision);
-            String newType = typeOverrides.get(key);
-            if (newType != null) {
-                log.debug("Adding artifact type for {}:{}:{} :: {}", organization, name, revision, type);
-                type = newType;
-            }
-        }
+        dd.addDependencyConfiguration(DEFAULT_CONFIGURATION, ANY_CONFIGURATION);
+
         if (type != null) {
-            // If we have a type specified, make sure that that's the artifact we get.
             Artifact typedArtifact = new DefaultArtifact(ModuleRevisionId.newInstance(organization, name, revision),
                                                          null, name, type, "." + type);
-            log.debug("Adding type-specific artifact for {}:{}:{} :: {}", organization, name, revision, type);
+            log.debug(">>>> Specifying artifact for {}:{}", name, type);
             DependencyArtifactDescriptor dad =
                     new DefaultDependencyArtifactDescriptor(dd, name, type, type, null, null);
             dd.addDependencyArtifact(DEFAULT_CONFIGURATION, dad);
             md.addArtifact(DEFAULT_CONFIGURATION, typedArtifact);
         }
         md.addDependency(dd);
-        log.trace("Resolving required libraries -- {}", purpose);
-        //init resolve report
+        
+        // There are some dependencies that don't seem to resolve correctly, at least with our implementation.  To
+        // counter this, we track a set of places where we need to override the type provided by the maven repo.
+        // This situation typically arises when the artifact in question specifies a packaging attribute for some
+        // configurations, and the configuration for which we're locking qualifies.  To manage this, we'll add a
+        // DependencyDescriptorMediator (via the lambda below) which, when it sees the dependency specified in the
+        // typeOverrides list, will add a DependencyArtifact to force the downloading of th correct type/extension.
+        // these adjustments allow us to include having to special case lots of stuff in the kamelet/assembly
+        // specifications.  It also will provide the same functions if users configure their own camelConnectors that
+        // encounter these situations.
+        
+        typeOverrides.forEach( (src, newType) -> {
+            String[] parts = src.split(":");
+            DependencyDescriptorMediator ddm = dependencyDescriptor -> {
+                String targetOrg = dependencyDescriptor.getDependencyRevisionId().getOrganisation();
+                String targetName = dependencyDescriptor.getDependencyRevisionId().getName();
+                String targetRev = dependencyDescriptor.getDependencyRevisionId().getRevision();
+                log.trace("CamelConn mediator called with {}:{}:{}", targetOrg, targetName, targetRev);
+                // We should get called only with the correct set, but I have seen things behave differently, so
+                // better to be safe.  So here we check that the passed-in dependency (target*) match the type
+                // overrides for which this DependencyDescriptorMediator is being constructed.
+                if (parts[0].equals(targetOrg) && parts[1].equals(targetName) && parts[2].equals(targetRev)) {
+                    log.trace(">>>> Specifying artifact for {}:{}:{}:{}", targetOrg, targetName, targetRev,
+                              newType);
+                    DependencyArtifactDescriptor dad =
+                            new DefaultDependencyArtifactDescriptor(dependencyDescriptor, targetName, newType,
+                                                                    newType, null, null);
+                    if (dependencyDescriptor instanceof DefaultDependencyDescriptor) {
+                        // PomModuleDescriptorBuilder.PomDependencyDescriptor is based on
+                        // DefaultDependencyDescriptor so this covers that case as well.
+                        
+                        // In this case, just update the existing dependency
+                        ((DefaultDependencyDescriptor)
+                                dependencyDescriptor).addDependencyArtifact(ANY_CONFIGURATION, dad);
+                    } else {
+                        log.error("Unexpected DependencyDescriptor class: {}.  Attempting to reconstruct descriptor " +
+                                          "for {}:{}:{}:{}",
+                                  dependencyDescriptor.getClass().getName(), targetOrg, targetName, targetRev, newType);
+                        NamespaceTransformer identityTransformer = new NamespaceTransformer() {
+                            public ModuleRevisionId transform(ModuleRevisionId ourMrid) {
+                                return ourMrid;
+                            }
+                            public boolean isIdentity() {
+                                return true;
+                            }
+                        };
+                        DefaultDependencyDescriptor ddRecon =
+                                DefaultDependencyDescriptor.transformInstance(
+                                        dependencyDescriptor, identityTransformer, false);
+                        DependencyArtifactDescriptor dadRecon =
+                                new DefaultDependencyArtifactDescriptor(ddRecon, targetName, newType,
+                                                                        newType, null, null);
+
+                        ddRecon.addDependencyArtifact(ANY_CONFIGURATION, dadRecon);
+                        return ddRecon;
+                    }
+                    return dependencyDescriptor;
+                } else {
+                    log.trace("Ignoring mediation for {}:{}:{}", targetOrg, targetName, targetRev);
+                }
+                return dependencyDescriptor;
+            };
+            // For each typed override, add a mediator to "fix it up" as required.
+            log.debug("Adding mediator for {}:{}", parts[0], parts[1]);
+            md.addDependencyDescriptorMediator(new ModuleId(parts[0], parts[1]),
+                                               ExactPatternMatcher.INSTANCE, ddm);
+        });
+        log.info("Resolving required libraries -- {}. This may take a while.", purpose);
+
         ResolveReport report = ivy.resolve(md, resolveOptions);
         
-        if (!loadErrorsAcceptable(report)) {
+        if (report.hasError()) {
+            // If we get errors, notify our users and fail.
             throw new ResolutionException(identity() + ": Error(s) encountered during resolution: " +
                                                   String.join(", ", report.getAllProblemMessages()));
         }
-        
         if (log.isTraceEnabled()) {
             // do long-winded report only when requested
             ArtifactDownloadReport[] reps = report.getAllArtifactsReports();
@@ -267,31 +330,5 @@ public class CamelResolver {
         }
         log.trace("{} -- Making {} artifacts available to {}", identity(), necessaryFiles.size(), purpose);
         return necessaryFiles;
-    }
-
-    // Verify that all the errors in the list are contained in our list of type overrides. Every element in the error
-    // report must be resolved via that override list.
-    private boolean loadErrorsAcceptable(ResolveReport report) {
-        if (report.hasError()) {
-            List<String> errs = report.getAllProblemMessages();
-            AtomicBoolean okError = new AtomicBoolean(true); // OK until proven otherwise
-            errs.forEach( (err) -> {
-                boolean foundOKError = false;
-                for (String key: typeOverrides.keySet()) {
-                    String[] parts = key.split(":");
-                    String goodIndicator = parts[0] + "#" + parts[1] + ";" + parts[2];
-                    foundOKError = err.contains(goodIndicator);
-                    if (foundOKError) {
-                        log.warn("Resolution issues ignored for {} due to expected resolution.", key);
-                        break;
-                    }
-                }
-                if (!foundOKError) {
-                    okError.set(false);
-                }
-            });
-            return okError.get();
-        }
-        return true;
     }
 }

--- a/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelRunner.java
+++ b/camelConnector/src/main/java/io/vantiq/extsrc/camelconn/discover/CamelRunner.java
@@ -9,6 +9,7 @@
 package io.vantiq.extsrc.camelconn.discover;
 
 import io.vantiq.extsrc.camel.HeaderDuplicationBean;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Component;
@@ -76,6 +77,7 @@ public class CamelRunner extends MainSupport implements Closeable {
     private Thread camelThread;
     
     private Boolean startupCompleted = false;
+    @Getter
     private Exception startupFailed = null;
     private final static String startupSync = "startupSync";
     
@@ -284,7 +286,7 @@ public class CamelRunner extends MainSupport implements Closeable {
                 // We could learn to ignore it & let camel throw the error, but our throwing the ResolutionException
                 // seems cleaner.  Notify about the problems closer to the source.
                 Collection<File> resolved = cr.resolve("org.apache.camel", lib, getCamelContext().getVersion(),
-                                                       "Component Resolution");
+                                                       "Discovered Component Resolution");
                 jarSet.addAll(resolved);
             }
     
@@ -299,7 +301,7 @@ public class CamelRunner extends MainSupport implements Closeable {
                 // We could learn to ignore it & let camel throw the error, but our throwing the ResolutionException
                 // seems cleaner.  Notify about the problems closer to the source.
                 Collection<File> resolved = cr.resolve("org.apache.camel", lib, getCamelContext().getVersion(),
-                                                       "Dataformat Resolution");
+                                                       "Discovered Dataformat Resolution");
                 jarSet.addAll(resolved);
             }
         }
@@ -325,7 +327,7 @@ public class CamelRunner extends MainSupport implements Closeable {
                 // We could learn to ignore it & let camel throw the error, but our throwing the ResolutionException
                 // seems cleaner.  Notify about the problems closer to the source.
                 Collection<File> resolved = cr.resolve(compParts[0], compParts[1], compParts[2],
-                                                       "Additional Library Resolution");
+                                                       "Additional Library Resolution: " + comp);
                 jarSet.addAll(resolved);
             }
         }
@@ -507,6 +509,7 @@ public class CamelRunner extends MainSupport implements Closeable {
             super.beforeStart();
         } catch (Exception e) {
             log.error("Failed in beforeStart(): ", e);
+            doFail(e);
             throw e;
         }
     }
@@ -634,6 +637,13 @@ public class CamelRunner extends MainSupport implements Closeable {
         log.error("Camel startup has failed due to: ", e);
         notifyStarted();
         super.doFail(e);
+    }
+    
+    public boolean isFailed() {
+        if (startupFailed != null) {
+            return true;
+        }
+        return false;
     }
     
     @Override

--- a/camelConnector/src/main/resources/assembly/camelconnector/projects/com.vantiq.extsrc.camelconn.camelConnector.json
+++ b/camelConnector/src/main/resources/assembly/camelconnector/projects/com.vantiq.extsrc.camelconn.camelConnector.json
@@ -107,7 +107,7 @@
         "type" : "String"
       },
       "connectorImageTag" : {
-        "default": "1.4.1",
+        "default": "1.4.2",
         "description" : "The image tag used to pull the Camel Connector image.  Generally, no need to change this. Ignore if not running in Kubernetes.",
         "type" : "String"
       }

--- a/camelConnector/src/main/resources/assembly/camelconnector/projects/com.vantiq.extsrc.camelconn.camelConnector.json
+++ b/camelConnector/src/main/resources/assembly/camelconnector/projects/com.vantiq.extsrc.camelconn.camelConnector.json
@@ -107,7 +107,7 @@
         "type" : "String"
       },
       "connectorImageTag" : {
-        "default": "1.3.2",
+        "default": "1.4.1",
         "description" : "The image tag used to pull the Camel Connector image.  Generally, no need to change this. Ignore if not running in Kubernetes.",
         "type" : "String"
       }

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentResolverTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentResolverTest.java
@@ -309,15 +309,8 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
         assertNotNull("No routebuilder", rb);
         setUseRouteBuilder(false);
         List<URI> repoList = new ArrayList<>();
-        // Still getting Error(s) encountered during resolution: download failed: com.atlassian.sal#sal-api;4.4.2!sal-api.atlassian-plugin
-        // Maybe plugin went away?  Can we avoid loading it? Seems to load anyway.  Have placed work around in
-        // CamelResolver which will look for this in the error & ignore it if present. This seems to be sufficient to
-        // get things going.  Apparent1y, there's an issue with the jira component. Without the extra library, we get
-        // other things not found as well, including, but not limited to:
-        //    	  -- artifact com.atlassian.sal#sal-api;4.4.2!sal-api.jar
-        //        -- artifact com.atlassian.jira#jira-rest-java-client-api;5.2.4!jira-rest-java-client-api.jar
-        //        -- artifact com.atlassian.jira#jira-rest-java-client-core;5.2.4!jira-rest-java-client-core.jar
-    
+        
+        // Routes using the JIRA component require an additional repo from which to fetch their dependencies.
         // As per https://developer.atlassian.com/server/framework/atlassian-sdk/atlassian-maven-repositories-2818705/,
         // the following is the official atlassian proxy for their public repos.  Without this
         repoList.add(new URI("https://packages.atlassian.com/mvn/maven-external/"));

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentResolverTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentResolverTest.java
@@ -312,7 +312,8 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
         
         // Routes using the JIRA component require an additional repo from which to fetch their dependencies.
         // As per https://developer.atlassian.com/server/framework/atlassian-sdk/atlassian-maven-repositories-2818705/,
-        // the following is the official atlassian proxy for their public repos.  Without this
+        // the following is the official atlassian proxy for their public repos. Without this, we end up with a
+        // number of unresolved dependencies, and things tend not to go well.
         repoList.add(new URI("https://packages.atlassian.com/mvn/maven-external/"));
         repoList.add(new URI("https://repo.maven.apache.org/maven2/"));
         // The following seems to be an old version of the address, but leaving it here in case we need it.


### PR DESCRIPTION
When working with the collection of JIRA assemblies and components, there were a couple of issues:

1. The JIRA component's dependencies could not be loaded.
2. Once that was resolved, an issue with the one of those dependencies remained.

The component's dependencies general issue is because those components are not located in the central maven repo -- they are located in an Atlassian-specific repo.  As it turns out, the connector already supports adding additional repositories.  The change represented in this PR adds the ability to manually add a _source override_ -- a file that we use while producing the assembly that contains the additional repository (-ies) required.  This implementation is not specific to the JIRA assemblies; we can use it wherever required.

The specific dependency issue appears to be a packaging issue. The sal-api is packaged as a plugin, but the repo that holds it doesn't load that type (it's just a `.jar` file).  To remedy this, we add a set of known file type overrides the the connector code, and add a mediator (Ivy term) to detect any attempt to load this code and override the artifact file type/extension.  It took a while to sort out how all this works, but making those _mediations_ solved the problem.  (Note: this is the same type of thing that's done in, say, _gradle_ to handle changes in revision based on other dependencies or `build.gradle` dependency specifications.)

Added a test to verify this case to the resolver test suite.