### PR TITLE
Fix DockerFile for camelconnector to fix newly reclassified to HIGH security issues

### DIFF
--- a/camelConnector/src/main/docker/Dockerfile
+++ b/camelConnector/src/main/docker/Dockerfile
@@ -1,4 +1,5 @@
 FROM amazoncorretto:11-alpine-jdk
+RUN apk update && apk add --upgrade libcrypto3 libssl3
 RUN mkdir /app
 ADD camelConnector.tar /app
 WORKDIR /app

--- a/camelConnector/src/main/resources/assembly/camelconnector/projects/com.vantiq.extsrc.camelconn.camelConnector.json
+++ b/camelConnector/src/main/resources/assembly/camelconnector/projects/com.vantiq.extsrc.camelconn.camelConnector.json
@@ -107,7 +107,7 @@
         "type" : "String"
       },
       "connectorImageTag" : {
-        "default": "1.4.2",
+        "default": "1.4.4",
         "description" : "The image tag used to pull the Camel Connector image.  Generally, no need to change this. Ignore if not running in Kubernetes.",
         "type" : "String"
       }


### PR DESCRIPTION
Fix quay.io security warnings.

Quite a number had crept in since last week's publication (or, more correctly, I think they were reclassified).

Anyway, add package upgrades for `libssl3` & `libcrypto3` to Dockerfile to correct these.

Upgrade version of resulting docker image to camel connector assembly defaults. (Skipping one patch number since that's the one with large number of HIGH security issues.)

Found when publishing new version.  Tracked & fixed, then published under unused tag to check.  Result:  Only 1 LOW warning (due to Camel version).