### PR TITLE
PythonExecSource: Bump aiohttp to 3.9.5, and catch up to vantiq sdk's

### DIFF
--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -12,11 +12,11 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('pyExecSrcVersion')) {
-        pyExecSrcVersion = '1.2.4'
+        pyExecSrcVersion = '1.2.5'
     }
     // If these change, update requirements-conn.in as well -- as that's used to generate the requirements.txt file
-    vantiqSdkVersion = '1.2.3'
-    vantiqConnectorSdkVersion = '1.2.5'
+    vantiqSdkVersion = '1.2.4'
+    vantiqConnectorSdkVersion = '1.2.6'
 }
 
 python {

--- a/pythonExecSource/requirements-conn.in
+++ b/pythonExecSource/requirements-conn.in
@@ -1,5 +1,5 @@
 websockets>=12.0
-aiohttp>=3.9.2
+aiohttp>=3.9.5
 urllib3>=2.0.7
-vantiqconnectorsdk>=1.2.5
-vantiqsdk>=1.2.3
+vantiqconnectorsdk>=1.2.6
+vantiqsdk>=1.2.4

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -6,7 +6,7 @@
 #
 aiofiles==23.2.1
     # via -r requirements-build.in
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   -r requirements-conn.in
     #   aioresponses
@@ -135,9 +135,9 @@ urllib3==2.1.0
     #   -r requirements-conn.in
     #   requests
     #   twine
-vantiqconnectorsdk==1.2.5
+vantiqconnectorsdk==1.2.6
     # via -r requirements-conn.in
-vantiqsdk==1.2.3
+vantiqsdk==1.2.4
     # via -r requirements-conn.in
 websockets==12.0
     # via


### PR DESCRIPTION
Fixes #479

AioHttp is dependabot warning.

Vantiq SDK's upgraded for analogous Dependabot warning (or our application thereof)