### PR TITLE
Update IDNA version to fix moderate security warnings

### DIFF
--- a/extpsdk/build.gradle
+++ b/extpsdk/build.gradle
@@ -11,7 +11,7 @@ ext {
         pypi_repo = 'testpypi'
     }
     if (!project.rootProject.hasProperty('vantiqConnectorSdkVersion')) {
-        vantiqConnectorSdkVersion = '1.2.4'
+        vantiqConnectorSdkVersion = '1.2.5'
     }
 }
 

--- a/extpsdk/build.gradle
+++ b/extpsdk/build.gradle
@@ -11,7 +11,7 @@ ext {
         pypi_repo = 'testpypi'
     }
     if (!project.rootProject.hasProperty('vantiqConnectorSdkVersion')) {
-        vantiqConnectorSdkVersion = '1.2.3'
+        vantiqConnectorSdkVersion = '1.2.4'
     }
 }
 

--- a/extpsdk/requirements.txt
+++ b/extpsdk/requirements.txt
@@ -44,7 +44,7 @@ importlib-metadata==6.8.0
     # via
     #   keyring
     #   twine
-iniconfig==1.1.1
+iniconfig==2.0.0
     # via pytest
 jaraco-classes==3.3.0
     # via keyring
@@ -80,7 +80,7 @@ pip-tools==7.3.0
     # via -r requirements-build.in
 pkginfo==1.9.6
     # via twine
-pluggy==1.0.0
+pluggy==1.3.0
     # via pytest
 pygments==2.17.2
     # via
@@ -103,7 +103,7 @@ pytest-html==4.1.1
     # via -r requirements-build.in
 pytest-metadata==3.0.0
     # via pytest-html
-pytest-timeout==2.1.0
+pytest-timeout==2.2.0
     # via -r requirements-build.in
 readme-renderer==42.0
     # via twine
@@ -117,7 +117,7 @@ rfc3986==2.0.0
     # via twine
 rich==13.7.0
     # via twine
-setuptools==65.5.1
+setuptools==69.0.2
     # via pip-tools
 tomli==2.0.1
     # via
@@ -134,7 +134,7 @@ urllib3==2.1.0
     #   twine
 websockets==12.0
     # via -r requirements-sdk.in
-wheel==0.38.1
+wheel==0.42.0
     # via pip-tools
 yarl==1.9.3
     # via aiohttp

--- a/extpsdk/requirements.txt
+++ b/extpsdk/requirements.txt
@@ -36,7 +36,7 @@ frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
-idna==3.6
+idna==3.7
     # via
     #   requests
     #   yarl

--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -12,10 +12,10 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('pyExecSrcVersion')) {
-        pyExecSrcVersion = '1.2.3'
+        pyExecSrcVersion = '1.2.4'
     }
     // If these change, update requirements-conn.in as well -- as that's used to generate the requirements.txt file
-    vantiqSdkVersion = '1.2.2'
+    vantiqSdkVersion = '1.2.3'
     vantiqConnectorSdkVersion = '1.2.3'
 }
 

--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -16,7 +16,7 @@ ext {
     }
     // If these change, update requirements-conn.in as well -- as that's used to generate the requirements.txt file
     vantiqSdkVersion = '1.2.3'
-    vantiqConnectorSdkVersion = '1.2.3'
+    vantiqConnectorSdkVersion = '1.2.5'
 }
 
 python {

--- a/pythonExecSource/requirements-conn.in
+++ b/pythonExecSource/requirements-conn.in
@@ -1,5 +1,5 @@
 websockets>=12.0
 aiohttp>=3.9.2
 urllib3>=2.0.7
-vantiqconnectorsdk>=1.2.3
+vantiqconnectorsdk>=1.2.5
 vantiqsdk>=1.2.3

--- a/pythonExecSource/requirements-conn.in
+++ b/pythonExecSource/requirements-conn.in
@@ -2,4 +2,4 @@ websockets>=12.0
 aiohttp>=3.9.2
 urllib3>=2.0.7
 vantiqconnectorsdk>=1.2.3
-vantiqsdk>=1.2.2
+vantiqsdk>=1.2.3

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -73,7 +73,7 @@ multidict==6.0.4
     #   yarl
 nh3==0.2.14
     # via readme-renderer
-packaging==23.2
+packaging==21.3
     # via
     #   build
     #   pytest
@@ -89,6 +89,8 @@ pygments==2.17.2
     # via
     #   readme-renderer
     #   rich
+pyparsing==3.1.2
+    # via packaging
 pyproject-hooks==1.0.0
     # via build
 pytest==7.4.3
@@ -133,7 +135,7 @@ urllib3==2.1.0
     #   -r requirements-conn.in
     #   requests
     #   twine
-vantiqconnectorsdk==1.2.3
+vantiqconnectorsdk==1.2.5
     # via -r requirements-conn.in
 vantiqsdk==1.2.3
     # via -r requirements-conn.in

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -39,7 +39,7 @@ frozenlist==1.4.0
     # via
     #   aiohttp
     #   aiosignal
-idna==3.6
+idna==3.7
     # via
     #   requests
     #   yarl

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -135,7 +135,7 @@ urllib3==2.1.0
     #   twine
 vantiqconnectorsdk==1.2.3
     # via -r requirements-conn.in
-vantiqsdk==1.2.2
+vantiqsdk==1.2.3
     # via -r requirements-conn.in
 websockets==12.0
     # via


### PR DESCRIPTION
Fixes #473 

Fix dependabot warnings about idna 3.6

Also updates pypi version numbers (one more to go after merge & publication of connector SDK)