### PR TITLE
PythonExecSource: Update Dependencies

### DIFF
--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -16,7 +16,7 @@ ext {
     }
     // If these change, update requirements-conn.in as well -- as that's used to generate the requirements.txt file
     vantiqPythonSdkVersion = '1.3.5'
-    vantiqConnectorSdkVersion = '1.2.10'
+    vantiqConnectorSdkVersion = '1.2.11'
 }
 
 python {

--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -12,10 +12,10 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('pyExecSrcVersion')) {
-        pyExecSrcVersion = '1.2.10'
+        pyExecSrcVersion = '1.2.11'
     }
     // If these change, update requirements-conn.in as well -- as that's used to generate the requirements.txt file
-    vantiqPythonSdkVersion = '1.3.4'
+    vantiqPythonSdkVersion = '1.3.5'
     vantiqConnectorSdkVersion = '1.2.10'
 }
 
@@ -59,7 +59,7 @@ python {
     // copy virtualenv instead of symlink (when created)
     envCopy = false
 
-    pip 'pip:24.0'
+    pip 'pip:24.2'
     pip 'pip-tools:7.4.1'
 }
 

--- a/pythonExecSource/requirements-build.in
+++ b/pythonExecSource/requirements-build.in
@@ -9,6 +9,8 @@ codetiming
 
 # Dependabot fix
 jinja2>=3.1.4
+setuptools>=70.0.0
+zipp>=3.19.1
 
 # For build
 pip-tools

--- a/pythonExecSource/requirements-conn.in
+++ b/pythonExecSource/requirements-conn.in
@@ -1,5 +1,5 @@
 websockets>=12.0
-aiohttp>=3.9.5
-vantiqconnectorsdk>=1.2.10
-vantiqsdk>=1.3.4
-requests>=2.32.0
+aiohttp>=3.10.2
+vantiqconnectorsdk>=1.2.11
+vantiqsdk>=1.3.5
+requests>=2.32.3

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -6,7 +6,9 @@
 #
 aiofiles==23.2.1
     # via -r requirements-build.in
-aiohttp==3.9.5
+aiohappyeyeballs==2.3.5
+    # via aiohttp
+aiohttp==3.10.2
     # via
     #   -r requirements-conn.in
     #   aioresponses
@@ -17,7 +19,7 @@ aiosignal==1.3.1
     # via aiohttp
 async-timeout==4.0.3
     # via aiohttp
-attrs==23.1.0
+attrs==24.2.0
     # via aiohttp
 build==1.1.1
     # via
@@ -35,7 +37,7 @@ docutils==0.20.1
     # via readme-renderer
 exceptiongroup==1.2.0
     # via pytest
-frozenlist==1.4.0
+frozenlist==1.4.1
     # via
     #   aiohttp
     #   aiosignal
@@ -67,7 +69,7 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.1.0
     # via jaraco-classes
-multidict==6.0.4
+multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
@@ -121,8 +123,10 @@ rfc3986==2.0.0
     # via twine
 rich==13.7.0
     # via twine
-setuptools==69.0.2
-    # via pip-tools
+setuptools==72.1.0
+    # via
+    #   -r requirements-build.in
+    #   pip-tools
 tomli==2.0.1
     # via
     #   build
@@ -135,9 +139,9 @@ urllib3==2.2.2
     # via
     #   requests
     #   twine
-vantiqconnectorsdk==1.2.10
+vantiqconnectorsdk==1.2.11
     # via -r requirements-conn.in
-vantiqsdk==1.3.4
+vantiqsdk==1.3.5
     # via -r requirements-conn.in
 websockets==12.0
     # via
@@ -146,7 +150,7 @@ websockets==12.0
     #   vantiqsdk
 wheel==0.42.0
     # via pip-tools
-yarl==1.9.3
+yarl==1.9.4
     # via aiohttp
-zipp==3.17.0
+zipp==3.19.2
     # via importlib-metadata


### PR DESCRIPTION
Fixes #507 

Update dependencies as per security warning, CVEs, dependabot, etc.

Will go in after #508 & vantiqsdk update since those publications necessary to build...