### PR TITLE
Disable SSL processing in a manner usable by the Python exec source connector

### DIFF
--- a/extpsdk/README.md
+++ b/extpsdk/README.md
@@ -83,9 +83,13 @@ In addition to the configuration properties shown above, the `server.config` fil
 *   `sendPings`: A boolean property that, if set to `true`, enables the SDK to send ping messages to the Vantiq Server. 
 The ping messages are handled by the underlying websockets library.
 *   `connectKWArgs`: A string property that, if set, contains a JSON string representing keyword arguments to be passed
-to the `websockets.client.connect()` call. A common case is alter SSL processing in development environments.
+to the `websockets.client.connect()` call. A common case is alter SSL processing in development environments. Here, you
+can pass either a set of keyword arguments to the `connect()` call, or the special argument `disableSslVerification`
+with a value of `true`.  This _special_ argument allows the connector SDK to perform the internal setup required to
+disable SSL verification.
 
-The system expects the `server.config` file to be located in a directory named `serverConfig` in the working directory of the connector.
+The system expects the `server.config` file to be located in a directory named `serverConfig` in 
+the working directory of the connector.
 
 For users who may not want to write the `authToken` property to a file because of its sensitive nature, set the environment variable `CONNECTOR_AUTH_TOKEN` to its value. If the `authToken` is specified in the `server.config` document, that value will take precedence.
 Otherwise, if the `authToken` is not set in the configuration file, the system will retrieve whatever value is provided in the environment variable.
@@ -108,10 +112,10 @@ authToken=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 sources=MySourceName
 targetServer=https://dev.vantiq.com/
 sendPings=true
