### PR TITLE
Upgrade jinja2

### DIFF
--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -12,11 +12,11 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('pyExecSrcVersion')) {
-        pyExecSrcVersion = '1.2.6'
+        pyExecSrcVersion = '1.2.7'
     }
     // If these change, update requirements-conn.in as well -- as that's used to generate the requirements.txt file
-    vantiqPythonSdkVersion = '1.2.5'
-    vantiqConnectorSdkVersion = '1.2.6'
+    vantiqPythonSdkVersion = '1.2.6'
+    vantiqConnectorSdkVersion = '1.2.7'
 }
 
 python {

--- a/pythonExecSource/requirements-build.in
+++ b/pythonExecSource/requirements-build.in
@@ -8,7 +8,7 @@ aioresponses>=0.7.6
 codetiming
 
 # Dependabot fix
-jinja2>=3.1.3
+jinja2>=3.1.4
 
 # For build
 pip-tools

--- a/pythonExecSource/requirements-conn.in
+++ b/pythonExecSource/requirements-conn.in
@@ -1,5 +1,5 @@
 websockets>=12.0
 aiohttp>=3.9.5
 urllib3>=2.0.7
-vantiqconnectorsdk>=1.2.6
-vantiqsdk>=1.2.4
+vantiqconnectorsdk>=1.2.7
+vantiqsdk>=1.2.6

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -135,9 +135,9 @@ urllib3==2.1.0
     #   -r requirements-conn.in
     #   requests
     #   twine
-vantiqconnectorsdk==1.2.6
+vantiqconnectorsdk==1.2.7
     # via -r requirements-conn.in
-vantiqsdk==1.2.4
+vantiqsdk==1.2.6
     # via -r requirements-conn.in
 websockets==12.0
     # via

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -51,7 +51,7 @@ iniconfig==2.0.0
     # via pytest
 jaraco-classes==3.3.0
     # via keyring
-jinja2==3.1.3
+jinja2==3.1.4
     # via
     #   -r requirements-build.in
     #   pytest-html


### PR DESCRIPTION
Fix dependabot security warning.

(Done in two steps so we can publish extpsdk to pypi from master.  Just a formality, but...)