### PR TITLE
Enable use of extension sdk's keyword arguments

### DIFF
--- a/pythonExecSource/README.md
+++ b/pythonExecSource/README.md
@@ -43,6 +43,25 @@ authToken = _cDWBfZLNO9FkXd-twjwKnVIBZSGwns35nF4nQFV_ps=
 sources = pythonSource
 ```
 
+As outlined in the vantiqconnectorsdk, there is also the option of providing extra keyword arguments that will be used
+to make connections to Vantiq.  These will be used both for the vantiqconnectorsdk connection as well any "regular"
+Vantiq connections used.  These are use, for example, for reading documents containing Python
+code.
+
+To make use of this capability, include the `connectKWArgs` property in your config file.
+
+A special case is use for disabling SSL verification (often used in development environments). To do this, use the
+argument `disableSslVerification`.  This sets up both the connector's websocket connection and the auxiliary 
+Vantiq connection to skip SSL verification.  Doing so, internally, requires some Python code not directly
+representable in JSON.  The following example shows how this is done.
+
+``
+targetServer = https://dev.vantiq.com
+authToken = _cDWBfZLNO9FkXd-twjwKnVIBZSGwns35nF4nQFV_ps=
+sources = pythonSource
+connectKWArgs={ "disableSslVerification": true }
+```
+
 For users who may not want to write the `authToken` property to a file because of its sensitive nature, set the environment variable `CONNECTOR_AUTH_TOKEN` to its value. If the `authToken` is specified in the `server.config` document, that value will take precedence.
 Otherwise, if the `authToken` is not set in the configuration file, the system will retrieve whatever value is provided in the environment variable.
 

--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -12,11 +12,11 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('pyExecSrcVersion')) {
-        pyExecSrcVersion = '1.2.12'
+        pyExecSrcVersion = '1.3.0'
     }
     // If these change, update requirements-conn.in as well -- as that's used to generate the requirements.txt file
-    vantiqPythonSdkVersion = '1.3.5'
-    vantiqConnectorSdkVersion = '1.2.12'
+    vantiqPythonSdkVersion = '1.4.0'
+    vantiqConnectorSdkVersion = '1.3.4'
 }
 
 python {

--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -16,7 +16,7 @@ ext {
     }
     // If these change, update requirements-conn.in as well -- as that's used to generate the requirements.txt file
     vantiqPythonSdkVersion = '1.4.0'
-    vantiqConnectorSdkVersion = '1.3.4'
+    vantiqConnectorSdkVersion = '1.3.3'
 }
 
 python {

--- a/pythonExecSource/requirements-conn.in
+++ b/pythonExecSource/requirements-conn.in
@@ -1,5 +1,5 @@
 websockets>=12.0
 aiohttp>=3.10.2
-vantiqconnectorsdk>=1.2.12
-vantiqsdk>=1.3.5
+vantiqconnectorsdk>=1.3.3
+vantiqsdk>=1.4.0
 requests>=2.32.3

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -140,9 +140,9 @@ urllib3==2.2.2
     # via
     #   requests
     #   twine
-vantiqconnectorsdk==1.2.12
+vantiqconnectorsdk==1.3.3
     # via -r requirements-conn.in
-vantiqsdk==1.3.5
+vantiqsdk==1.4.0
     # via -r requirements-conn.in
 websockets==12.0
     # via

--- a/pythonExecSource/src/main/python/pyExecConnector.py
+++ b/pythonExecSource/src/main/python/pyExecConnector.py
@@ -398,7 +398,10 @@ class PyExecConnector:
                 url = config[VantiqConnector.TARGET_SERVER]
                 # We may need to sanitize the URL here.
                 url = self.sanitize_url(url)
-                self.vantiq_client = Vantiq(url)
+                if isinstance(self.connection.connect_kw_args, dict) and self.connection.connect_kw_args:
+                    self.vantiq_client = Vantiq(url, "1", **self.connection.connect_kw_args)
+                else:
+                    self.vantiq_client = Vantiq(url)
                 await self.vantiq_client.set_access_token(config[VantiqConnector.AUTH_TOKEN])
         except VantiqException as ve:
             if self.vantiq_client is not None:


### PR DESCRIPTION
Fixes #529

Updates versions of SDKs in use, and adds a test to verify that things are acceptable.

Also, when making a "regular" Vantiq connection to pull documents containing Python source to execute, pass the same KW args along.