### PR TITLE
Extpsdk: Update dependencies

### DIFF
--- a/extpsdk/build.gradle
+++ b/extpsdk/build.gradle
@@ -11,7 +11,7 @@ ext {
         pypi_repo = 'testpypi'
     }
     if (!project.rootProject.hasProperty('vantiqConnectorSdkVersion')) {
-        vantiqConnectorSdkVersion = '1.2.10'
+        vantiqConnectorSdkVersion = '1.2.11'
     }
 }
 
@@ -55,7 +55,7 @@ python {
     // copy virtualenv instead of symlink (when created)
     envCopy = false
 
-    pip 'pip:24.0'
+    pip 'pip:24.2'
     pip 'pip-tools:7.4.1' // Bootstrap issue -- need this installed for the build
 }
 

--- a/extpsdk/requirements-build.in
+++ b/extpsdk/requirements-build.in
@@ -8,6 +8,8 @@ aioresponses>=0.7.6
 
 # Dependabot Fix
 jinja2>=3.1.4
+setuptools>=70.0.0
+zipp>=3.19.1
 
 # For build
 pip-tools

--- a/extpsdk/requirements-sdk.in
+++ b/extpsdk/requirements-sdk.in
@@ -1,4 +1,4 @@
 websockets>=12.0
-aiohttp>=3.9.5
+aiohttp>=3.10.2
 jprops>=2.0.2
-requests>=2.32.0
+requests>=2.32.3

--- a/extpsdk/requirements.txt
+++ b/extpsdk/requirements.txt
@@ -6,7 +6,9 @@
 #
 aiofiles==23.2.1
     # via -r requirements-build.in
-aiohttp==3.9.5
+aiohappyeyeballs==2.3.5
+    # via aiohttp
+aiohttp==3.10.2
     # via
     #   -r requirements-sdk.in
     #   aioresponses
@@ -16,7 +18,7 @@ aiosignal==1.3.1
     # via aiohttp
 async-timeout==4.0.3
     # via aiohttp
-attrs==21.4.0
+attrs==24.2.0
     # via aiohttp
 build==1.1.1
     # via
@@ -32,7 +34,7 @@ docutils==0.20.1
     # via readme-renderer
 exceptiongroup==1.2.0
     # via pytest
-frozenlist==1.4.0
+frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
@@ -64,7 +66,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.1.0
     # via jaraco-classes
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
@@ -118,8 +120,10 @@ rfc3986==2.0.0
     # via twine
 rich==13.7.0
     # via twine
-setuptools==69.0.2
-    # via pip-tools
+setuptools==72.1.0
+    # via
+    #   -r requirements-build.in
+    #   pip-tools
 tomli==2.0.1
     # via
     #   build
@@ -136,7 +140,9 @@ websockets==12.0
     # via -r requirements-sdk.in
 wheel==0.42.0
     # via pip-tools
-yarl==1.9.3
+yarl==1.9.4
     # via aiohttp
-zipp==3.17.0
-    # via importlib-metadata
+zipp==3.19.2
+    # via
+    #   -r requirements-build.in
+    #   importlib-metadata


### PR DESCRIPTION
Fixes #506 

Update dependencies as per CVE's, dependabot, git security, etc.

Separate from pythonExecSource since we want to push to pypi from master.  And pES depends on the python SDK (which this does not) & that analogous update isn't published yet.