### PR TITLE
Protect .onlyIf & .dependsOn from cases where tasks don't exist

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,9 +110,7 @@ subprojects {
             }
         }
     }
-    if (project.tasks.findByName('buildConnectorImage')) {
-        buildConnectorImage.dependsOn assemble
-    }
+
     project.afterEvaluate { x ->
         // Add dependency to Gradle for the archive file used in the connector docker image. This avoids warnings
         // from gradle about undeclared dependencies.  The warning didn't really cause an issue, but it looks messy
@@ -124,6 +122,10 @@ subprojects {
 
         if (project.tasks.findByName('copyConnectorBuildFiles') && project.tasks.findByName('distTar')) {
             copyConnectorBuildFiles.dependsOn distTar
+        }
+
+        if (project.tasks.findByName('buildConnectorImage')) {
+            buildConnectorImage.dependsOn assemble
         }
     }
 

--- a/camelAssemblies/build.gradle
+++ b/camelAssemblies/build.gradle
@@ -168,8 +168,10 @@ tasks.register('publishAssemblies') {
 importAssemblies.mustRunAfter( 'generateAssemblyResources' )
 publishAssemblies.mustRunAfter('importAssemblies')
 
-// This is not a connector so no connector image should be constructed or pushed.
-buildImages.onlyIf { false }
-buildConnectorImage.onlyIf { false }
-pushImages.onlyIf { false }
-pushConnectorImage.onlyIf { false }
+if (project.tasks.findByName('buildImages') != null && project.tasks.findByName('buildConnectorImage') != null) {
+    // This is not a connector so no connector image should be constructed or pushed.
+    buildImages.onlyIf { false }
+    buildConnectorImage.onlyIf { false }
+    pushImages.onlyIf { false }
+    pushConnectorImage.onlyIf { false }
+}

--- a/camelComponent/build.gradle
+++ b/camelComponent/build.gradle
@@ -82,8 +82,10 @@ artifacts {
     testArtifacts testJar
 }
 
-// This is not a connector so no connector image should be constructed or pushed.
-buildImages.onlyIf { false }
-buildConnectorImage.onlyIf { false }
-pushImages.onlyIf { false }
-pushConnectorImage.onlyIf { false }
+if (project.tasks.findByName('buildImages') && project.tasks.findByName('buildConnectorImage')) {
+    // This is not a connector so no connector image should be constructed or pushed.
+    buildImages.onlyIf { false }
+    buildConnectorImage.onlyIf { false }
+    pushImages.onlyIf { false }
+    pushConnectorImage.onlyIf { false }
+}

--- a/extjsdk/build.gradle
+++ b/extjsdk/build.gradle
@@ -101,8 +101,10 @@ task fatJar(type: Jar) {
                 collect( { zipTree(it) })
 }
 
-// This is not a connector so no connector image should be constructed or pushed.
-buildImages.onlyIf { false }
-buildConnectorImage.onlyIf { false }
-pushImages.onlyIf { false }
-pushConnectorImage.onlyIf { false }
+if (project.tasks.findByName('buildImages') && project.tasks.findByName('buildConnectorImage')) {
+    // This is not a connector so no connector image should be constructed or pushed.
+    buildImages.onlyIf { false }
+    buildConnectorImage.onlyIf { false }
+    pushImages.onlyIf { false }
+    pushConnectorImage.onlyIf { false }
+}

--- a/extpsdk/build.gradle
+++ b/extpsdk/build.gradle
@@ -130,8 +130,10 @@ tasks.matching { !it.name.startsWith('generate')
     task.mustRunAfter generateSetupCfg
 }
 
-// This is an SDK so no connector image should be constructed or pushed.
-buildImages.onlyIf { false }
-buildConnectorImage.onlyIf { false }
-pushImages.onlyIf { false }
-pushConnectorImage.onlyIf { false }
+if (project.tasks.findByName('buildImages') && project.tasks.findByName('buildConnectorImage')) {
+    // This is an SDK so no connector image should be constructed or pushed.
+    buildImages.onlyIf { false }
+    buildConnectorImage.onlyIf { false }
+    pushImages.onlyIf { false }
+    pushConnectorImage.onlyIf { false }
+}


### PR DESCRIPTION
Fixes #533

In cases where users are building, they may not have the various docker* gradle properties set.  When that's the case, the docker/dcompose plugins don't build those tasks, and gradle gets upset.

These changes validate that the tasks exist before setting the onlyIf, etc., values.