### PR TITLE
Fix some camel deprecation warnings

### DIFF
--- a/buildSrc/src/main/groovy/io/vantiq/extsrc/assy/tasks/AssemblyResourceGeneration.groovy
+++ b/buildSrc/src/main/groovy/io/vantiq/extsrc/assy/tasks/AssemblyResourceGeneration.groovy
@@ -73,7 +73,7 @@ class AssemblyResourceGeneration extends DefaultTask {
 
     public static final String FROM_ROUTE_TAG = 'from'
     public static final String ID_ROUTE_TAG = 'id'
-    public static final String ROUTE_TEMPLATE_TAG = 'route-template'
+    public static final String ROUTE_TEMPLATE_TAG = 'routeTemplate'
     public static final String TO_ROUTE_TAG = 'to'
     public static final String URI_ROUTE_TAG = 'uri'
 

--- a/camelAssemblies/src/main/resources/routeOverrides/fhir_sink/v4_4_3/fhir_sink.routes.yaml
+++ b/camelAssemblies/src/main/resources/routeOverrides/fhir_sink/v4_4_3/fhir_sink.routes.yaml
@@ -1,4 +1,4 @@
--   route-template:
+-   routeTemplate:
         id: Route templates from fhir_sink:v4_4_3 (modified)
         from:
             uri: vantiq://server.config?consumerOutputJsonStream=true&structuredMessageHeader=true

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/VantiqConfigurationTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/connector/VantiqConfigurationTest.java
@@ -587,7 +587,7 @@ public class VantiqConfigurationTest extends CamelTestSupport {
     // typeConverter in the context (trashed on close), and threw an NPE.  Here, we verify that this basic route
     // work as expected.  It takes a bit of time to set things up, but a reasonable test.
     public static final String FHIR_SINK_ROUTE_YAML = "\n"
-            + "-   route-template:\n"
+            + "-   routeTemplate:\n"
             + "       id: Route templates from fhir_sink:v3_21_0\n"
             + "       from:\n"
             + "           uri: direct:start\n"
@@ -600,14 +600,14 @@ public class VantiqConfigurationTest extends CamelTestSupport {
             + "                        steps:\n"
             + "                        -   unmarshal:\n"
             + "                                fhirJson:\n"
-            + "                                    fhir-version: '{{fhirVersion}}'\n"
-            + "                                    pretty-print: '{{prettyPrint}}'\n"
+            + "                                    fhirVersion: '{{fhirVersion}}'\n"
+            + "                                    prettyPrint: '{{prettyPrint}}'\n"
             + "                    -   simple: ${properties:encoding} =~ 'XML'\n"
             + "                        steps:\n"
             + "                        -   unmarshal:\n"
             + "                                fhirXml:\n"
-            + "                                    fhir-version: '{{fhirVersion}}'\n"
-            + "                                    pretty-print: '{{prettyPrint}}'\n"
+            + "                                    fhirVersion: '{{fhirVersion}}'\n"
+            + "                                    prettyPrint: '{{prettyPrint}}'\n"
             + "           -   to:\n"
             + "                    uri: fhir://{{apiName}}/{{methodName}}\n"
             + "                    parameters:\n"
@@ -629,8 +629,8 @@ public class VantiqConfigurationTest extends CamelTestSupport {
             + "                        password: '{{?password}}'\n"
             + "           - marshal:\n"
             + "               fhirJson:\n"
-            + "                   fhir-version: '{{fhirVersion}}'\n"
-            + "                   pretty-print: '{{prettyPrint}}'\n"
+            + "                   fhirVersion: '{{fhirVersion}}'\n"
+            + "                   prettyPrint: '{{prettyPrint}}'\n"
             + "           - to:\n"
             + "                  uri: mock:result"; // Send off to mock result so we can verify the output
 

--- a/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentResolverTest.java
+++ b/camelConnector/src/test/java/io/vantiq/extsrc/camelconn/discover/VantiqComponentResolverTest.java
@@ -1061,7 +1061,7 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
     
     private static class BeanIncludingRouteTemplate extends RouteBuilderWithProps {
         public String content = ""
-                + "-   route-template:\n"
+                + "-   routeTemplate:\n"
                 + "        id: Route templates from aws_s3_source:v3_21_0\n"
                 + "        beans:\n"
                 + "        -   name: renameHeaders\n"
@@ -1103,7 +1103,7 @@ public class VantiqComponentResolverTest extends CamelTestSupport {
         String headerDupBeanName;
         
         public String content = ""
-                + "-   route-template:\n"
+                + "-   routeTemplate:\n"
                 + "        id: Route templates from aws_s3_source:v3_21_0\n"
                 + "        beans:\n"
                 + "        -   name: renameHeaders\n"


### PR DESCRIPTION
No issue reported

Camel's yaml format now _encourages_ camelCase rather than _kebab-case_.  Fix places in tests & route overrides where this happens.

There are still a couple of places where this shows up, but those are preserved from the Camel Kamelet definitions, so we'll leave those at the source kamelets define them.  The kebab-case properties still work;  we just get deprecation warnings in the code.  Where we're generating these, we fix them.