### PR TITLE
Fix requests-related CVE

### DIFF
--- a/extpsdk/build.gradle
+++ b/extpsdk/build.gradle
@@ -11,7 +11,7 @@ ext {
         pypi_repo = 'testpypi'
     }
     if (!project.rootProject.hasProperty('vantiqConnectorSdkVersion')) {
-        vantiqConnectorSdkVersion = '1.2.7'
+        vantiqConnectorSdkVersion = '1.2.8'
     }
 }
 

--- a/extpsdk/requirements-sdk.in
+++ b/extpsdk/requirements-sdk.in
@@ -2,3 +2,4 @@ websockets>=12.0
 aiohttp>=3.9.5
 urllib3>=2.0.7
 jprops>=2.0.2
+requests>=2.32.0

--- a/extpsdk/requirements.txt
+++ b/extpsdk/requirements.txt
@@ -107,8 +107,9 @@ pytest-timeout==2.2.0
     # via -r requirements-build.in
 readme-renderer==42.0
     # via twine
-requests==2.31.0
+requests==2.32.3
     # via
+    #   -r requirements-sdk.in
     #   requests-toolbelt
     #   twine
 requests-toolbelt==1.0.0


### PR DESCRIPTION
Fixes #489

Upgrade requests to newer version.  Deal with CVE.

Will be parallel change for python exec source.  Two-stepper so that we can push to pypi from master.