### PR TITLE
Update certifi as per dependabot

### DIFF
--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -12,11 +12,11 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('pyExecSrcVersion')) {
-        pyExecSrcVersion = '1.2.9'
+        pyExecSrcVersion = '1.2.10'
     }
     // If these change, update requirements-conn.in as well -- as that's used to generate the requirements.txt file
-    vantiqPythonSdkVersion = '1.3.3'
-    vantiqConnectorSdkVersion = '1.2.9'
+    vantiqPythonSdkVersion = '1.3.4'
+    vantiqConnectorSdkVersion = '1.2.10'
 }
 
 python {

--- a/pythonExecSource/requirements-conn.in
+++ b/pythonExecSource/requirements-conn.in
@@ -1,5 +1,5 @@
 websockets>=12.0
 aiohttp>=3.9.5
-vantiqconnectorsdk>=1.2.9
-vantiqsdk>=1.3.3
+vantiqconnectorsdk>=1.2.10
+vantiqsdk>=1.3.4
 requests>=2.32.0

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -23,7 +23,7 @@ build==1.1.1
     # via
     #   -r requirements-build.in
     #   pip-tools
-certifi==2023.11.17
+certifi==2024.7.4
     # via requests
 charset-normalizer==3.3.2
     # via requests

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -135,9 +135,9 @@ urllib3==2.2.2
     # via
     #   requests
     #   twine
-vantiqconnectorsdk==1.2.9
+vantiqconnectorsdk==1.2.10
     # via -r requirements-conn.in
-vantiqsdk==1.3.3
+vantiqsdk==1.3.4
     # via -r requirements-conn.in
 websockets==12.0
     # via


### PR DESCRIPTION
Fixes #500 

Update version of certifi in use.

Update published versions.

Requires #501 as well as Vantiq/vantiq-python-sdk#48 to merge & publish before this is is merged.