### PR TITLE
Update dependencies & clean up the test output

### DIFF
--- a/extpsdk/build.gradle
+++ b/extpsdk/build.gradle
@@ -55,8 +55,8 @@ python {
     // copy virtualenv instead of symlink (when created)
     envCopy = false
 
-    pip 'pip:23.3.1'
-    pip 'pip-tools:7.3.0' // Bootstrap issue -- need this installed for the build
+    pip 'pip:24.0'
+    pip 'pip-tools:7.4.1' // Bootstrap issue -- need this installed for the build
 }
 
 task pytest(type: PythonTask) {

--- a/extpsdk/build.gradle
+++ b/extpsdk/build.gradle
@@ -11,7 +11,7 @@ ext {
         pypi_repo = 'testpypi'
     }
     if (!project.rootProject.hasProperty('vantiqConnectorSdkVersion')) {
-        vantiqConnectorSdkVersion = '1.2.1'
+        vantiqConnectorSdkVersion = '1.2.2'
     }
 }
 

--- a/extpsdk/pytest.ini
+++ b/extpsdk/pytest.ini
@@ -1,5 +1,7 @@
 # pytest.ini
 [pytest]
+filterwarnings =
+    ignore:There is no current event loop:DeprecationWarning
 junit_logging = all
 junit_suite_name=io.vantiq.extsrc.extpsdk
 minversion = 6.0

--- a/extpsdk/requirements-build.in
+++ b/extpsdk/requirements-build.in
@@ -1,10 +1,13 @@
 # For testing
 pytest>=7.4.3
 pytest-html>=4.1.1
-pytest-asyncio>=0.21.1
+pytest-asyncio>=0.23.6
 pytest-timeout
 aiofiles
 aioresponses>=0.7.6
+
+# Dependabot Fix
+jinja2>=3.1.3
 
 # For build
 pip-tools

--- a/extpsdk/requirements.txt
+++ b/extpsdk/requirements.txt
@@ -18,7 +18,7 @@ async-timeout==4.0.3
     # via aiohttp
 attrs==21.4.0
     # via aiohttp
-build==0.7.0
+build==1.1.1
     # via
     #   -r requirements-build.in
     #   pip-tools
@@ -48,8 +48,10 @@ iniconfig==1.1.1
     # via pytest
 jaraco-classes==3.3.0
     # via keyring
-jinja2==3.1.2
-    # via pytest-html
+jinja2==3.1.3
+    # via
+    #   -r requirements-build.in
+    #   pytest-html
 jprops==2.0.2
     # via -r requirements-sdk.in
 keyring==24.3.0
@@ -72,8 +74,6 @@ packaging==21.3
     # via
     #   build
     #   pytest
-pep517==0.13.1
-    # via build
 pip==23.3.1
     # via pip-tools
 pip-tools==7.3.0
@@ -88,6 +88,8 @@ pygments==2.17.2
     #   rich
 pyparsing==3.0.7
     # via packaging
+pyproject-hooks==1.0.0
+    # via build
 pytest==7.4.3
     # via
     #   -r requirements-build.in
@@ -95,7 +97,7 @@ pytest==7.4.3
     #   pytest-html
     #   pytest-metadata
     #   pytest-timeout
-pytest-asyncio==0.21.1
+pytest-asyncio==0.23.6
     # via -r requirements-build.in
 pytest-html==4.1.1
     # via -r requirements-build.in
@@ -120,8 +122,8 @@ setuptools==65.5.1
 tomli==2.0.1
     # via
     #   build
-    #   pep517
     #   pip-tools
+    #   pyproject-hooks
     #   pytest
 twine==4.0.2
     # via -r requirements-build.in

--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -16,7 +16,7 @@ ext {
     }
     // If these change, update requirements-conn.in as well -- as that's used to generate the requirements.txt file
     vantiqSdkVersion = '1.2.2'
