### PR TITLE
EXTPSDK: Add ability to provide keyword arguments to connect() call

### DIFF
--- a/extpsdk/README.md
+++ b/extpsdk/README.md
@@ -82,6 +82,8 @@ In addition to the configuration properties shown above, the `server.config` fil
 
 *   `sendPings`: A boolean property that, if set to `true`, enables the SDK to send ping messages to the Vantiq Server. 
 The ping messages are handled by the underlying websockets library.
+*   `connectKWArgs`: A string property that, if set, contains a JSON string representing keyword arguments to be passed
+to the `websockets.client.connect()` call. A common case is alter SSL processing in development environments.
 
 The system expects the `server.config` file to be located in a directory named `serverConfig` in the working directory of the connector.
 
@@ -91,12 +93,26 @@ Otherwise, if the `authToken` is not set in the configuration file, the system w
 The server config file is written as `property=value`, with each property on its own line. The following is an example 
 of a valid `server.config` file (including the `authToken`, but that can be omitted and specified as an environment 
 variable instead):
+
 ```
 authToken=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 sources=MySourceName
 targetServer=https://dev.vantiq.com/
 sendPings=true
 ```
+
+In a development environment, one might disable SSL processing by providing the following config file:
+
+```
+authToken=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+sources=MySourceName
+targetServer=https://dev.vantiq.com/
+sendPings=true
+connectKWArgs={ "ssl": false }
+```
+
+(Note that although this is Python code, the `connectKWArgs` property contains JSON, so the `false` must be
+provided as JSON -- lowercase.)
 
 ### Program Flow
 

--- a/extpsdk/build.gradle
+++ b/extpsdk/build.gradle
@@ -11,7 +11,7 @@ ext {
         pypi_repo = 'testpypi'
     }
     if (!project.rootProject.hasProperty('vantiqConnectorSdkVersion')) {
-        vantiqConnectorSdkVersion = '1.2.12'
+        vantiqConnectorSdkVersion = '1.3.0'
     }
 }
 


### PR DESCRIPTION
Fixes #528

It is occasionally necessary to provide extra arguments to the websockets connect call.  This is typically a case for disabling SSL verification in a development environment.

To enable this, we provide for the `connectKWArgs` property to be part of the `server.config` file used to specify the connection to Vantiq in a connector.  The content of this property should be a valid JSON string specifying the names & values of the keyword arguments.  Note that this is "just" a string -- making Python calls is not supported.  A typical case will be something like

```
connectKWArgs={ "ssl": false}
```

as part of the `server.config` file.