### PR TITLE
Update assembly generation for Camel v4

### DIFF
--- a/buildSrc/src/main/groovy/io/vantiq/extsrc/assy/tasks/AssemblyResourceGeneration.groovy
+++ b/buildSrc/src/main/groovy/io/vantiq/extsrc/assy/tasks/AssemblyResourceGeneration.groovy
@@ -227,7 +227,7 @@ class AssemblyResourceGeneration extends DefaultTask {
 
     // Definitions from CamelConnector that we may need
     public static final String CAMEL_CONNECTOR_DEPLOYMENT_SERVICE = 'ConnectorDeployment'
-    public static final String CAMEL_CONNECTOR_DEPLOYMENT_PACKAGE = 'com.vantiq.extsrc.camelconn'
+    public static final String CAMEL_CONNECTOR_DEPLOYMENT_PACKAGE = 'com.vantiq.extsrc.camel4conn'
 
     public static final String CAMEL_CONNECTOR_DEPLOYMENT_PROCEDURE = DEPLOYMENT_PROCEDURE_NAME
 

--- a/camelAssemblies/README.md
+++ b/camelAssemblies/README.md
@@ -12,7 +12,7 @@ create Vantiq services and sources for connections to or from external systems s
 **IMPORTANT:** A basic understanding of the [Vantiq Camel Connector](../camelConnector/README.md) is assumed.
 
 All assemblies contained herein (Vantiq Camel assemblies) are built atop the base Camel Connector assembly, 
-`com.vantiq.extsrc.camelconn.camelConnector`.  Specifically, the Camel Connector 
+`com.vantiq.extsrc.camel4conn.camelConnector`.  Specifically, the Camel Connector 
 assembly defines the Camel Connector source implementation type and the schema type
 `com.vantiq.extsrc.camelcomp.message` that defines the message format for messages used between the Camel connector
 and the Vantiq system.
@@ -44,7 +44,7 @@ names of the included Vantiq components. Those that get data _from_ another syst
 
 Each assembly and its included components are named including the name of the system with which they
 interact and the Apache Camel version in use (kamelets are Camel version specific).  For example, an assembly using 
-Camel version 3.21.x for consuming information from Amazon's AWS S3 will be in the Vantiq Camel assembly
+Camel version 4.4.3 for consuming information from Amazon's AWS S3 will be in the Vantiq Camel assembly
 
     com.vantiq.extsrc.camel.kamelets.v4_4_3.aws_s3_source
 
@@ -64,7 +64,8 @@ configured to make the connection to the associated information system via the C
 The Vantiq Camel assemblies contained herein are composed of the following.
 
 * Vantiq Source -- this is the Vantiq component that represents the external system to the Vantiq environment.
-  * The Vantiq source will be of type `CAMEL`. This is defined in the Camel Connector assembly `com.vantiq.extsrc.camelconn.camelConnector`.
+  * The Vantiq source will be of type `CAMEL`. This is defined in the Camel Connector assembly `com.vantiq.extsrc.
+    camel4conn.camelConnector`.
   * The source's configuration will include the Camel route to/from (source/sink) the external source via Camel 
     Component(s).
   * The configuration may include configuration information (such as credentials, type of interaction) generated 
@@ -121,7 +122,7 @@ To make use of any Vantiq Camel assembly defined herein, the user should perform
 
 * Add the Vantiq Catalog containing the definitions. In Vantiq public systems, this is, at the time of this writing, 
   named `CamelCatalog`. This must be done once per namespace into which any of these assemblies will be installed.
-* From that catalog, import the `com.vantiq.extsrc.camelconn.camelConnector` assembly. This is a prerequisite for 
+* From that catalog, install the `com.vantiq.extsrc.camel4conn.camelConnector` assembly. This is a prerequisite for 
   the Vantiq Camel assemblies.  See the [Camel Connector document](../camelConnector/README.md).
   * As with the addition of the Vantiq Catalog, this needs to be done once per Vantiq namespace in which these 
     assemblies are being used.
@@ -129,18 +130,17 @@ To make use of any Vantiq Camel assembly defined herein, the user should perform
     * The `CAMEL` source implementation type.
     * The Vantiq _schema_ used for the _structured messages_ used to interact with the source.
     * A deployment procedure used to deploy the connector to Kubernetes via a Vantiq K8sCluster.
-* From that catalog, import the Vantiq Camel assembly or assemblies desired, providing the configuration properties as 
+* From that catalog, install the Vantiq Camel assembly or assemblies desired, providing the configuration properties as 
   requested. 
-  * These configuration properties
-  will often include addressing information and credentials for the remote systems. It is strongly suggested that 
-    credential information (or other confidential information) be stored in Vantiq 
+  * These configuration properties will often include addressing information and credentials for the remote systems. 
+    It is strongly suggested that credential information (or other confidential information) be stored in Vantiq 
     Secrets, and referenced using the `@secrets()` notation.
 
 ## Using the Vantiq Camel Assemblies
 
 Once installed, each Vantiq Camel assembly creates a source & service for interacting with that source.
 
-The source is defined and  implemented via a [Camel Connector](../camelConnector/README.md). To run the Camel 
+The source is defined and implemented via a [Camel Connector](../camelConnector/README.md). To run the Camel 
 Connector, please see the [Camel Connector overview](../camelConnector/README.md). To deploy said connector using a 
 Vantiq K8sCluster, see [Deploying the Camel Connector to Kubernetes](#deploying-the-camel-connector-to-kubernetes)
 
@@ -150,10 +150,10 @@ All are constructed to use _structured messages_ as defined by the
 [Camel Component](../camelComponent/README.md#structured-headers-and-messages). Consequently, messages sent to/from 
 the service should be in this format. Specifically, such messages contain two (2) properties: `header` and `message`,
 where the `header` property contains the Camel headers, and the `message` property contains Camel message.
-The associated Vantiq _schema_ is defined via the `com.vantiq.extsrc.camelconn.camelConnector` assembly imported as 
+The associated Vantiq _schema_ is defined via the `com.vantiq.extsrc.camel4conn.camelConnector` assembly imported as 
 described above.  This imported assembly is a prerequisite for the other Vantiq Camel assemblies.
 
-**Note**: Some of these Vantiq Camel assemblies (specifically those that work with systems
+**Note**: With some of these Vantiq Camel assemblies (specifically those that work with systems
 with limited messaging capabilities),
 the Vantiq Component will construct output messages (the `message` property) with a single 
 property (`stringVal` or `byteVal`) containing the 
@@ -194,8 +194,7 @@ The actions required to perform the deployment are the same as those described f
 1) The service and procedure to use varies from assembly to assembly
   (they are named and packaged as per the assembly), and
 2) The source name value should not (cannot) be provided.  It is provided by the assembly and the specialized 
-   service 
-   contained therein.
+   service contained therein.
 
 So, using the same assembly as an example, assembly installation will provide the service definition
 

--- a/camelAssemblies/README.md
+++ b/camelAssemblies/README.md
@@ -33,7 +33,7 @@ This subproject will generate Vantiq assemblies from the Camel definitions downl
 as the `camel-kamelet` library from the dependencies (see the `build.gradle` file in this subproject).
 To generate the assembles, just run `../gradlew assemble`. After that, the Vantiq assemblies will be
 located in zip files under the build/distributions directory.
-For example,`build/distributions/ftp_sink_v3_21_0.zip`.
+For example,`build/distributions/ftp_sink_v4_4_3.zip`.
 
 ## Terminology and Naming
 
@@ -46,11 +46,11 @@ Each assembly and its included components are named including the name of the sy
 interact and the Apache Camel version in use (kamelets are Camel version specific).  For example, an assembly using 
 Camel version 3.21.x for consuming information from Amazon's AWS S3 will be in the Vantiq Camel assembly
 
-    com.vantiq.extsrc.camel.kamelets.v3_21_0.aws_s3_source
+    com.vantiq.extsrc.camel.kamelets.v4_4_3.aws_s3_source
 
 while an assembly for sending data to Amazon's AWS SNS will be found in
 
-    com.vantiq.extsrc.camel.kamelets.v3_21_0.aws_sns_sink
+    com.vantiq.extsrc.camel.kamelets.v4_4_3.aws_sns_sink
 
 For each of these cases, the Vantiq components contained in the assembly will have that assembly name as their 
 package name. The _base name_ for Vantiq components will be the kamelet name, with suffixes specific to the Vantiq 
@@ -74,10 +74,10 @@ The Vantiq Camel assemblies contained herein are composed of the following.
 * Vantiq Service -- this is the Vantiq item with which Vail code interacts.
   * The service interacts with the Vantiq source to move information to/from the Vantiq system.
   * The service is in the package matching the assembly name, and named with the base name with the suffix 
-    `_service`.  For example, `com.vantiq.extsrc.camel.kamelets.v3_21_0.aws_sns_sink.aws_sns_sink_service`.
+    `_service`.  For example, `com.vantiq.extsrc.camel.kamelets.v4_4_3.aws_sns_sink.aws_sns_sink_service`.
   * Each service is defined with an _inbound_ or _outbound_ event named with the base name with the suffix 
     `_serviceEvent`. Continuing the example above, `aws_sns_sink_serviceEvent` (so the full service event name is 
-    `com.vantiq.extsrc.camel.kamelets.v3_21_0.aws_sns_sink.aws_sns_sink_service/aws_sns_sink_serviceEvent`).
+    `com.vantiq.extsrc.camel.kamelets.v4_4_3.aws_sns_sink.aws_sns_sink_service/aws_sns_sink_serviceEvent`).
 * Vantiq Deployment Service
   * A service is created to deploy a Vantiq Camel Connector to a Vantiq K8s CLuster.
   * The service name is in the assembly's package, and named with the base name with the suffix `_Deployment`.
@@ -182,11 +182,11 @@ Each assembly contains such a service for performing the deployment. The service
 within the assembly, and is named using the base name with the `_Deployment` suffix.  So, for example, the 
 deployment service for the AWS EventBridge sink is
 
-`com.vantiq.extsrc.camel.kamelets.v3_21_0.aws_eventbridge_sink.Aws_eventbride_sink_Deployment`
+`com.vantiq.extsrc.camel.kamelets.v4_4_3.aws_eventbridge_sink.Aws_eventbride_sink_Deployment`
 
 with the deployment procedure being
 
-`com.vantiq.extsrc.camel.kamelets.v3_21_0.aws_eventbridge_sink.Aws_eventbride_sink_Deployment.deployToK8s()`
+`com.vantiq.extsrc.camel.kamelets.v4_4_3.aws_eventbridge_sink.Aws_eventbride_sink_Deployment.deployToK8s()`
 
 The actions required to perform the deployment are the same as those described for 
 [deploying a Camel Connector](../camelConnector/README.md#camelConnectorDeployment) with two (2) differences:

--- a/camelAssemblies/src/main/resources/routeOverrides/fhir_sink/v4_4_3/fhir_sink.routes.yaml
+++ b/camelAssemblies/src/main/resources/routeOverrides/fhir_sink/v4_4_3/fhir_sink.routes.yaml
@@ -1,0 +1,43 @@
+-   route-template:
+        id: Route templates from fhir_sink:v4_4_3 (modified)
+        from:
+            uri: vantiq://server.config?consumerOutputJsonStream=true&structuredMessageHeader=true
+            steps:
+            -   choice:
+                    precondition: true
+                    when:
+                    -   simple: ${properties:encoding} =~ 'JSON'
+                        steps:
+                        -   unmarshal:
+                                fhirJson:
+                                    fhirVersion: '{{fhirVersion}}'
+                                    prettyPrint: '{{prettyPrint}}'
+                    -   simple: ${properties:encoding} =~ 'XML'
+                        steps:
+                        -   unmarshal:
+                                fhirXml:
+                                    fhirVersion: '{{fhirVersion}}'
+                                    prettyPrint: '{{prettyPrint}}'
+            -   to:
+                    uri: fhir://{{apiName}}/{{methodName}}
+                    parameters:
+                        serverUrl: '{{serverUrl}}'
+                        encoding: '{{encoding}}'
+                        fhirVersion: '{{fhirVersion}}'
+                        log: '{{log}}'
+                        prettyPrint: '{{prettyPrint}}'
+                        lazyStartProducer: '{{lazyStartProducer}}'
+                        proxyHost: '{{?proxyHost}}'
+                        proxyPassword: '{{?proxyPassword}}'
+                        proxyPort: '{{?proxyPort}}'
+                        proxyUser: '{{?proxyUser}}'
+                        accessToken: '{{?accessToken}}'
+                        username: '{{?username}}'
+                        password: '{{?password}}'
+            - marshal:
+                    fhirJson:
+                        fhirVersion: '{{fhirVersion}}'
+                        prettyPrint: '{{prettyPrint}}'
+            - to:
+                    uri: vantiq://server.config?consumerOutputJsonStream=true&structuredMessageHeader=true
+

--- a/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_add_comment_sink/v4_4_3/jira_add_comment_sink.json
+++ b/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_add_comment_sink/v4_4_3/jira_add_comment_sink.json
@@ -1,0 +1,14 @@
+{
+  "camelRuntime": {
+  },
+  "general": {
+    "repoList": [
+      "https://repo.maven.apache.org/maven2/",
+      "https://packages.atlassian.com/mvn/maven-external/"
+    ],
+    "additionalLibraries": [
+      "org.apache.httpcomponents:httpmime:4.5.13",
+      "org.apache.httpcomponents:httpclient-cache:4.5.13"
+    ]
+  }
+}

--- a/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_add_issue_sink/v4_4_3/jira_add_issue_sink.json
+++ b/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_add_issue_sink/v4_4_3/jira_add_issue_sink.json
@@ -1,0 +1,14 @@
+{
+  "camelRuntime": {
+  },
+  "general": {
+    "repoList": [
+      "https://repo.maven.apache.org/maven2/",
+      "https://packages.atlassian.com/mvn/maven-external/"
+    ],
+    "additionalLibraries": [
+      "org.apache.httpcomponents:httpmime:4.5.13",
+      "org.apache.httpcomponents:httpclient-cache:4.5.13"
+    ]
+  }
+}

--- a/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_oauth_source/v4_4_3/jira_oauth_source.json
+++ b/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_oauth_source/v4_4_3/jira_oauth_source.json
@@ -1,0 +1,14 @@
+{
+  "camelRuntime": {
+  },
+  "general": {
+    "repoList": [
+      "https://repo.maven.apache.org/maven2/",
+      "https://packages.atlassian.com/mvn/maven-external/"
+    ],
+    "additionalLibraries": [
+      "org.apache.httpcomponents:httpmime:4.5.13",
+      "org.apache.httpcomponents:httpclient-cache:4.5.13"
+    ]
+  }
+}

--- a/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_source/v4_4_3/jira_source.json
+++ b/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_source/v4_4_3/jira_source.json
@@ -1,0 +1,14 @@
+{
+  "camelRuntime": {
+  },
+  "general": {
+    "repoList": [
+      "https://repo.maven.apache.org/maven2/",
+      "https://packages.atlassian.com/mvn/maven-external/"
+    ],
+    "additionalLibraries": [
+      "org.apache.httpcomponents:httpmime:4.5.13",
+      "org.apache.httpcomponents:httpclient-cache:4.5.13"
+    ]
+  }
+}

--- a/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_transition_issue_sink/v4_4_3/jira_transition_issue_sink.json
+++ b/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_transition_issue_sink/v4_4_3/jira_transition_issue_sink.json
@@ -1,0 +1,14 @@
+{
+  "camelRuntime": {
+  },
+  "general": {
+    "repoList": [
+      "https://repo.maven.apache.org/maven2/",
+      "https://packages.atlassian.com/mvn/maven-external/"
+    ],
+    "additionalLibraries": [
+      "org.apache.httpcomponents:httpmime:4.5.13",
+      "org.apache.httpcomponents:httpclient-cache:4.5.13"
+    ]
+  }
+}

--- a/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_update_issue_sink/v4_4_3/jira_update_issue_sink.json
+++ b/camelAssemblies/src/main/resources/sourceConfigOverrides/jira_update_issue_sink/v4_4_3/jira_update_issue_sink.json
@@ -1,0 +1,14 @@
+{
+  "camelRuntime": {
+  },
+  "general": {
+    "repoList": [
+      "https://repo.maven.apache.org/maven2/",
+      "https://packages.atlassian.com/mvn/maven-external/"
+    ],
+    "additionalLibraries": [
+      "org.apache.httpcomponents:httpmime:4.5.13",
+      "org.apache.httpcomponents:httpclient-cache:4.5.13"
+    ]
+  }
+}

--- a/camelAssemblies/src/main/resources/vantiqNotes/fhir_sink.md
+++ b/camelAssemblies/src/main/resources/vantiqNotes/fhir_sink.md
@@ -25,7 +25,7 @@ PROCEDURE doFhirSearch(urlParam String, resourceType String): Object
 var msg = { resourceType: resourceType }
 var headers = {CamelFhir.url = urlParam }
 
-publish {headers: headers, message: msg } to SERVICE EVENT  "com.vantiq.extsrc.camel.kamelets.v3_21_0.fhir_sink.fhir_sink_service/fhir_sink_serviceEvent"
+publish {headers: headers, message: msg } to SERVICE EVENT  "com.vantiq.extsrc.camel.kamelets.v4_4_3.fhir_sink.fhir_sink_service/fhir_sink_serviceEvent"
 
 return null
 ```
@@ -44,7 +44,7 @@ PROCEDURE returnFhirSearch(urlParam String, resourceType String): Object array
 var msg = { resourceType: resourceType }
 var headers = {CamelFhir.url = urlParam }
 
-var res = select * from source com.vantiq.extsrc.camel.kamelets.v3_21_0.fhir_sink.fhir_sink_source 
+var res = select * from source com.vantiq.extsrc.camel.kamelets.v4_4_3.fhir_sink.fhir_sink_source 
 	with message = msg, headers = headers
 return res
 ```

--- a/camelConnector/README.md
+++ b/camelConnector/README.md
@@ -309,7 +309,7 @@ accidentally override any existing Sources or Types.
 
 # The Camel Connector Assembly
 
-This repository defines a Camel Connector Assembly (`com.vantiq.extsrc.camelconn.CamelConnector`) which can be
+This repository defines a Camel Connector Assembly (`com.vantiq.extsrc.camel4conn.CamelConnector`) which can be
 imported into a Vantiq catalog. Some Vantiq installations will contain a public catalog (the _Camel Catalog_) that
 contains this assembly.
 
@@ -318,7 +318,7 @@ The assembly, once imported, defines the following Vantiq entities.
 * The CAMEL Source Implementation.  This is used to [define the Vantiq Source](#sourceConfiguration).
 * The `com.vantiq.extsrc.camelcomp.message` schema type.
     See [Camel Component Structured Messages](../camelComponent/README.md#structuredMessages)
-* The `com.vantiq.extsrc.camelcomp.ConnectorDeployment` service, including the `deployToK8s()` procedure.
+* The `com.vantiq.extsrc.camel4comp.ConnectorDeployment` service, including the `deployToK8s()` procedure.
 
 Once this assembly is installed, these items are available for use in the namespace in which the assembly is installed.
 Use of the source implementation and the schema type are outlined in the links provided.

--- a/camelConnector/README.md
+++ b/camelConnector/README.md
@@ -318,7 +318,7 @@ The assembly, once imported, defines the following Vantiq entities.
 * The CAMEL Source Implementation.  This is used to [define the Vantiq Source](#sourceConfiguration).
 * The `com.vantiq.extsrc.camelcomp.message` schema type.
     See [Camel Component Structured Messages](../camelComponent/README.md#structuredMessages)
-* The `com.vantiq.extsrc.camel4comp.ConnectorDeployment` service, including the `deployToK8s()` procedure.
+* The `com.vantiq.extsrc.camel4conn.ConnectorDeployment` service, including the `deployToK8s()` procedure.
 
 Once this assembly is installed, these items are available for use in the namespace in which the assembly is installed.
 Use of the source implementation and the schema type are outlined in the links provided.

--- a/camelConnector/build.gradle
+++ b/camelConnector/build.gradle
@@ -107,7 +107,7 @@ java.targetCompatibility = JavaVersion.VERSION_17
  */
 
 task zipAssembly(type: Zip) {
-    def inFiles =  project.fileTree('src/main/resources/assembly/camelconnector')
+    def inFiles =  project.fileTree('src/main/resources/assembly/camel4connector')
     logger.debug('Infiles: {}', inFiles)
 
     project(':camelComponent').fileTree('src/main/resources/types').each { f ->
@@ -120,7 +120,7 @@ task zipAssembly(type: Zip) {
         include 'types/**/*'
     }
     into "${project.name}"
-    archiveName "${project.name}-assembly.zip"
+    archiveName "camel4connector-assembly.zip"
 }
 
 jar.finalizedBy zipAssembly

--- a/camelConnector/build.gradle
+++ b/camelConnector/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     implementation "com.google.code.gson:gson:${gsonVersion}"
     // Used for downloading route documents
     implementation "io.vantiq:vantiq-sdk:${vantiqSDKVersion}"
+    implementation "org.apache.logging.log4j:log4j-slf4j2-impl:${log4JVersion}"
 
     // The following are the DSL libraries to include for support of the various route builders.
     // We need to include them in the base product (as oppose to using our constructed classloader)
@@ -70,7 +71,6 @@ dependencies {
     // End of DSL-specific inclusions.
 
     testImplementation project(path: ":camelComponent", configuration: "testArtifacts")
-    testImplementation "org.apache.logging.log4j:log4j-slf4j2-impl:${log4JVersion}"
     testImplementation "org.apache.camel:camel-test-junit5:${camelVersion}"
     testImplementation "io.vantiq:vantiq-sdk:${vantiqSDKVersion}"
     testImplementation project(path: ":extjsdk", configuration: 'testArtifacts')

--- a/camelConnector/src/main/docker/Dockerfile
+++ b/camelConnector/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:11-alpine-jdk
+FROM amazoncorretto:17-alpine-jdk
 RUN apk update && apk add --upgrade libcrypto3 libssl3
 RUN mkdir /app
 ADD camelConnector.tar /app

--- a/camelConnector/src/main/resources/assembly/camel4connector/documents/com.vantiq.extsrc.camel4conn.camelConnectorToK8s.template
+++ b/camelConnector/src/main/resources/assembly/camel4connector/documents/com.vantiq.extsrc.camel4conn.camelConnectorToK8s.template
@@ -1,0 +1,24 @@
+[
+     {
+         "type": "image",
+         "name": "quay.io/vantiq/camelconnector-source:${CONN_VERSION}",
+         "pullPolicy": "IfNotPresent"
+     },
+     {
+        "type": "file",
+        "path": "/app/serverConfig",
+        "filename": "server.config",
+        "content": "targetServer=${TARGET_SERVER_URL}\\nsources=${SOURCE_NAME}\\n"
+     },
+     {
+        "type": "environmentVariable",
+        "name": "CONNECTOR_AUTH_TOKEN",
+        "value": "${AUTH_TOKEN}",
+        "asSecret": true
+     },
+     {
+        "type": "resourceLimit",
+        "cpu": "${CPU_LIMIT}",
+        "memory": "${MEMORY_LIMIT}"
+     }
+]

--- a/camelConnector/src/main/resources/assembly/camel4connector/procedures/com/vantiq/extsrc/camel4conn/ConnectorDeployment_deployToK8s.vail
+++ b/camelConnector/src/main/resources/assembly/camel4connector/procedures/com/vantiq/extsrc/camel4conn/ConnectorDeployment_deployToK8s.vail
@@ -1,0 +1,72 @@
+package com.vantiq.extsrc.camel4conn
+
+import service io.vantiq.text.Template
+
+PROCEDURE ConnectorDeployment.deployToK8s(clusterName String REQUIRED, installationName String REQUIRED, k8sNamespace String, targetUrl String, accessToken String, sourceName String Required, cpuLimit String, memoryLimit String, connectorImageTag String)
+
+// Check for parameter values.  Overrides from parameters take precedence.
+
+var selfNode = select ONE from system.nodes where type == "self"
+log.debug("Self node will use URI: {}", [selfNode.uri])
+
+if (k8sNamespace == null) {
+	k8sNamespace = "default"
+}
+
+if (targetUrl == null) {
+	var configVal = ResourceConfig.get("vantiqTargetUrl")
+	if (configVal == null || trim(configVal) == "") {
+		var selfNode = select ONE from system.nodes where
+			name == "self" and type == "self"
+		if (selfNode != null) {
+			targetUrl = selfNode.uri
+		}
+	} else {
+		targetUrl = configVal
+	}
+}
+
+if (accessToken == null) {
+	var configVal = ResourceConfig.get("vantiqAccessToken")
+	accessToken = configVal
+}
+
+if (cpuLimit == null) {
+	var configVal = ResourceConfig.get("vantiqCpuLimit")
+	cpuLimit = configVal
+}
+
+if (memoryLimit == null) {
+	var configVal = ResourceConfig.get("vantiqMemoryLimit")
+	memoryLimit = configVal
+}
+
+if (connectorImageTag == null) {
+	var configVal = ResourceConfig.get("connectorImageTag")
+	connectorImageTag = configVal
+}
+
+if (targetUrl == null || accessToken == null || sourceName == null || cpuLimit == null || memoryLimit == null || connectorImageTag == null) {
+	exception("com.vantiq.extsrc.camelconn.deployToK8s.parameters",
+		"Missing value for at least one of targetUrl ({0}), accessToken ({1}), sourceName ({2}), cpuLimit ({3}), memoryLimit ({4}), or connectorImageTag ({5}).",
+		[targetUrl, accessToken, sourceName, cpuLimit, memoryLimit, connectorImageTag])
+}
+
+// Now that we have the values we expect, let's prepare our installation configuration.
+
+var templateDoc = Template.documentReference("com.vantiq.extsrc.camelconn.camelConnectorToK8s.template")
+var k8sConfig = Template.format(templateDoc, {  TARGET_SERVER_URL: targetUrl,
+												AUTH_TOKEN: accessToken,
+												SOURCE_NAME: sourceName,
+												CPU_LIMIT: cpuLimit,
+												MEMORY_LIMIT: memoryLimit,
+												CONN_VERSION: connectorImageTag })
+log.debug("Preparing to create installation {} on cluster {} (ns: {}) with config: {}", [installationName, clusterName, k8sNamespace, k8sConfig])
+
+execute ResourceAPI.executeOp({
+    op: "deploy",
+    resourceName: "system.k8sclusters",
+    resourceId: clusterName,
+    object: { name: installationName, k8sNamespace: k8sNamespace, clusterName: clusterName, config: k8sConfig}
+    //parameters: { name: "else" }
+})

--- a/camelConnector/src/main/resources/assembly/camel4connector/procedures/com/vantiq/extsrc/camel4conn/ConnectorDeployment_deployToK8s.vail
+++ b/camelConnector/src/main/resources/assembly/camel4connector/procedures/com/vantiq/extsrc/camel4conn/ConnectorDeployment_deployToK8s.vail
@@ -54,7 +54,7 @@ if (targetUrl == null || accessToken == null || sourceName == null || cpuLimit =
 
 // Now that we have the values we expect, let's prepare our installation configuration.
 
-var templateDoc = Template.documentReference("com.vantiq.extsrc.camelconn.camelConnectorToK8s.template")
+var templateDoc = Template.documentReference("com.vantiq.extsrc.camel4conn.camelConnectorToK8s.template")
 var k8sConfig = Template.format(templateDoc, {  TARGET_SERVER_URL: targetUrl,
 												AUTH_TOKEN: accessToken,
 												SOURCE_NAME: sourceName,

--- a/camelConnector/src/main/resources/assembly/camel4connector/projects/com.vantiq.extsrc.camel4conn.camelConnector.json
+++ b/camelConnector/src/main/resources/assembly/camel4connector/projects/com.vantiq.extsrc.camel4conn.camelConnector.json
@@ -41,12 +41,13 @@
         "resourceReference": "/documents/com.vantiq.extsrc.camel4conn.camelConnectorToK8s.template"
       },
       {
-        "resourceReference" : "/system.services/com.vantiq.extsrc.camel4conn.ConnectorDeployment"
+        "name" : "com.vantiq.extsrc.camel4conn.ConnectorDeployment",
+        "resourceReference" : "/services/com.vantiq.extsrc.camel4conn.ConnectorDeployment",
+        "type": 63
       },
       {
         "name" : "com.vantiq.extsrc.camel4conn.ConnectorDeployment.deployToK8s",
-        "resourceReference" : "/procedures/com.vantiq.extsrc.camel4conn.ConnectorDeployment.deployToK8s",
-        "serviceName" : "ConnectorDeployment"
+        "resourceReference" : "/procedures/com.vantiq.extsrc.camel4conn.ConnectorDeployment.deployToK8s"
       }
     ],
     "visibleResources": [
@@ -57,7 +58,7 @@
         "resourceReference": "/documents/com.vantiq.extsrc.camel4conn.camelConnectorToK8s.template"
       },
       {
-        "resourceReference" : "/system.services/com.vantiq.extsrc.camel4conn.ConnectorDeployment"
+        "resourceReference" : "/services/com.vantiq.extsrc.camel4conn.ConnectorDeployment"
       }
     ],
     "configurationMappings": {
@@ -107,7 +108,7 @@
         "type" : "String"
       },
       "connectorImageTag" : {
-        "default": "2.0.1",
+        "default": "4.4.3.1",
         "description" : "The image tag used to pull the Camel Connector image.  Generally, no need to change this. Ignore if not running in Kubernetes.",
         "type" : "String"
       }

--- a/camelConnector/src/main/resources/assembly/camel4connector/projects/com.vantiq.extsrc.camel4conn.camelConnector.json
+++ b/camelConnector/src/main/resources/assembly/camel4connector/projects/com.vantiq.extsrc.camel4conn.camelConnector.json
@@ -1,0 +1,115 @@
+{
+    "name": "com.vantiq.extsrc.camel4conn.camelConnector",
+    "type": "dev",
+    "ars_relationships": [
+        
+    ],
+    "links": [
+        
+    ],
+    "tools": [
+        
+    ],
+    "views": [
+        
+    ],
+    "partitions": [
+        
+    ],
+    "isAssembly": true,
+    "options": {
+        "description": "Camel Connector Definition",
+        "filterBitArray": "ffffffffffffffffffffffffffffffff",
+        "type": "dev",
+        "v": 5,
+        "isModeloProject": true
+    },
+    "resources": [
+      {
+        "label": "CAMEL",
+        "name" : "CAMEL",
+        "resourceReference": "/sourceimpls/CAMEL",
+        "type" : 69
+      },
+      {
+        "label" : "com.vantiq.extsrc.camelcomp.message",
+        "name" : "com.vantiq.extsrc.camelcomp.message",
+        "resourceReference": "/types/com.vantiq.extsrc.camelcomp.message",
+        "type": 1
+      },
+      {
+        "resourceReference": "/documents/com.vantiq.extsrc.camel4conn.camelConnectorToK8s.template"
+      },
+      {
+        "resourceReference" : "/system.services/com.vantiq.extsrc.camel4conn.ConnectorDeployment"
+      },
+      {
+        "name" : "com.vantiq.extsrc.camel4conn.ConnectorDeployment.deployToK8s",
+        "resourceReference" : "/procedures/com.vantiq.extsrc.camel4conn.ConnectorDeployment.deployToK8s",
+        "serviceName" : "ConnectorDeployment"
+      }
+    ],
+    "visibleResources": [
+      {
+        "resourceReference": "/types/com.vantiq.extsrc.camelcomp.message"
+      },
+      {
+        "resourceReference": "/documents/com.vantiq.extsrc.camel4conn.camelConnectorToK8s.template"
+      },
+      {
+        "resourceReference" : "/system.services/com.vantiq.extsrc.camel4conn.ConnectorDeployment"
+      }
+    ],
+    "configurationMappings": {
+      "connectorImageTag" : [ {
+        "property" : "connectorImageTag",
+        "resource" : "procedures",
+        "resourceId" : "com.vantiq.extsrc.camel4conn.ConnectorDeployment.deployToK8s"
+      } ],
+      "vantiqAccessToken" : [ {
+        "property" : "vantiqAccessToken",
+        "resource" : "procedures",
+        "resourceId" : "com.vantiq.extsrc.camel4conn.ConnectorDeployment.deployToK8s"
+      } ],
+      "vantiqCpuLimit" : [ {
+        "property" : "vantiqCpuLimit",
+        "resource" : "procedures",
+        "resourceId" : "com.vantiq.extsrc.camel4conn.ConnectorDeployment.deployToK8s"
+      } ],
+      "vantiqMemoryLimit" : [ {
+        "property" : "vantiqMemoryLimit",
+        "resource" : "procedures",
+        "resourceId" : "com.vantiq.extsrc.camel4conn.ConnectorDeployment.deployToK8s"
+      } ],
+      "vantiqServerUrl" : [ {
+        "property" : "vantiqTargetUrl",
+        "resource" : "procedures",
+        "resourceId" : "com.vantiq.extsrc.camel4conn.ConnectorDeployment.deployToK8s"
+      } ]
+    },
+    "configurationProperties": {
+      "vantiqServerUrl" : {
+        "description" : "The URL that the connector will use to contact Vantiq. Usually, this is what a user would type into the browser, but it may be different for access from the Kubernetes cluster in which this will run. Ignore if not running in Kubernetes.",
+        "type" : "String"
+      },
+      "vantiqAccessToken" : {
+        "description" : "Access token to be used by the connector to access Vantiq. Ignore if not using Kubernetes.",
+        "type" : "String"
+      },
+      "vantiqCpuLimit" : {
+        "default" : "500m",
+        "description" : "Kubernetes resource limit for the connector's CPU usage. Ignore if not using Kubernetes.",
+        "type" : "String"
+      },
+      "vantiqMemoryLimit" : {
+        "default" : "1Gi",
+        "description" : "Kubernetes resource limit for the connector's memory usage. Ignore if not using Kubernetes.",
+        "type" : "String"
+      },
+      "connectorImageTag" : {
+        "default": "2.0.1",
+        "description" : "The image tag used to pull the Camel Connector image.  Generally, no need to change this. Ignore if not running in Kubernetes.",
+        "type" : "String"
+      }
+    }
+}

--- a/camelConnector/src/main/resources/assembly/camel4connector/services/com/vantiq/extsrc/camel4conn/ConnectorDeployment.json
+++ b/camelConnector/src/main/resources/assembly/camel4connector/services/com/vantiq/extsrc/camel4conn/ConnectorDeployment.json
@@ -1,0 +1,75 @@
+{
+    "active": true,
+    "ars_relationships": [
+        
+    ],
+    "description": "Service for deployment of Camel Connector",
+    "globalType": null,
+    "interface" : [ {
+      "name" : "deployToK8s",
+      "description" : "Creates a K8sInstallation running the Vantiq Camel Connector. The procedure parameters provide the specifics required. Assumes that a K8sCluster already exists.",
+      "parameters" : [
+          {
+            "description" : "The name of the K8sCluster to which to deploy this connector.",
+            "multi" : false,
+            "name" : "clusterName",
+            "required" : true,
+            "type" : "String"
+          },{
+            "description" : "The name of the K8sInstallation to be deployed.",
+            "multi" : false,
+            "name" : "installationName",
+            "required" : true,
+            "type" : "String"
+          },{
+            "description" : "The name of Kubernetes namespace into which to deploy.",
+            "multi" : false,
+            "name" : "k8sNamespace",
+            "required" : false,
+            "type" : "String"
+          },{
+            "description" : "The URL of the Vantiq server with which the connector will interact. Generally, this is the same as what might be used in the browser, but it may be different when contacting from within a Kubernetes cluster.",
+            "multi" : false,
+            "name" : "targetUrl",
+            "required" : false,
+            "type" : "String"
+          },{
+            "description" : "The access token the connector will use to make the connection to the Vantiq server.",
+            "multi" : false,
+            "name" : "accessToken",
+            "required" : false,
+            "type" : "String"
+          },{
+            "description" : "The name of the Vantiq source implemented by this connector.",
+            "multi" : false,
+            "name" : "sourceName",
+            "required" : true,
+            "type" : "String"
+          },{
+            "description" : "The limit on the CPU usage for this connector within the Kubernetes cluster.",
+            "multi" : false,
+            "name" : "cpuLimit",
+            "required" : false,
+            "type" : "String"
+          },{
+            "description" : "The limit on the memory usage for this connector within the Kubernetes cluster.",
+            "multi" : false,
+            "name" : "memoryLimit",
+            "required" : false,
+            "type" : "String"
+          },{
+          "description" : "The docker image tag to be used when fetching the image to run",
+          "multi" : false,
+          "name" : "connectorImageTag",
+          "required" : false,
+          "type" : "String"
+        } ]
+      } ],
+    "internalEventHandlers": [ ],
+    "name": "com.vantiq.extsrc.camel4conn.ConnectorDeployment",
+    "partitionType": null,
+    "replicationFactor": 1,
+    "scheduledProcedures": {
+        
+    }
+}

--- a/camelConnector/src/main/resources/assembly/camel4connector/sourceimpls/CAMEL.json
+++ b/camelConnector/src/main/resources/assembly/camel4connector/sourceimpls/CAMEL.json
@@ -1,0 +1,9 @@
+{
+  "name" : "CAMEL",
+  "baseType" : "EXTENSION",
+  "verticle" : "service:extensionSource",
+  "config" : {},
+  "operations" : [ "publish", "query", "notification" ],
+  "baseConfigProperties": [
+  ]
+}


### PR DESCRIPTION
**Note**: This is a merge into a staging branch.  Said staging branch will be merged into master soon.

Updates assembly generation.  Generally, we've taken steps to support using assemblies from multiple camel versions in the same namespace.  There are places where our code is different, but we've named the packages to include at least part of the camel version.  At this point, pending news that that the camel 3 assemblies are being used, we plan to delete them from the catalog after the camel 4 stuff is made available.

Assemblies are camel version specific so add appropriate overrides (where required) for this version.  This is in the src/main/resources path.

Update assembly generation code to correctly merge maps of lists for our `additionalLibrary` support.  Jira, specifically, seems to have some issues with the interactions of their libraries and our Ivy code, so we supplement as required to pick up a few things that seem to get mangled. Update `dockerfile` to use Java 17-based image.

Update READMEs to refer to new versions of things.

Fixed a few other issues along the way, including the inclusion of the appropriate logger implementation in the camel connector.