### PR TITLE
Upgrade code & environment for JDK 17.  But not using it yet.

### DIFF
--- a/CSVSource/src/main/java/io/vantiq/extsrc/CSVSource/CSVMain.java
+++ b/CSVSource/src/main/java/io/vantiq/extsrc/CSVSource/CSVMain.java
@@ -130,14 +130,14 @@ public class CSVMain {
             }
         }
         if (exitProcessor != null) {
-            exitProcessor.doExit(code);
+            exitProcessor.processExit(code);
         } else {
             System.exit(code);
         }
     }
     
-    interface ExitProcessor {
-        default void doExit(int code) {
+    public interface ExitProcessor {
+        default void processExit(int code) {
             System.exit(code);
         }
     }

--- a/CSVSource/src/main/java/io/vantiq/extsrc/CSVSource/CSVMain.java
+++ b/CSVSource/src/main/java/io/vantiq/extsrc/CSVSource/CSVMain.java
@@ -41,6 +41,8 @@ public class CSVMain {
     static final int NO_AUTH_EXIT = 1;
     static final int NO_SOURCE_EXIT = 2;
     static final int NO_SERVER_EXIT = 3;
+    
+    private static ExitProcessor exitProcessor = null;
 
     /**
      * Connects to the Vantiq source and starts polling for data. Exits when all sources are done running.
@@ -59,6 +61,10 @@ public class CSVMain {
         startSources(sources);
         
         // Can leave now because the threads created by the sources' WebSocket connections will keep the JVM alive
+    }
+    
+    public static void setExitProcessor(ExitProcessor ep) {
+        exitProcessor = ep;
     }
     
     /**
@@ -123,6 +129,16 @@ public class CSVMain {
                 source.stop();
             }
         }
-        System.exit(code);
+        if (exitProcessor != null) {
+            exitProcessor.doExit(code);
+        } else {
+            System.exit(code);
+        }
+    }
+    
+    interface ExitProcessor {
+        default void doExit(int code) {
+            System.exit(code);
+        }
     }
 }

--- a/CSVSource/src/test/java/io/vantiq/extsrc/CSVSource/TestCSVMain.java
+++ b/CSVSource/src/test/java/io/vantiq/extsrc/CSVSource/TestCSVMain.java
@@ -10,7 +10,6 @@ package io.vantiq.extsrc.CSVSource;
 
 import static org.junit.Assert.fail;
 
-import java.security.Permission;
 import java.util.List;
 import java.util.Properties;
 
@@ -22,13 +21,13 @@ public class TestCSVMain {
     
     @Before
     public void setup() {
-        System.setSecurityManager(new NoExit());
+        CSVMain.setExitProcessor(new NoExit());
     }
     
     @After
     public void tearDown() {
         List<CSVCore> sources = CSVMain.sources;
-        System.setSecurityManager(null);
+        CSVMain.setExitProcessor(null);
         if (sources != null) {
             for (CSVCore s : sources) {
                 s.stop();
@@ -105,16 +104,10 @@ public class TestCSVMain {
     
 // ================================================= Helper functions =================================================
     
-    private static class NoExit extends SecurityManager 
-    {
+    private static class NoExit implements CSVMain.ExitProcessor {
         @Override
-        public void checkPermission(Permission perm) {}
-        @Override
-        public void checkPermission(Permission perm, Object context) {}
-        @Override
-        public void checkExit(int status) 
+        public void doExit(int status)
         {
-            super.checkExit(status);
             if (status == 1) {
                 throw new ExitException("Exit Requested: auth token was not specified.");
             } else if (status == 2) {

--- a/CSVSource/src/test/java/io/vantiq/extsrc/CSVSource/TestCSVMain.java
+++ b/CSVSource/src/test/java/io/vantiq/extsrc/CSVSource/TestCSVMain.java
@@ -106,7 +106,7 @@ public class TestCSVMain {
     
     private static class NoExit implements CSVMain.ExitProcessor {
         @Override
-        public void doExit(int status)
+        public void processExit(int status)
         {
             if (status == 1) {
                 throw new ExitException("Exit Requested: auth token was not specified.");

--- a/CSVSource/src/test/java/io/vantiq/extsrc/CSVSource/TestCSVReader.java
+++ b/CSVSource/src/test/java/io/vantiq/extsrc/CSVSource/TestCSVReader.java
@@ -39,7 +39,6 @@ public class TestCSVReader extends TestCSVBase{
     @After
     public void tearDown() {
         List<CSVCore> sources = CSVMain.sources;
-        System.setSecurityManager(null);
         if (sources != null) {
             for (CSVCore s : sources) {
                 s.stop();

--- a/CSVSource/src/test/java/io/vantiq/extsrc/CSVSource/TestCSVReaderFixedLength.java
+++ b/CSVSource/src/test/java/io/vantiq/extsrc/CSVSource/TestCSVReaderFixedLength.java
@@ -38,7 +38,6 @@ public class TestCSVReaderFixedLength extends TestCSVConfigFixedLength {
     @After
     public void tearDown() {
         List<CSVCore> sources = CSVMain.sources;
-        System.setSecurityManager(null);
         if (sources != null) {
             for (CSVCore s : sources) {
                 s.stop();

--- a/EasyModbusSource/src/main/java/io/vantiq/extsrc/EasyModbusSource/EasyModbusMain.java
+++ b/EasyModbusSource/src/main/java/io/vantiq/extsrc/EasyModbusSource/EasyModbusMain.java
@@ -9,12 +9,8 @@
 package io.vantiq.extsrc.EasyModbusSource;
 
 import io.vantiq.extjsdk.Utils;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 import org.slf4j.Logger;
@@ -47,6 +43,7 @@ public class EasyModbusMain {
     static final int NO_SOURCE_EXIT = 2;
     static final int NO_SERVER_EXIT = 3;
 
+    private static ExitProcessor exitProcessor = null;
     /**
      * Connects to the Vantiq source and starts polling for data. Exits when all
      * sources are done running.
@@ -67,6 +64,10 @@ public class EasyModbusMain {
 
         // Can leave now because the threads created by the sources' WebSocket
         // connections will keep the JVM alive
+    }
+    
+    public static void setExitProcessor(ExitProcessor ep) {
+        exitProcessor = ep;
     }
 
     /**
@@ -136,6 +137,15 @@ public class EasyModbusMain {
                 source.stop();
             }
         }
+        if (exitProcessor != null) {
+            exitProcessor.processExit(code);
+        }
         System.exit(code);
+    }
+    
+    public interface ExitProcessor {
+        default void processExit(int code) {
+            System.exit(code);
+        }
     }
 }

--- a/EasyModbusSource/src/test/java/io/vantiq/extsrc/EasyModbusSource/TestEasyModbusMain.java
+++ b/EasyModbusSource/src/test/java/io/vantiq/extsrc/EasyModbusSource/TestEasyModbusMain.java
@@ -10,7 +10,6 @@ package io.vantiq.extsrc.EasyModbusSource;
 
 import static org.junit.Assert.fail;
 
-import java.security.Permission;
 import java.util.List;
 import java.util.Properties;
 
@@ -22,13 +21,13 @@ public class TestEasyModbusMain {
 
     @Before
     public void setup() {
-        System.setSecurityManager(new NoExit());
+        EasyModbusMain.setExitProcessor(new NoExit());
     }
 
     @After
     public void tearDown() {
         List<EasyModbusCore> sources = EasyModbusMain.sources;
-        System.setSecurityManager(null);
+        EasyModbusMain.setExitProcessor(null);
         if (sources != null) {
             for (EasyModbusCore s : sources) {
                 s.stop();
@@ -103,21 +102,11 @@ public class TestEasyModbusMain {
         s2.stop();
     }
 
-    // ================================================= Helper functions
-    // =================================================
+    // ================================================= Helper functions ==============================================
 
-    private static class NoExit extends SecurityManager {
+    private static class NoExit implements EasyModbusMain.ExitProcessor {
         @Override
-        public void checkPermission(Permission perm) {
-        }
-
-        @Override
-        public void checkPermission(Permission perm, Object context) {
-        }
-
-        @Override
-        public void checkExit(int status) {
-            super.checkExit(status);
+        public void processExit(int status) {
             if (status == 1) {
                 throw new ExitException("Exit Requested: auth token was not specified.");
             } else if (status == 2) {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,7 +1,6 @@
-
 plugins {
     id 'java'
-    id 'io.franzbecker.gradle-lombok' version '5.0.0'
+    id("io.freefair.lombok") version "6.3.0" // version "8.7.1"
 }
 
 repositories {
@@ -12,7 +11,7 @@ ext {
     apacheCommonsLangVersion = '3.12.0'
     jacksonVersion = '2.14.2'
     log4JVersion='2.17.2'
-    lombokVersion = '1.18.24'
+    lombokVersion = '1.18.26'
     slf4jApiVersion = '1.7.25'
 }
 

--- a/camelComponent/build.gradle
+++ b/camelComponent/build.gradle
@@ -48,7 +48,7 @@ group = 'io.vantiq.extsrc.camel'
 version = '1.0-SNAPSHOT'
 description = 'Camel Vantiq Component'
 java.sourceCompatibility = 1.11
-java.targetCompatibility = JavaVersion.VERSION_11
+java.targetCompatibility = JavaVersion.VERSION_17
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'

--- a/camelComponent/build.gradle
+++ b/camelComponent/build.gradle
@@ -48,7 +48,7 @@ group = 'io.vantiq.extsrc.camel'
 version = '1.0-SNAPSHOT'
 description = 'Camel Vantiq Component'
 java.sourceCompatibility = 1.11
-java.targetCompatibility = JavaVersion.VERSION_17
+java.targetCompatibility = JavaVersion.VERSION_11
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'

--- a/camelConnector/build.gradle
+++ b/camelConnector/build.gradle
@@ -100,7 +100,7 @@ group = 'io.vantiq.extsrc.camelconnector'
 version = 'unspecified'
 description = 'Vantiq Camel Connector'
 java.sourceCompatibility = 1.11
-java.targetCompatibility = JavaVersion.VERSION_11
+java.targetCompatibility = JavaVersion.VERSION_17
 
 /**
  * The following task builds an assembly project zip file to make the CAMEL source implementation type

--- a/camelConnector/build.gradle
+++ b/camelConnector/build.gradle
@@ -100,7 +100,7 @@ group = 'io.vantiq.extsrc.camelconnector'
 version = 'unspecified'
 description = 'Vantiq Camel Connector'
 java.sourceCompatibility = 1.11
-java.targetCompatibility = JavaVersion.VERSION_17
+java.targetCompatibility = JavaVersion.VERSION_11
 
 /**
  * The following task builds an assembly project zip file to make the CAMEL source implementation type

--- a/jdbcSource/build.gradle
+++ b/jdbcSource/build.gradle
@@ -1,10 +1,14 @@
+
+plugins {
+    id("io.freefair.lombok") version "6.3.0" // version "8.7.1"
+    id 'java'
+    id 'application'
+    id 'idea'
+    id 'eclipse'
+}
+
 group 'io.vantiq'
 version 'unspecified'
-
-apply plugin: 'java'
-apply plugin: 'application'
-apply plugin: 'io.franzbecker.gradle-lombok'
-
 
 sourceCompatibility = 1.8
 

--- a/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCMain.java
+++ b/jdbcSource/src/main/java/io/vantiq/extsrc/jdbcSource/JDBCMain.java
@@ -46,6 +46,8 @@ public class JDBCMain {
     static final int NO_SOURCE_EXIT = 2;
     static final int NO_SERVER_EXIT = 3;
     
+    private static ExitProcessor exitProcessor = null;
+    
     /**
      * Connects to the Vantiq source and starts polling for data. Exits when all sources are done running.
      * @param args  Should be either null or the first argument as a config file
@@ -63,6 +65,10 @@ public class JDBCMain {
         startSources(sources);
         
         // Can leave now because the threads created by the sources' WebSocket connections will keep the JVM alive
+    }
+    
+    public static void setExitProcessor(ExitProcessor ep) {
+        exitProcessor = ep;
     }
     
     /**
@@ -127,6 +133,15 @@ public class JDBCMain {
                 source.stop();
             }
         }
+        if (exitProcessor != null) {
+            exitProcessor.processExit(code);
+        }
         System.exit(code);
+    }
+    
+    public interface ExitProcessor {
+        default void processExit(int code) {
+            System.exit(code);
+        }
     }
 }

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCMain.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBCMain.java
@@ -10,7 +10,6 @@ package io.vantiq.extsrc.jdbcSource;
 
 import static org.junit.Assert.fail;
 
-import java.security.Permission;
 import java.util.List;
 import java.util.Properties;
 
@@ -22,13 +21,13 @@ public class TestJDBCMain {
     
     @Before
     public void setup() {
-        System.setSecurityManager(new NoExit());
+        JDBCMain.setExitProcessor(new NoExit());
     }
     
     @After
     public void tearDown() {
         List<JDBCCore> sources = JDBCMain.sources;
-        System.setSecurityManager(null);
+        JDBCMain.setExitProcessor(null);
         if (sources != null) {
             for (JDBCCore s : sources) {
                 s.stop();
@@ -105,16 +104,10 @@ public class TestJDBCMain {
     
 // ================================================= Helper functions =================================================
     
-    private static class NoExit extends SecurityManager 
-    {
+    private static class NoExit implements JDBCMain.ExitProcessor {
         @Override
-        public void checkPermission(Permission perm) {}
-        @Override
-        public void checkPermission(Permission perm, Object context) {}
-        @Override
-        public void checkExit(int status) 
+        public void processExit(int status)
         {
-            super.checkExit(status);
             if (status == 1) {
                 throw new ExitException("Exit Requested: auth token was not specified.");
             } else if (status == 2) {

--- a/jmsSource/src/main/java/io/vantiq/extsrc/jmsSource/JMSMain.java
+++ b/jmsSource/src/main/java/io/vantiq/extsrc/jmsSource/JMSMain.java
@@ -9,12 +9,8 @@
 package io.vantiq.extsrc.jmsSource;
 
 import io.vantiq.extjsdk.Utils;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 import org.slf4j.Logger;
@@ -47,6 +43,7 @@ public class JMSMain {
     static final int NO_SERVER_EXIT = 3;
     static final int NO_CONFIG_EXIT = 4;
 
+    private static ExitProcessor exitProcessor = null;
     /**
      * Connects to the Vantiq source and starts polling for data. Exits when all sources are done running.
      * @param args  Should be either null or the first argument as a config file
@@ -67,6 +64,10 @@ public class JMSMain {
         startSources(sources);
 
         // Can leave now because the threads created by the sources' WebSocket connections will keep the JVM alive
+    }
+    
+    public static void setExitProcessor(ExitProcessor ep) {
+        exitProcessor = ep;
     }
 
     /**
@@ -131,6 +132,15 @@ public class JMSMain {
                 source.stop();
             }
         }
+        if (exitProcessor != null) {
+            exitProcessor.processExit(code);
+        }
         System.exit(code);
+    }
+    
+    public interface ExitProcessor {
+        default void processExit(int code) {
+            System.exit(code);
+        }
     }
 }

--- a/jmsSource/src/test/java/io/vantiq/extsrc/jmsSource/TestJMSMain.java
+++ b/jmsSource/src/test/java/io/vantiq/extsrc/jmsSource/TestJMSMain.java
@@ -10,7 +10,6 @@ package io.vantiq.extsrc.jmsSource;
 
 import static org.junit.Assert.fail;
 
-import java.security.Permission;
 import java.util.List;
 import java.util.Properties;
 
@@ -22,13 +21,13 @@ public class TestJMSMain {
     
     @Before
     public void setup() {
-        System.setSecurityManager(new NoExit());
+        JMSMain.setExitProcessor(new NoExit());
     }
     
     @After
     public void tearDown() {
         List<JMSCore> sources = JMSMain.sources;
-        System.setSecurityManager(null);
+        JMSMain.setExitProcessor(null);
         if (sources != null) {
             for (JMSCore s : sources) {
                 s.stop();
@@ -105,16 +104,10 @@ public class TestJMSMain {
     
 // ================================================= Helper functions =================================================
     
-    private static class NoExit extends SecurityManager 
-    {
+    private static class NoExit implements JMSMain.ExitProcessor {
         @Override
-        public void checkPermission(Permission perm) {}
-        @Override
-        public void checkPermission(Permission perm, Object context) {}
-        @Override
-        public void checkExit(int status) 
+        public void processExit(int status)
         {
-            super.checkExit(status);
             if (status == 1) {
                 throw new ExitException("Exit Requested: auth token was not specified.");
             } else if (status == 2) {

--- a/objectRecognitionSource/build.gradle
+++ b/objectRecognitionSource/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'application'
-    id 'io.franzbecker.gradle-lombok'
+    id("io.freefair.lombok") version "6.3.0" // version "8.7.1"
 }
 
 group 'io.vantiq'

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionMain.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionMain.java
@@ -10,12 +10,8 @@
 package io.vantiq.extsrc.objectRecognition;
 
 import io.vantiq.extjsdk.Utils;
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 import org.slf4j.Logger;
@@ -44,6 +40,8 @@ public class ObjectRecognitionMain {
     static String targetVantiqServer;
     static String modelDirectory;
     
+    private static ExitProcessor exitProcessor = null;
+    
     /**
      * Connects to the Vantiq source and starts polling for data. Exits when all sources are done running.
      * @param args  Should be either null or the first argument as a config file
@@ -61,6 +59,10 @@ public class ObjectRecognitionMain {
         startSources(sources);
         
         // Can leave now because the threads created by the sources' WebSocket connections will keep the JVM alive
+    }
+    
+    public static void setExitProcessor(ExitProcessor ep) {
+        exitProcessor = ep;
     }
     
     /**
@@ -127,6 +129,15 @@ public class ObjectRecognitionMain {
                 source.stop();
             }
         }
+        if (exitProcessor != null) {
+            exitProcessor.processExit(code);
+        }
         System.exit(code);
+    }
+    
+    public interface ExitProcessor {
+        default void processExit(int code) {
+            System.exit(code);
+        }
     }
 }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecMain.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/TestObjRecMain.java
@@ -11,7 +11,6 @@ package io.vantiq.extsrc.objectRecognition;
 
 import static org.junit.Assert.fail;
 
-import java.security.Permission;
 import java.util.List;
 import java.util.Properties;
 
@@ -26,13 +25,13 @@ public class TestObjRecMain {
         ObjectRecognitionMain.authToken             = "gcy1hHR39ge2PNCZeiUbYKAev-G7u-KyPh2Ns4gI0Y8=";
         ObjectRecognitionMain.targetVantiqServer    = "http://localhost:8080";  // Used to be ws:  -- should handle this directly
         ObjectRecognitionMain.modelDirectory        = "models/";
-        System.setSecurityManager(new NoExit());
+        ObjectRecognitionMain.setExitProcessor(new NoExit());
     }
     
     @After
     public void tearDown() {
         List<ObjectRecognitionCore> sources = ObjectRecognitionMain.sources;
-        System.setSecurityManager(null);
+        ObjectRecognitionMain.setExitProcessor(null);
         if (sources != null) {
             for (ObjectRecognitionCore s : sources) {
                 s.stop();
@@ -100,16 +99,10 @@ public class TestObjRecMain {
     
 // ================================================= Helper functions =================================================
     
-    private static class NoExit extends SecurityManager 
-    {
+    private static class NoExit implements ObjectRecognitionMain.ExitProcessor {
         @Override
-        public void checkPermission(Permission perm) {}
-        @Override
-        public void checkPermission(Permission perm, Object context) {}
-        @Override
-        public void checkExit(int status) 
+        public void processExit(int status)
         {
-            super.checkExit(status);
             throw new ExitException("Exit Requested");
         }
     }

--- a/opcuaSource/build.gradle
+++ b/opcuaSource/build.gradle
@@ -6,7 +6,7 @@ buildscript {
 }
 
 plugins {
-    id 'io.franzbecker.gradle-lombok'
+    id("io.freefair.lombok") version "6.3.0" // version "8.7.1"
     id 'java'
     id 'application'
     id 'idea'

--- a/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/WriteToOPCUA.java
+++ b/opcuaSource/src/test/java/io/vantiq/extsrc/opcua/uaOperations/WriteToOPCUA.java
@@ -136,7 +136,8 @@ public class WriteToOPCUA extends OpcUaTestBase {
         OpcUaESClient client = Utils.makeConnection(config, false);
 
         try {
-            client.writeValue(exampleNamespace + "IAmNotThere", "HelloWorld/ScalarTypes/Int32", "Int32", new Integer(42));
+            client.writeValue(exampleNamespace + "IAmNotThere", "HelloWorld/ScalarTypes/Int32",
+                              "Int32", 42);
         }
         catch (OpcExtRuntimeException e) {
             if (!e.getMessage().startsWith(OpcUaESClient.ERROR_PREFIX + ".badNamespaceURN")) {

--- a/testConnector/src/main/java/io/vantiq/extsrc/testConnector/TestConnectorMain.java
+++ b/testConnector/src/main/java/io/vantiq/extsrc/testConnector/TestConnectorMain.java
@@ -43,6 +43,7 @@ public class TestConnectorMain {
     static final int NO_SOURCE_EXIT = 2;
     static final int NO_SERVER_EXIT = 3;
 
+    private static ExitProcessor exitProcessor = null;
     /**
      * Connects to the Vantiq source and starts polling for data. Exits when all sources are done running.
      * @param args  Should be either null or the first argument as a config file
@@ -60,6 +61,10 @@ public class TestConnectorMain {
         startSources(sources);
 
         // Can leave now because the threads created by the sources' WebSocket connections will keep the JVM alive
+    }
+    
+    public static void setExitProcessor(ExitProcessor ep) {
+        exitProcessor = ep;
     }
 
     /**
@@ -124,6 +129,15 @@ public class TestConnectorMain {
                 source.stop();
             }
         }
+        if (exitProcessor != null) {
+            exitProcessor.processExit(code);
+        }
         System.exit(code);
+    }
+    
+    public interface ExitProcessor {
+        default void processExit(int code) {
+            System.exit(code);
+        }
     }
 }

--- a/testConnector/src/test/java/io/vantiq/extsrc/testConnector/TestTestConnectorMain.java
+++ b/testConnector/src/test/java/io/vantiq/extsrc/testConnector/TestTestConnectorMain.java
@@ -10,7 +10,6 @@ package io.vantiq.extsrc.testConnector;
 
 import static org.junit.Assert.fail;
 
-import java.security.Permission;
 import java.util.List;
 import java.util.Properties;
 
@@ -22,13 +21,13 @@ public class TestTestConnectorMain {
 
     @Before
     public void setup() {
-        System.setSecurityManager(new NoExit());
+        TestConnectorMain.setExitProcessor(new NoExit());
     }
 
     @After
     public void tearDown() {
         List<TestConnectorCore> sources = TestConnectorMain.sources;
-        System.setSecurityManager(null);
+        TestConnectorMain.setExitProcessor(null);
         if (sources != null) {
             for (TestConnectorCore s : sources) {
                 s.stop();
@@ -105,16 +104,10 @@ public class TestTestConnectorMain {
 
 // ================================================= Helper functions =================================================
 
-    private static class NoExit extends SecurityManager
-    {
+    private static class NoExit implements TestConnectorMain.ExitProcessor {
         @Override
-        public void checkPermission(Permission perm) {}
-        @Override
-        public void checkPermission(Permission perm, Object context) {}
-        @Override
-        public void checkExit(int status)
+        public void processExit(int status)
         {
-            super.checkExit(status);
             if (status == 1) {
                 throw new ExitException("Exit Requested: auth token was not specified.");
             } else if (status == 2) {


### PR DESCRIPTION
Upgrade source to JDK 17 level without warnings.

In prep for some other work to be done soon, upgrade things to run with JDK 17.  This is mostly changes to use of the Java security manager (which is now deprecated) that we were using in tests.  Replaced with try-finally & a so-called `ExitProcessor` that allows us to through exceptions rather than exit (useful in testing).  This is a test-only change.

Upgraded/changed Lombok plugin since the one in use is in maintenance-only mode and doesn't support Java 17.

Other minor tweaks.