### PR TITLE
Upgrade ExtensionSource docker images to supported base image.

### DIFF
--- a/CSVSource/src/main/docker/Dockerfile
+++ b/CSVSource/src/main/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:11-jre-slim
+FROM amazoncorretto:11-alpine-jdk
+RUN apk update && apk add --upgrade libcrypto3 libssl3
 RUN mkdir /app
 ADD CSVSource.tar /app
 WORKDIR /app

--- a/EasyModbusSource/src/main/docker/Dockerfile
+++ b/EasyModbusSource/src/main/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:11-jre-slim
+FROM amazoncorretto:11-alpine-jdk
+RUN apk update && apk add --upgrade libcrypto3 libssl3
 RUN mkdir /app
 ADD EasyModbusSource.tar /app
 WORKDIR /app

--- a/camelAssemblies/build.gradle
+++ b/camelAssemblies/build.gradle
@@ -168,3 +168,8 @@ tasks.register('publishAssemblies') {
 importAssemblies.mustRunAfter( 'generateAssemblyResources' )
 publishAssemblies.mustRunAfter('importAssemblies')
 
+// This is not a connector so no connector image should be constructed or pushed.
+buildImages.onlyIf { false }
+buildConnectorImage.onlyIf { false }
+pushImages.onlyIf { false }
+pushConnectorImage.onlyIf { false }

--- a/camelComponent/build.gradle
+++ b/camelComponent/build.gradle
@@ -75,3 +75,8 @@ artifacts {
     testArtifacts testJar
 }
 
+// This is not a connector so no connector image should be constructed or pushed.
+buildImages.onlyIf { false }
+buildConnectorImage.onlyIf { false }
+pushImages.onlyIf { false }
+pushConnectorImage.onlyIf { false }

--- a/extjsdk/build.gradle
+++ b/extjsdk/build.gradle
@@ -101,3 +101,9 @@ task fatJar(type: Jar) {
                 findAll( { it.name.endsWith('jar') && !it.name.startsWith('groovy')}).
                 collect( { zipTree(it) })
 }
+
+// This is not a connector so no connector image should be constructed or pushed.
+buildImages.onlyIf { false }
+buildConnectorImage.onlyIf { false }
+pushImages.onlyIf { false }
+pushConnectorImage.onlyIf { false }

--- a/extpsdk/build.gradle
+++ b/extpsdk/build.gradle
@@ -129,3 +129,9 @@ tasks.matching { !it.name.startsWith('generate')
                     && it.name != 'clean' }.all { Task task ->
     task.mustRunAfter generateSetupCfg
 }
+
+// This is an SDK so no connector image should be constructed or pushed.
+buildImages.onlyIf { false }
+buildConnectorImage.onlyIf { false }
+pushImages.onlyIf { false }
+pushConnectorImage.onlyIf { false }

--- a/jdbcSource/src/main/docker/Dockerfile
+++ b/jdbcSource/src/main/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:11-jre-slim
+FROM amazoncorretto:11-alpine-jdk
+RUN apk update && apk add --upgrade libcrypto3 libssl3
 RUN mkdir /app
 ADD jdbcSource.tar /app
 WORKDIR /app

--- a/jmsSource/src/main/docker/Dockerfile
+++ b/jmsSource/src/main/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:11-jre-slim
+FROM amazoncorretto:11-alpine-jdk
+RUN apk update && apk add --upgrade libcrypto3 libssl3
 RUN mkdir /app
 ADD jmsSource.tar /app
 WORKDIR /app

--- a/objectRecognitionSource/src/main/docker/Dockerfile
+++ b/objectRecognitionSource/src/main/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:11-jre-slim
+FROM amazoncorretto:11-alpine-jdk
+RUN apk update && apk add --upgrade libcrypto3 libssl3
 RUN mkdir /app
 ADD objectRecognitionSource.tar /app
 WORKDIR /app

--- a/opcuaSource/src/main/docker/Dockerfile
+++ b/opcuaSource/src/main/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:11-jre-slim
+FROM amazoncorretto:11-alpine-jdk
+RUN apk update && apk add --upgrade libcrypto3 libssl3
 RUN mkdir /app
 ADD opcuaSource.tar /app
 WORKDIR /app

--- a/pythonExecSource/src/main/templates/Dockerfile.tmpl
+++ b/pythonExecSource/src/main/templates/Dockerfile.tmpl
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.8.13-slim-buster
+FROM python:3.12.3-slim
 RUN mkdir /app
 ENV PYTHONPATH /app
 RUN pip install --no-cache-dir --upgrade pip
-# The localRequirements.txt file is a requirements.txt formatted file specfiying any local package installations
+# The localRequirements.txt file is a requirements.txt formatted file specifying any local package installations
 # desired.  This may be necessary if, for example, the python code this connector may execute requires additional
 # python packages installed (e.g., tensorflow).
 #

--- a/testConnector/src/main/docker/Dockerfile
+++ b/testConnector/src/main/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:11-jre-slim
+FROM amazoncorretto:11-alpine-jdk
+RUN apk update && apk add --upgrade libcrypto3 libssl3
 RUN mkdir /app
 ADD testConnector.tar /app
 WORKDIR /app

--- a/udpSource/src/main/docker/Dockerfile
+++ b/udpSource/src/main/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:11-jre-slim
+FROM amazoncorretto:11-alpine-jdk
+RUN apk update && apk add --upgrade libcrypto3 libssl3
 RUN mkdir /app
 ADD udpSource.tar /app
 WORKDIR /app


### PR DESCRIPTION
Fixes #351 

Update base docker images to a supported one & update that image to avoid CVE warnings (as just done with CamelConnector dockerFile).

Also, as a convenience, update build.gradle's so that `buildImages` and/or `pushImages` (as well as their intermediaries) won't run since they aren't connectors & don't publish docker images.