### PR TITLE
Improve ObjRec tests

### DIFF
--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/ObjRecTestBase.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/ObjRecTestBase.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
+import java.util.List;
 
 import static org.junit.Assume.assumeTrue;
 
@@ -41,16 +42,24 @@ public class ObjRecTestBase {
 
     // Camera with some recognizable objects in it.
     // Use camera "close to home" -- CalTrans camera close to the office...
-//    public static final String IP_CAMERA_URL = "https://wzmedia.dot.ca.gov/D4/S680_at_N_Main_St.stream/playlist.m3u8";
+    public static final String IP_CAMERA_CALTRANS_WALNUTCREEK = "https://wzmedia.dot.ca.gov/D4/S680_at_N_Main_St.stream/playlist.m3u8";
     // Walnut Creek/North Main camera (above) currently malfunctioning.  Swapping to Hwy 242 Junction for now.
     // Keeping old around to swap back sometime.
 //    public static final String IP_CAMERA_URL = "https://wzmedia.dot.ca.gov/D4/N680_JSO_JCT_242.stream/playlist.m3u8";
 //    public static final String IP_CAMERA_URL = "https://wzmedia.dot.ca.gov/D3/80_reed.stream/playlist.m3u8";
 //    public static final String IP_CAMERA_URL = "http://166.143.31.94/cgi-bin/camera?resolution=640&amp;" +
 //            "quality=1&amp;Language=0&amp;1666639808";
-//    public static final String IP_CAMERA_URL = "http://115.179.100.76:8080/SnapshotJPEG?Resolution=640x480" +
-//            "&Quality=Standard&View=Normal&Count=224935296";
-    public static final String IP_CAMERA_URL = "http://220.233.144.165:8888/mjpg/video.mjpg"; // Sydney harbour camera
+    public static final String IP_CAMERA_JAPAN = "http://115.179.100.76:8080/SnapshotJPEG?Resolution=640x480" +
+            "&Quality=Standard&View=Normal&Count=224935296";
+    public static final String IP_CAMERA_SYDNEY_HARBOR = "http://220.233.144.165:8888/mjpg/video.mjpg"; // Sydney
+    // harbour camera
+    public static final List<String> CAMERA_CHOICE = List.of(
+            IP_CAMERA_CALTRANS_WALNUTCREEK,
+            IP_CAMERA_JAPAN,
+            IP_CAMERA_SYDNEY_HARBOR
+    );
+    
+    public static String IP_CAMERA_URL = null;
 
     @BeforeClass
     public static void getProps() {
@@ -112,5 +121,19 @@ public class ObjRecTestBase {
         } catch (java.io.IOException e) {
             return false;
         }
+    }
+    
+    public static String findValidCamera() {
+        String workingIPCamera = null;
+        
+        for (String cam: CAMERA_CHOICE) {
+            if (isIpAccessible(cam)) {
+                workingIPCamera = cam;
+                break;
+            }
+        }
+        IP_CAMERA_URL = workingIPCamera;
+        assumeTrue("No valid IP camera found", IP_CAMERA_URL != null);
+        return IP_CAMERA_URL;
     }
 }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestNetworkStreamRetriever.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestNetworkStreamRetriever.java
@@ -39,7 +39,7 @@ public class TestNetworkStreamRetriever extends ObjRecTestBase {
     @Test
     public void testIpCamera() {
         // Don't fail if camera's offline...
-        assumeTrue("Could not open requested url", isIpAccessible(IP_CAMERA_URL));
+        findValidCamera();
         
         try {
             Map<String, String> config = new LinkedHashMap<>();
@@ -64,7 +64,7 @@ public class TestNetworkStreamRetriever extends ObjRecTestBase {
     @Ignore("Test camera seems to have disappeared.  Need a more reliable strategy for these things")
     public void testRtspCamera() {
         // Don't fail if camera's offline...
-        assumeTrue("Could not open requested url", isIpAccessible(IP_CAMERA_URL));
+        assumeTrue("Could not open requested url", isIpAccessible(RTSP_CAMERA_ADDRESS));
 
         try {
             Map<String, String> config = new LinkedHashMap<>();

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
@@ -32,7 +32,7 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         put("name", QUERY_FILENAME);
     }};
     
-    static final String ipCameraInUse = IP_CAMERA_URL;
+    static final String ipCameraInUse = findValidCamera();
     static boolean cameraOperational = false;
     @BeforeClass
     public static void setup() {

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
@@ -138,6 +138,7 @@ public class TestParallelProcessing extends NeuralNetTestBase {
         }
 
         // Setting up dataSource config options
+        findValidCamera();
         dataSource.put("camera", IP_CAMERA_URL);
         dataSource.put("type", "network");
 

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -120,7 +120,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
     static final int CROPPED_WIDTH = 200;
     static final int CROPPED_HEIGHT = 150;
     
-    static final String ipCameraToUse = IP_CAMERA_URL;
+    static final String ipCameraToUse = findValidCamera();
     static boolean cameraOperational = false;
     @BeforeClass
     public static void setup() throws Exception {


### PR DESCRIPTION
Fixes #521 

Hopefully improve on the _whack-a-mole_ game with online IP cameras.  We know of at least 3 cameras that sort of come & go, and each time one goes for a while, we swap in the code.

This change maintains a list of those cameras. As the tests run, the tests probe the cameras to see if they are IP accessible.  The first one found to be OK is returned and used for that particular test (or test suite).  If one is offline, we move on and try another.

While certainly not foolproof, this will hopefully reduce the number of failed tests due to these situations.  When no valid camera is found, the tests should ignore themselves (`assumeTrue`) so things should quiet down a bit.