### PR TITLE
Add reconnectSecret to Python connector SDK.

### DIFF
--- a/extpsdk/build.gradle
+++ b/extpsdk/build.gradle
@@ -11,7 +11,7 @@ ext {
         pypi_repo = 'testpypi'
     }
     if (!project.rootProject.hasProperty('vantiqConnectorSdkVersion')) {
-        vantiqConnectorSdkVersion = '1.2.11'
+        vantiqConnectorSdkVersion = '1.2.12'
     }
 }
 


### PR DESCRIPTION
Fixes #511 

Adds support for `reconnectSecret` to the Python connector sdk.  This allows a particular instance to reconnect, stating that it is this particular instance, and that the server should toss whatever it thinks is the current one.

For connectors, there's no more than one connector serving a particular source (in a namespace) at at time.  If another connector connects for that source, the server may reply that there's already a connector doing that work.  In this case, the existing connection remains.

However, connectors connect using web sockets, and these are sometimes placed in the _half open_ state.  This state is that the client (initiating) side is told that the connection is closed, but the network on the server side doesn't find out for a while.  When this happens, the server will refuse the connection because there's already some other connector doing that.  But that connector's been told the connection is dead.  In this case, the connector has to wait until the network software finally informs the server that the session is defunct.

The `reconnectSecret` allows the new connection to say, "I am that one you think is still going on."  In that case, the server will toss the old connection (which is, generally dead, but no one thought that was important enough to mention to the server) and allow things to continue.

There's been code for this in the Java Connector SDK for a while, but I forgot it in the Python one.  This remedies that situation.

I'm making an experimental extension whereby the connector deployer can specify this secret in the `server.config` file.  Normally, the `reconnectSecret` is internally generated and used, so it's entirely transparent to the user.  However, there has been some speculation that this might be of use for some customers who kill the docker/k8s container and restart.  Since the `reconnectSecret` lives for the life of the connection, it'll not be used here.  At this point, it's not documented since I don't really know if it'll work or be appropriate.  If this customer finds it necessary, we can let them try it experimentally.  Then add docs later, if needed.

Once this is merged, there will be a subsequent PR to extend the PythonExecSource connector to use this version of the SDK.