-    vantiqConnectorSdkVersion = '1.2.1'
+    vantiqConnectorSdkVersion = '1.2.2'
 }
 
 python {

--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -59,8 +59,8 @@ python {
     // copy virtualenv instead of symlink (when created)
     envCopy = false
 
-    pip 'pip:23.3.1'
-    pip 'pip-tools:7.3.0'
+    pip 'pip:24.0'
+    pip 'pip-tools:7.4.1'
 }
 
 tasks.withType(PythonTask) {

--- a/pythonExecSource/pytest.ini
+++ b/pythonExecSource/pytest.ini
@@ -1,5 +1,7 @@
 # pytest.ini
 [pytest]
+filterwarnings =
+    ignore:There is no current event loop:DeprecationWarning
 minversion = 6.0
 addopts = -rE -q --html=./build/reports/tests/test/index.html --junit-xml=./build/test-results/test/TEST-io.vantiq.pyexecsource.pytest.xml
 asyncio_mode = strict

--- a/pythonExecSource/requirements-build.in
+++ b/pythonExecSource/requirements-build.in
@@ -1,11 +1,14 @@
 # For testing
 pytest>=7.4.3
 pytest-html>=4.1.1
-pytest-asyncio>=0.21.1
+pytest-asyncio>=0.23.6
 pytest-timeout
 aiofiles
 aioresponses>=0.7.6
 codetiming
+
+# Dependabot fix
+jinja2>=3.1.3
 
 # For build
 pip-tools

--- a/pythonExecSource/requirements-conn.in
+++ b/pythonExecSource/requirements-conn.in
@@ -1,5 +1,5 @@
 websockets>=12.0
 aiohttp>=3.9.2
 urllib3>=2.0.7
-vantiqconnectorsdk>=1.2.1
+vantiqconnectorsdk>=1.2.2
 vantiqsdk>=1.2.2

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -19,7 +19,7 @@ async-timeout==4.0.3
     # via aiohttp
 attrs==23.1.0
     # via aiohttp
-build==1.0.3
+build==1.1.1
     # via
     #   -r requirements-build.in
     #   pip-tools
@@ -51,8 +51,10 @@ iniconfig==2.0.0
     # via pytest
 jaraco-classes==3.3.0
     # via keyring
-jinja2==3.1.2
-    # via pytest-html
+jinja2==3.1.3
+    # via
+    #   -r requirements-build.in
+    #   pytest-html
 jprops==2.0.2
     # via vantiqconnectorsdk
 keyring==24.3.0
@@ -96,7 +98,7 @@ pytest==7.4.3
     #   pytest-html
     #   pytest-metadata
     #   pytest-timeout
-pytest-asyncio==0.23.0b0
+pytest-asyncio==0.23.6
     # via -r requirements-build.in
 pytest-html==4.1.1
     # via -r requirements-build.in

--- a/pythonExecSource/src/test/python/test_PyExecConnectorLive.py
+++ b/pythonExecSource/src/test/python/test_PyExecConnectorLive.py
@@ -559,6 +559,11 @@ class TestLiveConnection:
             if connectors is not None:
                 await connectors.connector_set.close()
 
+        if isinstance(self.vantiq_connection, Vantiq):
+            # close connection to avoid spurious warnings from the test framework.
+            # Good code hygiene to do the close anyway
+            await self.vantiq_connection.close()
+
     @staticmethod
     def check_test_conditions():
         if _server_url is None or _access_token is None or (_username is None and _password is None):


### PR DESCRIPTION
Updated dependencies to pacify dependabot.  While there, updated a few others so the build stops whining about things.

Fixed issue where tests often complained about writing to closed sessions.  Not really an issue, but made it hard to see real issues. Also, silenced deprecation warning down in pytest-asyncio.

Updated connector SDK version.  Once this is approved & tests pass, I'll push that to pypi & update the pythonExecSource as well.  It's a two step process...