### PR TITLE
Upgrade build-info-extractor to latest 4.x.y version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     dependencies {
         classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
         classpath 'com.netflix.nebula:gradle-ospackage-plugin:4.4.0'
-        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.4.15"
+        classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.33.10"
         classpath "gradle.plugin.com.github.lkishalmi.gradle:gradle-gatling-plugin:0.4.1"
     }
 }


### PR DESCRIPTION
Fixes #503

Old usage (build-info-extractor-gradle 4.4.15) fails to resolve `build-info-extractor 2.7.x` -- Maven claims it's there, but things fail to resolve for related versions

Upgraded to latest 4.x.y (4.33.10) and the world looks better.  No issues with the Jenkins build (which is what this is used for, I think).

No changes in actual code.