-connectKWArgs={ "ssl": false }
+connectKWArgs={ "disableSslVerification": true }
 ```
 
-(Note that although this is Python code, the `connectKWArgs` property contains JSON, so the `false` must be
+(Note that although this is Python code, the `connectKWArgs` property contains JSON, so the `true` must be
 provided as JSON -- lowercase.)
 
 ### Program Flow

--- a/extpsdk/build.gradle
+++ b/extpsdk/build.gradle
@@ -11,7 +11,7 @@ ext {
         pypi_repo = 'testpypi'
     }
     if (!project.rootProject.hasProperty('vantiqConnectorSdkVersion')) {
-        vantiqConnectorSdkVersion = '1.3.0'
+        vantiqConnectorSdkVersion = '1.3.1'
     }
 }
 

--- a/extpsdk/build.gradle
+++ b/extpsdk/build.gradle
@@ -11,7 +11,7 @@ ext {
         pypi_repo = 'testpypi'
     }
     if (!project.rootProject.hasProperty('vantiqConnectorSdkVersion')) {
-        vantiqConnectorSdkVersion = '1.3.1'
+        vantiqConnectorSdkVersion = '1.3.2'
     }
 }
 

--- a/extpsdk/build.gradle
+++ b/extpsdk/build.gradle
@@ -11,7 +11,7 @@ ext {
         pypi_repo = 'testpypi'
     }
     if (!project.rootProject.hasProperty('vantiqConnectorSdkVersion')) {
-        vantiqConnectorSdkVersion = '1.3.2'
+        vantiqConnectorSdkVersion = '1.3.3'
     }
 }
 

--- a/extpsdk/pytest.ini
+++ b/extpsdk/pytest.ini
@@ -5,7 +5,7 @@ filterwarnings =
 junit_logging = all
 junit_suite_name=io.vantiq.extsrc.extpsdk
 minversion = 6.0
-addopts = -rE -q --junit-xml=./build/test-results/test/TEST-io.vantiq.extsrc.extpsdk.pytest.xml
+addopts = -rE -q --html=./build/reports/tests/test/index.html --junit-xml=./build/test-results/test/TEST-io.vantiq.extsrc.extpsdk.pytest.xml
 asyncio_mode = strict
 testpaths = src/test/python
 pythonpath = src/main/python

--- a/extpsdk/src/main/python/vantiqconnectorsdk.py
+++ b/extpsdk/src/main/python/vantiqconnectorsdk.py
@@ -226,7 +226,10 @@ class VantiqSourceConnection:
                     disable_ssl = kw_temp.get(VantiqConnector.DISABLE_SSL_VERIFICATION)
                     if disable_ssl is not None and disable_ssl:
                         self.disable_ssl_check = True
-                        self.connect_kw_args = {"ssl": ssl.SSLContext(ssl.CERT_NONE)}
+                        ctx = ssl.create_default_context()
+                        ctx.check_hostname = False
+                        ctx.verify_mode = ssl.CERT_NONE
+                        self.connect_kw_args = {"ssl": ctx}
                     else:
                         self.connect_kw_args = kw_temp
                 except JSONDecodeError as jde:

--- a/extpsdk/src/main/python/vantiqconnectorsdk.py
+++ b/extpsdk/src/main/python/vantiqconnectorsdk.py
@@ -226,7 +226,7 @@ class VantiqSourceConnection:
                     disable_ssl = kw_temp.get(VantiqConnector.DISABLE_SSL_VERIFICATION)
                     if disable_ssl is not None and disable_ssl:
                         self.disable_ssl_check = True
-                        self.connect_kw_args = {"sslopt": {"cert_reqs": ssl.CERT_NONE}}
+                        self.connect_kw_args = {"ssl": ssl.SSLContext(ssl.CERT_NONE)}
                     else:
                         self.connect_kw_args = kw_temp
                 except JSONDecodeError as jde:

--- a/extpsdk/src/main/python/vantiqconnectorsdk.py
+++ b/extpsdk/src/main/python/vantiqconnectorsdk.py
@@ -45,6 +45,7 @@ __all__ = ['VantiqSourceConnection',
            ]
 
 import asyncio
+import ssl
 import uuid
 from asyncio import Future
 import json
@@ -172,6 +173,7 @@ class VantiqConnector:
     PORT_PROPERTY_NAME = "tcpProbePort"
     TCP_PROBE_PORT_DEFAULT = 8000
     CONNECT_KW_ARGS = 'connectKWArgs'
+    DISABLE_SSL_VERIFICATION = 'disableSslVerification'
 
 
 class VantiqConnectorException(RuntimeError):
@@ -210,6 +212,7 @@ class VantiqSourceConnection:
         self._connector_set = None
         # Initialize with empty to make usage easier.
         self.connect_kw_args: dict = {}
+        self.disable_ssl_check = False
         if config is not None:
             fixedReconnectSecret : string = config.get(VantiqConnector.FIXED_RECONNECT_SECRET, None)
             if fixedReconnectSecret is None:
@@ -220,7 +223,12 @@ class VantiqSourceConnection:
             if kwArgString is not None:
                 try:
                     kw_temp : dict = json.loads(kwArgString)
-                    self.connect_kw_args = kw_temp
+                    disable_ssl = kw_temp.get(VantiqConnector.DISABLE_SSL_VERIFICATION)
+                    if disable_ssl is not None and disable_ssl:
+                        self.disable_ssl_check = True
+                        self.connect_kw_args = {"sslopt": {"cert_reqs": ssl.CERT_NONE}}
+                    else:
+                        self.connect_kw_args = kw_temp
                 except JSONDecodeError as jde:
                     raise VantiqConnectorConfigException(f'{VantiqConnector.CONNECT_KW_ARGS} did not contain valid '
                                                          f'JSON string.') from jde


### PR DESCRIPTION
Fixes #528 (for real!)

Previously, we added the ability to handle keyword arguments, passing them through to the Vantiq websocket connection.

Unfortunately, when making use of this in the connector, there are inconsistencies between the keyword arguments supported by the "regular" Vantiq connection of this SDK's websocket connection.  

To handle this, we extend the keyword argument support in include `disableSslVerification=true`.  When this is provided, the connector SDK builds a special SSL context with hostname & certification verification disabled, and uses that as the keyword `dict`-ionary.  This is acceptable to both the web sockets connection & the Vantiq rest connection.

Updated a few versions & documentation...