### PR TITLE
Update urllib3 for CVE fix

### DIFF
--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -12,11 +12,11 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('pyExecSrcVersion')) {
-        pyExecSrcVersion = '1.2.8'
+        pyExecSrcVersion = '1.2.9'
     }
     // If these change, update requirements-conn.in as well -- as that's used to generate the requirements.txt file
-    vantiqPythonSdkVersion = '1.3.2'
-    vantiqConnectorSdkVersion = '1.2.8'
+    vantiqPythonSdkVersion = '1.3.3'
+    vantiqConnectorSdkVersion = '1.2.9'
 }
 
 python {

--- a/pythonExecSource/requirements-conn.in
+++ b/pythonExecSource/requirements-conn.in
@@ -1,6 +1,5 @@
 websockets>=12.0
 aiohttp>=3.9.5
-urllib3>=2.0.7
-vantiqconnectorsdk>=1.2.8
-vantiqsdk>=1.3.2
+vantiqconnectorsdk>=1.2.9
+vantiqsdk>=1.3.3
 requests>=2.32.0

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -131,14 +131,13 @@ tomli==2.0.1
     #   pytest
 twine==4.0.2
     # via -r requirements-build.in
-urllib3==2.1.0
+urllib3==2.2.2
     # via
-    #   -r requirements-conn.in
     #   requests
     #   twine
-vantiqconnectorsdk==1.2.8
+vantiqconnectorsdk==1.2.9
     # via -r requirements-conn.in
-vantiqsdk==1.3.2
+vantiqsdk==1.3.3
     # via -r requirements-conn.in
 websockets==12.0
     # via


### PR DESCRIPTION
Fixes #495 

Update urllib3 & vantiq components.  These are for the pythonExecSource.  Multiple PRs so we can always publish from master.