### PR TITLE
Improve ObjectRec test reliability & consistency

### DIFF
--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/ObjRecTestBase.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/ObjRecTestBase.java
@@ -18,6 +18,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.util.List;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assume.assumeTrue;
 
 public class ObjRecTestBase {
@@ -124,6 +125,10 @@ public class ObjRecTestBase {
     }
     
     public static String findValidCamera() {
+        return findValidCamera(false);
+    }
+    
+    public static String findValidCamera(boolean failIfNone) {
         String workingIPCamera = null;
         
         for (String cam: CAMERA_CHOICE) {
@@ -133,7 +138,11 @@ public class ObjRecTestBase {
             }
         }
         IP_CAMERA_URL = workingIPCamera;
-        assumeTrue("No valid IP camera found", IP_CAMERA_URL != null);
+        if (failIfNone) {
+            assertNotNull("No valid IP camera found for testing", IP_CAMERA_URL);
+        } else {
+            assumeTrue("No valid IP camera found found for testing", IP_CAMERA_URL != null);
+        }
         return IP_CAMERA_URL;
     }
 }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/ObjRecTestBase.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/ObjRecTestBase.java
@@ -48,14 +48,14 @@ public class ObjRecTestBase {
     // Keeping old around to swap back sometime.
 //    public static final String IP_CAMERA_URL = "https://wzmedia.dot.ca.gov/D4/N680_JSO_JCT_242.stream/playlist.m3u8";
 //    public static final String IP_CAMERA_URL = "https://wzmedia.dot.ca.gov/D3/80_reed.stream/playlist.m3u8";
-//    public static final String IP_CAMERA_URL = "http://166.143.31.94/cgi-bin/camera?resolution=640&amp;" +
-//            "quality=1&amp;Language=0&amp;1666639808";
-    public static final String IP_CAMERA_JAPAN = "http://115.179.100.76:8080/SnapshotJPEG?Resolution=640x480" +
-            "&Quality=Standard&View=Normal&Count=224935296";
+//    public static final String IP_CAMERA_URL =
+//          "http://166.143.31.94/cgi-bin/camera?resolution=640&amp;quality=1&amp;Language=0&amp;1666639808";
+    public static final String IP_CAMERA_JAPAN =
+            "http://115.179.100.76:8080/SnapshotJPEG?Resolution=640x480&Quality=Standard&View=Normal&Count=224935296";
     public static final String IP_CAMERA_SYDNEY_HARBOR = "http://220.233.144.165:8888/mjpg/video.mjpg"; // Sydney
     // harbour camera
     public static final List<String> CAMERA_CHOICE = List.of(
-            IP_CAMERA_CALTRANS_WALNUTCREEK,
+//            IP_CAMERA_CALTRANS_WALNUTCREEK, unreliable
             IP_CAMERA_JAPAN,
             IP_CAMERA_SYDNEY_HARBOR
     );

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestNetworkStreamRetriever.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestNetworkStreamRetriever.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import io.vantiq.extsrc.objectRecognition.ObjRecTestBase;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
+
 import org.junit.Test;
 
 import io.vantiq.extsrc.objectRecognition.NoSendORCore;
@@ -17,7 +17,9 @@ import io.vantiq.extsrc.objectRecognition.exception.ImageAcquisitionException;
 
 public class TestNetworkStreamRetriever extends ObjRecTestBase {
 
-    static final String RTSP_CAMERA_ADDRESS = "rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mp4";
+//    static final String RTSP_CAMERA_ADDRESS = "rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mp4";
+    static final String RTSP_CAMERA_ADDRESS =
+            "rtsp://rtspstream:6887db7543c447ddd4ccdb1d2493ee26@zephyr.rtsp.stream/movie";
     // Alternate purportedly opened, but sometimes apparently broken...
     // "rtsp://demo:demo@ipvmdemo.dyndns.org:5541/onvif-media/media.amp?profile=profile_1_h264&sessiontimeout=60&streamtype=unicast";
 
@@ -34,6 +36,11 @@ public class TestNetworkStreamRetriever extends ObjRecTestBase {
     public void tearDown() {
         retriever.close();
         source.close();
+    }
+    
+    @Test
+    public void verifySomeIpCameraValid() {
+        findValidCamera(true);
     }
     
     @Test
@@ -61,10 +68,8 @@ public class TestNetworkStreamRetriever extends ObjRecTestBase {
     }
 
     @Test
-    @Ignore("Test camera seems to have disappeared.  Need a more reliable strategy for these things")
     public void testRtspCamera() {
         // Don't fail if camera's offline...
-        assumeTrue("Could not open requested url", isIpAccessible(RTSP_CAMERA_ADDRESS));
 
         try {
             Map<String, String> config = new LinkedHashMap<>();

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestNetworkStreamRetriever.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/imageRetriever/TestNetworkStreamRetriever.java
@@ -1,8 +1,8 @@
 package io.vantiq.extsrc.objectRecognition.imageRetriever;
 
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
 
+import java.security.MessageDigest;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -44,7 +44,7 @@ public class TestNetworkStreamRetriever extends ObjRecTestBase {
     }
     
     @Test
-    public void testIpCamera() {
+    public void testIpCamera() throws Exception {
         // Don't fail if camera's offline...
         findValidCamera();
         
@@ -56,19 +56,29 @@ public class TestNetworkStreamRetriever extends ObjRecTestBase {
             fail("Could not setup retriever: " + e.getMessage());
         }
         
-        try {
-            ImageRetrieverResults imgResults = retriever.getImage();
-            assert imgResults != null;
-            byte[] data = imgResults.getImage();
-            assert data != null;
-            assert data.length > 0;
-        } catch (ImageAcquisitionException e) {
-            fail("Exception occurred when requesting frame from camera: " + e.toString());
+        byte[] previousDigest = null;
+        MessageDigest md = MessageDigest.getInstance("MD5");
+        
+        for (int i = 0; i < 10; i++) {
+            try {
+                ImageRetrieverResults imgResults = retriever.getImage();
+                assert imgResults != null;
+                byte[] data = imgResults.getImage();
+                assert data != null;
+                assert data.length > 0;
+                byte[] digest = md.digest(data);
+                if (previousDigest != null) {
+                    assert !previousDigest.equals(digest);
+                }
+                previousDigest = digest;
+            } catch (ImageAcquisitionException e) {
+                fail("Exception occurred when requesting frame from camera: " + e.toString());
+            }
         }
     }
 
     @Test
-    public void testRtspCamera() {
+    public void testRtspCamera() throws Exception {
         // Don't fail if camera's offline...
 
         try {
@@ -78,15 +88,24 @@ public class TestNetworkStreamRetriever extends ObjRecTestBase {
         } catch (Exception e) {
             fail("Could not setup retriever: " + e.getMessage());
         }
-
-        try {
-            ImageRetrieverResults imgResults = retriever.getImage();
-            assert imgResults != null;
-            byte[] data = imgResults.getImage();
-            assert data != null;
-            assert data.length > 0;
-        } catch (ImageAcquisitionException e) {
-            fail("Exception occurred when requesting frame from camera: " + e.toString());
+        
+        byte[] previousDigest = null;
+        MessageDigest md = MessageDigest.getInstance("MD5");
+        for (int i = 0; i < 10; i++) {
+            try {
+                ImageRetrieverResults imgResults = retriever.getImage();
+                assert imgResults != null;
+                byte[] data = imgResults.getImage();
+                assert data != null;
+                assert data.length > 0;
+                byte[] digest = md.digest(data);
+                if (previousDigest != null) {
+                    assert !previousDigest.equals(digest);
+                }
+                previousDigest = digest;
+            } catch (ImageAcquisitionException e) {
+                fail("Exception occurred when requesting frame from camera: " + e.toString());
+            }
         }
     }
 }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
@@ -323,8 +323,9 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         Map<String,Object> neuralNet = new LinkedHashMap<String,Object>();
         
         // Setting up dataSource config options
-        dataSource.put("camera", ipCameraInUse);
-        dataSource.put("type", "network");
+        dataSource.put("fileLocation", VIDEO_LOCATION);
+        dataSource.put("fileExtension", "mov");
+        dataSource.put("type", "file");
         
         // Setting up general config options
         general.put("allowQueries", true);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestParallelProcessing.java
@@ -138,9 +138,9 @@ public class TestParallelProcessing extends NeuralNetTestBase {
         }
 
         // Setting up dataSource config options
-        findValidCamera();
-        dataSource.put("camera", IP_CAMERA_URL);
-        dataSource.put("type", "network");
+        dataSource.put("fileLocation", VIDEO_LOCATION);
+        dataSource.put("fileExtension", "mov");
+        dataSource.put("type", "file");
 
         // Setting up neuralNet config options
         neuralNet.put("type", "test");

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -1915,6 +1915,9 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         config.put("metaFile", META_FILE);
         config.put("cropBeforeAnalysis", preCrop);
         config.put("includeEncodedImage", true);
+        // Some of these tests are close here, so the confidence can vary.  Pick a
+        // reasonable value for the threshold.
+        config.put("threshold", 50);
         if (labelOption) {
             config.put("labelImage", "true");
         }
@@ -2088,7 +2091,8 @@ public class TestYoloProcessor extends NeuralNetTestBase {
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     void resultsEquals(List<Map<String, ?>> list, List<Map> expectedRes) {
-        assertEquals("list Size: " + list.size() + ", expected: " + expectedRes.size() + " :: " + list,
+        assertEquals("list Size: " + list.size() +" :: " + list +
+                             ", expected: " + expectedRes.size() + " :: " + expectedRes,
                 expectedRes.size(), list.size());
         for (int i = 0; i < list.size(); i++) {
             mapEquals(list.get(i), expectedRes.get(i));

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -2160,7 +2160,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         neuralNet.put("type", "yolo");
         neuralNet.put("metaFile", META_FILE);
         neuralNet.put("pbFile", PB_FILE);
-        neuralNet.put("threshold", 60); // Overcome strange interpretation of camera images
+        neuralNet.put("threshold", 50); // Overcome strange interpretation of camera images
 
         // Placing general config options in "objRecConfig"
         objRecConfig.put("general", general);

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -120,8 +120,9 @@ public class TestYoloQueries extends NeuralNetTestBase {
     static final int CROPPED_WIDTH = 200;
     static final int CROPPED_HEIGHT = 150;
     
-    static final String ipCameraToUse = findValidCamera();
+    static String ipCameraToUse = null;
     static boolean cameraOperational = false;
+    
     @BeforeClass
     public static void setup() throws Exception {
         if (testAuthToken != null && testVantiqServer != null) {
@@ -144,7 +145,7 @@ public class TestYoloQueries extends NeuralNetTestBase {
             } catch (Exception e) {
                 fail("Trapped exception creating source impl: " + e);
             }
-            
+            ipCameraToUse = findValidCamera();
             cameraOperational = isIpAccessible(ipCameraToUse);
             createServerConfig();
             setupSource(createSourceDef());

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -1183,8 +1183,9 @@ public class TestYoloQueries extends NeuralNetTestBase {
         Map<String, Object> neuralNet = new LinkedHashMap<>();
         
         // Setting up dataSource config options
-        dataSource.put("camera", ipCameraToUse);
-        dataSource.put("type", "network");
+        dataSource.put("fileLocation", VIDEO_LOCATION);
+        dataSource.put("fileExtension", "mov");
+        dataSource.put("type", "file");
         
         // Setting up general config options
         general.put("allowQueries", true);


### PR DESCRIPTION
Fixes #523 

Adds a test (and some minor refactoring) that will fail if no valid IP cameras are found.  This avoids tons of result pollution when such things happen, but still lets us know without have to count skipped tests.

Also, generated new RTSP camera & re-enabled RTSP-based network retriever test.  We'll see how long this one lasts.