### PR TITLE
upgrade aiohttp for extpsdk

### DIFF
--- a/extpsdk/build.gradle
+++ b/extpsdk/build.gradle
@@ -11,7 +11,7 @@ ext {
         pypi_repo = 'testpypi'
     }
     if (!project.rootProject.hasProperty('vantiqConnectorSdkVersion')) {
-        vantiqConnectorSdkVersion = '1.2.5'
+        vantiqConnectorSdkVersion = '1.2.6'
     }
 }
 

--- a/extpsdk/requirements-sdk.in
+++ b/extpsdk/requirements-sdk.in
@@ -1,4 +1,4 @@
 websockets>=12.0
-aiohttp>=3.9.2
+aiohttp>=3.9.5
 urllib3>=2.0.7
 jprops>=2.0.2

--- a/extpsdk/requirements.txt
+++ b/extpsdk/requirements.txt
@@ -6,7 +6,7 @@
 #
 aiofiles==23.2.1
     # via -r requirements-build.in
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   -r requirements-sdk.in
     #   aioresponses

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -6,7 +6,7 @@
 #
 aiofiles==23.2.1
     # via -r requirements-build.in
-aiohttp==3.9.5
+aiohttp==3.9.3
     # via
     #   -r requirements-conn.in
     #   aioresponses

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -6,7 +6,7 @@
 #
 aiofiles==23.2.1
     # via -r requirements-build.in
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   -r requirements-conn.in
     #   aioresponses


### PR DESCRIPTION
Fixes #477

Will separate from pythonExecSource upgrade of aiohttp & vantiqsdk so that we can publish to pypi from master.  PythonExecSource uses the connector SDK, so there's a bit of a two step to be able to officially run tests, etc.