### PR TITLE
Update pypi metadata to reflect current dependencies

### DIFF
--- a/extpsdk/build.gradle
+++ b/extpsdk/build.gradle
@@ -11,7 +11,7 @@ ext {
         pypi_repo = 'testpypi'
     }
     if (!project.rootProject.hasProperty('vantiqConnectorSdkVersion')) {
-        vantiqConnectorSdkVersion = '1.2.2'
+        vantiqConnectorSdkVersion = '1.2.3'
     }
 }
 

--- a/extpsdk/src/main/templates/setup.cfg.tmpl
+++ b/extpsdk/src/main/templates/setup.cfg.tmpl
@@ -10,14 +10,14 @@ author_email = fcarter@vantiq.com
 license= MIT
 classifiers =
     License :: OSI Approved :: MIT License
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 
 [options]
 package_dir = =src/main/python
 py_modules = vantiqconnectorsdk
-python_requires = >=3.8
+python_requires = >=3.10
 install_requires=
     websockets>=11.0.3
     jprops>=2.0.2

--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -12,11 +12,11 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('pyExecSrcVersion')) {
-        pyExecSrcVersion = '1.2.1'
+        pyExecSrcVersion = '1.2.3'
     }
     // If these change, update requirements-conn.in as well -- as that's used to generate the requirements.txt file
     vantiqSdkVersion = '1.2.2'
-    vantiqConnectorSdkVersion = '1.2.2'
+    vantiqConnectorSdkVersion = '1.2.3'
 }
 
 python {

--- a/pythonExecSource/requirements-conn.in
+++ b/pythonExecSource/requirements-conn.in
@@ -1,5 +1,5 @@
 websockets>=12.0
 aiohttp>=3.9.2
 urllib3>=2.0.7
-vantiqconnectorsdk>=1.2.2
+vantiqconnectorsdk>=1.2.3
 vantiqsdk>=1.2.2

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -133,7 +133,7 @@ urllib3==2.1.0
     #   -r requirements-conn.in
     #   requests
     #   twine
-vantiqconnectorsdk==1.2.1
+vantiqconnectorsdk==1.2.3
     # via -r requirements-conn.in
 vantiqsdk==1.2.2
     # via -r requirements-conn.in

--- a/pythonExecSource/src/main/templates/setup.cfg.tmpl
+++ b/pythonExecSource/src/main/templates/setup.cfg.tmpl
@@ -10,14 +10,14 @@ author_email = fcarter@vantiq.com
 license= MIT
 classifiers =
     License :: OSI Approved :: MIT License
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 
 [options]
 package_dir = =src/main/python
 py_modules = pyExecConnector
-python_requires = >=3.8
+python_requires = >=3.10
 install_requires=
     aiohttp>=3.8
     websockets>=10.2


### PR DESCRIPTION
Really only supporting 3.10, so make that clear.  Update versions  for publication