### PR TITLE
pick up new connector SDK version

### DIFF
--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/ObjRecTestBase.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/ObjRecTestBase.java
@@ -48,8 +48,10 @@ public class ObjRecTestBase {
 //    public static final String IP_CAMERA_URL = "https://wzmedia.dot.ca.gov/D3/80_reed.stream/playlist.m3u8";
 //    public static final String IP_CAMERA_URL = "http://166.143.31.94/cgi-bin/camera?resolution=640&amp;" +
 //            "quality=1&amp;Language=0&amp;1666639808";
-    public static final String IP_CAMERA_URL = "http://115.179.100.76:8080/SnapshotJPEG?Resolution=640x480" +
-            "&Quality=Standard&View=Normal&Count=224935296";
+//    public static final String IP_CAMERA_URL = "http://115.179.100.76:8080/SnapshotJPEG?Resolution=640x480" +
+//            "&Quality=Standard&View=Normal&Count=224935296";
+    public static final String IP_CAMERA_URL = "http://220.233.144.165:8888/mjpg/video.mjpg"; // Sydney harbour camera
+
     @BeforeClass
     public static void getProps() {
         testAuthToken = System.getProperty("TestAuthToken", null);

--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -12,11 +12,11 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('pyExecSrcVersion')) {
-        pyExecSrcVersion = '1.2.11'
+        pyExecSrcVersion = '1.2.12'
     }
     // If these change, update requirements-conn.in as well -- as that's used to generate the requirements.txt file
     vantiqPythonSdkVersion = '1.3.5'
-    vantiqConnectorSdkVersion = '1.2.11'
+    vantiqConnectorSdkVersion = '1.2.12'
 }
 
 python {

--- a/pythonExecSource/requirements-conn.in
+++ b/pythonExecSource/requirements-conn.in
@@ -1,5 +1,5 @@
 websockets>=12.0
 aiohttp>=3.10.2
-vantiqconnectorsdk>=1.2.11
+vantiqconnectorsdk>=1.2.12
 vantiqsdk>=1.3.5
 requests>=2.32.3

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -117,6 +117,7 @@ requests==2.32.3
     #   -r requirements-conn.in
     #   requests-toolbelt
     #   twine
+    #   vantiqsdk
 requests-toolbelt==1.0.0
     # via twine
 rfc3986==2.0.0
@@ -139,7 +140,7 @@ urllib3==2.2.2
     # via
     #   requests
     #   twine
-vantiqconnectorsdk==1.2.11
+vantiqconnectorsdk==1.2.12
     # via -r requirements-conn.in
 vantiqsdk==1.3.5
     # via -r requirements-conn.in
@@ -153,4 +154,6 @@ wheel==0.42.0
 yarl==1.9.4
     # via aiohttp
 zipp==3.19.2
-    # via importlib-metadata
+    # via
+    #   -r requirements-build.in
+    #   importlib-metadata


### PR DESCRIPTION
Fixes #514 

Just picks up changes to connector SDK for `reconnectSecret`.  No other changes