### PR TITLE
Add search capabilities for types.

### DIFF
--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_checkGeneralParams.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_checkGeneralParams.vail
@@ -1,0 +1,19 @@
+package com.vantiq.fhir
+private stateless PROCEDURE fhirService.checkGeneralParams(generalParams Object): Object
+
+var checkedParams = {}
+
+if (generalParams) {
+    for (gp in generalParams) {
+        if (gp.key == "_format") {
+            exception("com.vantiq.fhir.notsupported.format", 
+                "The _format argument is not supported.", [])
+        } else if (gp.key == "_elements") {
+            // Be nice & trim whitespace out of an _elements specification
+            checkedParams[gp.key] = replace(gp.value, "\\s+", "")
+        } else {
+            checkedParams[gp.key] = gp.value
+        }
+    }
+}
+return checkedParams

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_create.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_create.vail
@@ -9,8 +9,8 @@ if (generalParms) {
     for (gp in generalParms) {
         var gpValue = gp.value
         if (gp.key == "_format") {
-            exception("com.vantiq.fhir.formatnotsupport",
-            "The _format argument is not supported.", [])
+            exception("com.vantiq.fhir.formatnotsupport", 
+                "The _format argument is not supported.", [])
         } else if (gp.key == "_elements") {
             // Be nice & trim whitespace out of an _elements specification
             gpValue = replace(gpValue, "\\s+", "")

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_create.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_create.vail
@@ -1,28 +1,7 @@
 package com.vantiq.fhir
-PROCEDURE fhirService.create(type String REQUIRED, resource Object REQUIRED, versionId String, generalParms Object): Object
+PROCEDURE fhirService.create(type String REQUIRED, resource Object REQUIRED, versionId String): Object
 
 var path = type
-
-if (generalParms) {
-    var gpExt = ""
-    var prefix = ""
-    for (gp in generalParms) {
-        var gpValue = gp.value
-        if (gp.key == "_format") {
-            exception("com.vantiq.fhir.formatnotsupport", 
-                "The _format argument is not supported.", [])
-        } else if (gp.key == "_elements") {
-            // Be nice & trim whitespace out of an _elements specification
-            gpValue = replace(gpValue, "\\s+", "")
-        }
-        gpExt = gpExt + prefix + gp.key + "=" + gpValue
-        prefix = "&"
-    }
-
-    if (gpExt.length() > 0) {
-        path = path + "?" + gpExt
-    }
-}
 
 var retVal = fhirService.performRestOpWithData("POST", path, resource)
 if (typeOf(retVal) == "List") {

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_createErrorMsg.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_createErrorMsg.vail
@@ -11,8 +11,10 @@ var errDetails = exc.params[2]
 var opOutcome = null
 var resValue = null
 
+log.debug("Creating error message for {}", [exc])
 log.debug("Error details: {}: {}", [typeOf(errDetails), errDetails])
 if (errDetails && typeOf(errDetails) == "String") {
+    log.debug("ErrDetails is a String, parsing {}", [errDetails])
     // If we get an error back, check to see if the error included was JSON.  If so, parse
     // it & report the details.  If we get an error parsing it, then it's probably just a plain
     // string so we'll just pass it along.

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_fetchCapabilityStatement.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_fetchCapabilityStatement.vail
@@ -1,4 +1,6 @@
-/* Returns the capability statement for this FHIR server */
+/**
+* Returns the capability statement for this FHIR server
+*/
 package com.vantiq.fhir
 import service com.vantiq.fhir.fhirService
 

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_getCapabilityStatement.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_getCapabilityStatement.vail
@@ -1,5 +1,7 @@
-/* Returns the capability statement for the source used by this service.
-  If none present, it will fetch one from the source. */
+/**
+* Returns the capability statement for the source used by this service.
+* If none present, it will fetch one from the source.
+*/
 package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOp.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOp.vail
@@ -8,7 +8,7 @@ var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
 
 if (!theSource) {
-    fhirService.setSource("com.vantiq.fhir.fhirServer")
+    fhirService.setSource()
     theSource = fhirSource.getValue()
 }
 var retVal = ""

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOp.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOp.vail
@@ -8,7 +8,7 @@ var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
 
 if (!theSource) {
-    fhirSource.setValue("com.vantiq.fhir.fhirServer")
+    fhirService.setSource("com.vantiq.fhir.fhirServer")
     theSource = fhirSource.getValue()
 }
 var retVal = ""

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOpQuery.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOpQuery.vail
@@ -9,7 +9,7 @@ var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
 
 if (!theSource) {
-    fhirService.setSource("com.vantiq.fhir.fhirServer")
+    fhirService.setSource()
     theSource = fhirSource.getValue()
 }
 var retVal = ""

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOpQuery.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOpQuery.vail
@@ -1,0 +1,41 @@
+package com.vantiq.fhir
+
+import service com.vantiq.fhir.fhirService
+
+private PROCEDURE fhirService.performRestOpQuery(method String REQUIRED, targetPath String REQUIRED,
+                    query Object Required): Any
+
+var theSource = fhirSource.getValue()
+log.debug("Current value of fhirSource to use: {}", [theSource])
+
+if (!theSource) {
+    fhirSource.setValue("com.vantiq.fhir.fhirServer")
+    theSource = fhirSource.getValue()
+}
+var retVal = ""
+
+log.debug("Performing {} method on path {} with query {}", [method, targetPath, query])
+try {
+    if (method == "GET" || method == "HEAD") {
+        retVal = SELECT from SOURCE @theSource with path = targetPath,
+            method = method,
+            query = query,
+            contentType = "application/fhir+json",
+            responseType = "application/fhir+json"
+    } else {
+        var bod = Encode.formUrl(query)
+        retVal = SELECT from SOURCE @theSource with path = targetPath,
+            method = method,
+            body = bod,
+            contentType = "application/x-www-form-urlencoded",
+            responseType = "application/fhir+json"
+
+    }
+} catch (e) {
+    if (e.code == "io.vantiq.sourcemgr.remote.query.client.failure") {
+        retVal = fhirService.createErrorMsg(e, targetPath)
+    } else {
+        rethrow(e)
+    }
+}
+return retVal

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOpQuery.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOpQuery.vail
@@ -9,7 +9,7 @@ var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
 
 if (!theSource) {
-    fhirSource.setValue("com.vantiq.fhir.fhirServer")
+    fhirService.setSource("com.vantiq.fhir.fhirServer")
     theSource = fhirSource.getValue()
 }
 var retVal = ""

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOpWithData.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOpWithData.vail
@@ -10,7 +10,7 @@ var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
 
 if (!theSource) {
-    fhirService.setSource("com.vantiq.fhir.fhirServer")
+    fhirService.setSource()
     theSource = fhirSource.getValue()
 }
 var retVal = ""

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOpWithData.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOpWithData.vail
@@ -10,7 +10,7 @@ var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
 
 if (!theSource) {
-    fhirSource.setValue("com.vantiq.fhir.fhirServer")
+    fhirService.setSource("com.vantiq.fhir.fhirServer")
     theSource = fhirSource.getValue()
 }
 var retVal = ""

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_read.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_read.vail
@@ -2,7 +2,7 @@
 //
 // @param type String the FHIR resource type
 // @param id String the id desired
-// @param generalParms Object (optional) a set of name/value pairs representing the general parameters for this call.
+// @param generalParams Object (optional) a set of name/value pairs representing the general parameters for this call.
 //                                       The general parameters include _summary & _element. _pretty can be included.
 //                                       though it provides no value since the caller is not getting JSON back.
 //                                       _format is not permitted in this context.
@@ -10,6 +10,6 @@ package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService
 
-PROCEDURE fhirService.read(type String REQUIRED, id String REQUIRED, genParams Object): Object
+PROCEDURE fhirService.read(type String REQUIRED, id String REQUIRED, generalParams Object): Object
 
-return fhirService.vread(type, id, null, genParams)
+return fhirService.vread(type, id, null, generalParams)

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_read.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_read.vail
@@ -1,11 +1,14 @@
-// Read a type based on its id
-//
-// @param type String the FHIR resource type
-// @param id String the id desired
-// @param generalParams Object (optional) a set of name/value pairs representing the general parameters for this call.
-//                                       The general parameters include _summary & _element. _pretty can be included.
-//                                       though it provides no value since the caller is not getting JSON back.
-//                                       _format is not permitted in this context.
+/**
+* Read a type based on its id
+*
+* @param type String the FHIR resource type
+* @param id String the id desired
+* @param generalParams Object (optional) a set of name/value pairs representing the general parameters for this call.
+*                                        The general parameters include _summary & _element. _pretty can be included.
+*                                        though it provides no value since the caller is not getting JSON back.
+*                                        _format is not permitted in this context.
+*/
+
 package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_read.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_read.vail
@@ -4,7 +4,7 @@
 // @param id String the id desired
 // @param generalParms Object (optional) a set of name/value pairs representing the general parameters for this call.
 //                                       The general parameters include _summary & _element. _pretty can be included.
-//                                       though it provides not value since the caller is not getting JSON back.
+//                                       though it provides no value since the caller is not getting JSON back.
 //                                       _format is not permitted in this context.
 package com.vantiq.fhir
 

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_returnLink.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_returnLink.vail
@@ -1,0 +1,41 @@
+package com.vantiq.fhir
+
+import service com.vantiq.fhir.fhirService
+
+/**
+* Perform a search based on the type & query provided
+*
+* Using the current source, run the search query for a particular type. If no method is provided,
+* we use GET. If search via POST is desired, provide "POST" as the method parameter.
+*
+* @param type String The FHIR Resource type to search
+* @param query Object The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object here ("{}").
+* @param method String GET or POST
+*/
+
+PROCEDURE fhirService.returnLink(link String REQUIRED)
+var theSource = fhirSource.getValue()
+var sourceBase = fhirSourceBase.getValue()
+var sourceBaseSansSlash = sourceBase.substr(0, sourceBase.length() - 1)
+log.debug("Current value of fhirSource to use: {}", [theSource])
+
+if (!theSource) {
+    // FIXME -- this should snarf the assembly's parameter value
+    fhirService.setSource("com.vantiq.fhir.fhirServer")
+    theSource = fhirSource.getValue()
+}
+
+if (!link.trimLeft().startsWith(sourceBase) && !link.trimLeft().startsWith(sourceBaseSansSlash)) {
+    exception("com.vantiq.fhir.link.mismatch", 
+                "The link provided ({0}) is not serviced by the current source ({1}) whose URI is {2}.",
+                [link, theSource, sourceBase])
+}
+var relativeLink 
+if (link.trimLeft().startsWith(sourceBase)) {
+    relativeLink = link.trimLeft().substring(sourceBase.length())
+} else {
+    relativeLink = link.trimLeft().substring(sourceBaseSansSlash.length())
+}
+log.debug("Looking for relative link {} from {}", [relativeLink, link])
+
+return fhirService.performRestOp("GET", relativeLink)

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_returnLink.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_returnLink.vail
@@ -3,14 +3,12 @@ package com.vantiq.fhir
 import service com.vantiq.fhir.fhirService
 
 /**
-* Perform a search based on the type & query provided
+* Fetch a link
 *
-* Using the current source, run the search query for a particular type. If no method is provided,
-* we use GET. If search via POST is desired, provide "POST" as the method parameter.
+* Using the current source, fetch the link by converting the absolute URL to a relative one. FHIR uses absolutes which
+* don't mix well with Vantiq sources.
 *
-* @param type String The FHIR Resource type to search
-* @param query Object The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object here ("{}").
-* @param method String GET or POST
+* @param link String The URL of the link to return.
 */
 
 PROCEDURE fhirService.returnLink(link String REQUIRED)

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_returnLink.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_returnLink.vail
@@ -14,22 +14,22 @@ import service com.vantiq.fhir.fhirService
 */
 
 PROCEDURE fhirService.returnLink(link String REQUIRED)
+
 var theSource = fhirSource.getValue()
+if (!theSource) {
+    fhirService.setSource()
+    theSource = fhirSource.getValue()
+}
 var sourceBase = fhirSourceBase.getValue()
 var sourceBaseSansSlash = sourceBase.substr(0, sourceBase.length() - 1)
 log.debug("Current value of fhirSource to use: {}", [theSource])
-
-if (!theSource) {
-    // FIXME -- this should snarf the assembly's parameter value
-    fhirService.setSource("com.vantiq.fhir.fhirServer")
-    theSource = fhirSource.getValue()
-}
 
 if (!link.trimLeft().startsWith(sourceBase) && !link.trimLeft().startsWith(sourceBaseSansSlash)) {
     exception("com.vantiq.fhir.link.mismatch", 
                 "The link provided ({0}) is not serviced by the current source ({1}) whose URI is {2}.",
                 [link, theSource, sourceBase])
 }
+
 var relativeLink 
 if (link.trimLeft().startsWith(sourceBase)) {
     relativeLink = link.trimLeft().substring(sourceBase.length())

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_returnLink.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_returnLink.vail
@@ -1,7 +1,3 @@
-package com.vantiq.fhir
-
-import service com.vantiq.fhir.fhirService
-
 /**
 * Fetch a link
 *
@@ -10,6 +6,10 @@ import service com.vantiq.fhir.fhirService
 *
 * @param link String The URL of the link to return.
 */
+
+package com.vantiq.fhir
+
+import service com.vantiq.fhir.fhirService
 
 PROCEDURE fhirService.returnLink(link String REQUIRED)
 

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchCompartment.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchCompartment.vail
@@ -1,0 +1,54 @@
+package com.vantiq.fhir
+
+import service com.vantiq.fhir.fhirService
+
+/**
+* Perform a search based on the compartment, id, & query provided
+*
+* Using the current source, run the search query for a particular compartment. If no method is provided,
+* we use GET. If search via POST is desired, provide "POST" as the method parameter.
+*
+* The compartment will be searched.  If the type parameter is provided, the results are restricted to entries of
+* that type.
+*
+* @param type String The FHIR Resource type to search
+* @param id String Id of the compartment
+* @param query Object The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object here ("{}").
+* @param type String The FHIR resource type within the compartment to which to restrict the search.
+* @param method String GET or POST
+*/
+
+PROCEDURE fhirService.searchCompartment(compartment String REQUIRED, 
+                                        id String REQUIRED,
+                                        query Object REQUIRED,
+                                        type String,
+                                        method String)
+var theSource = fhirSource.getValue()
+log.debug("Current value of fhirSource to use: {}", [theSource])
+log.debug("searchCompartment({}, {}, {}, {}, {})", [
+    compartment, id, query, type, method
+])
+if (!theSource) {
+    fhirService.setSource("com.vantiq.fhir.fhirServer")
+    theSource = fhirSource.getValue()
+}
+var targetPath = compartment + "/" + id
+if (type) {
+    targetPath = targetPath + "/" + type
+}
+if (!method) {
+    method = "GET"
+} 
+if (method == "GET" && !type) {
+    // The spec requires that GET requests for a compartment/id (sans type) require the extra * to distinguish
+    // the request from a "read" operation on a type with the same name as the compartment.
+    targetPath = targetPath + "/*"
+} else if (method == "POST") {
+    if (type) {
+        targetPath = targetPath + "/" + type + "/_search"
+    } else {
+        targetPath = targetPath + "/_search"
+    }
+}
+log.debug("Performing compartment search using targetPath: {}, query: query", [targetPath, query])
+return fhirService.performRestOpQuery(method, targetPath, query )

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchCompartment.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchCompartment.vail
@@ -29,7 +29,7 @@ log.debug("searchCompartment({}, {}, {}, {}, {})", [
     compartment, id, query, type, method
 ])
 if (!theSource) {
-    fhirService.setSource("com.vantiq.fhir.fhirServer")
+    fhirService.setSource()
     theSource = fhirSource.getValue()
 }
 var targetPath = compartment + "/" + id

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchCompartment.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchCompartment.vail
@@ -1,7 +1,3 @@
-package com.vantiq.fhir
-
-import service com.vantiq.fhir.fhirService
-
 /**
 * Perform a search based on the compartment, id, & query provided
 *
@@ -11,12 +7,16 @@ import service com.vantiq.fhir.fhirService
 * The compartment will be searched.  If the type parameter is provided, the results are restricted to entries of
 * that type.
 *
-* @param type String The FHIR Resource type to search
+* @param compartment String The FHIR Resource compartment to search
 * @param id String Id of the compartment
 * @param query Object The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object here ("{}").
 * @param type String The FHIR resource type within the compartment to which to restrict the search.
 * @param method String GET or POST
 */
+
+package com.vantiq.fhir
+
+import service com.vantiq.fhir.fhirService
 
 PROCEDURE fhirService.searchCompartment(compartment String REQUIRED, 
                                         id String REQUIRED,

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchSystem.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchSystem.vail
@@ -1,7 +1,3 @@
-package com.vantiq.fhir
-
-import service com.vantiq.fhir.fhirService
-
 /**
 * Perform a search of the system
 *
@@ -11,6 +7,10 @@ import service com.vantiq.fhir.fhirService
 * @param query Object The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object ("{}").
 * @param method String GET or POST.  Optional
 */
+
+package com.vantiq.fhir
+
+import service com.vantiq.fhir.fhirService
 
 PROCEDURE fhirService.searchSystem(query Object REQUIRED, method String)
 var theSource = fhirSource.getValue()

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchSystem.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchSystem.vail
@@ -17,7 +17,7 @@ var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
 
 if (!theSource) {
-    fhirService.setSource("com.vantiq.fhir.fhirServer")
+    fhirService.setSource()
     theSource = fhirSource.getValue()
 }
 var targetPath = "/"

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchSystem.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchSystem.vail
@@ -3,29 +3,27 @@ package com.vantiq.fhir
 import service com.vantiq.fhir.fhirService
 
 /**
-* Perform a search based on the type & query provided
+* Perform a search of the system
 *
 * Using the current source, run the search query for a particular type. If no method is provided,
 * we use GET. If search via POST is desired, provide "POST" as the method parameter.
 *
-* @param type String The FHIR Resource type to search
-* @param query Object The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object here ("{}").
-* @param method String GET or POST
+* @param query Object The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object ("{}").
+* @param method String GET or POST.  Optional
 */
 
-PROCEDURE fhirService.searchType(type String REQUIRED, query Object REQUIRED, method String)
+PROCEDURE fhirService.searchSystem(query Object REQUIRED, method String)
 var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
 
 if (!theSource) {
-    // FIXME -- get parameter from assembly
     fhirService.setSource("com.vantiq.fhir.fhirServer")
     theSource = fhirSource.getValue()
 }
-var targetPath = type
+var targetPath = "/"
 if (!method) {
     method = "GET"
 } else if (method == "POST") {
-    targetPath = type + "/_search"
+    targetPath = "/_search"
 }
 return fhirService.performRestOpQuery(method, targetPath, query )

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchType.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchType.vail
@@ -1,7 +1,3 @@
-package com.vantiq.fhir
-
-import service com.vantiq.fhir.fhirService
-
 /**
 * Perform a search based on the type & query provided
 *
@@ -11,9 +7,13 @@ import service com.vantiq.fhir.fhirService
 * @param type String The FHIR Resource type to search
 * @param query Object The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object here ("{}").
 * @param generalParams (optional) a set of name/value pairs representing the modifiers for this call.
-*                                        The general parameters include _summary & _elements. 
+*                                        The general parameters include _summary & _elements.
 * @param method String (optional) GET or POST
 */
+
+package com.vantiq.fhir
+
+import service com.vantiq.fhir.fhirService
 
 PROCEDURE fhirService.searchType(type String REQUIRED, query Object REQUIRED, generalParams Object, method String)
 var theSource = fhirSource.getValue()

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchType.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchType.vail
@@ -10,17 +10,30 @@ import service com.vantiq.fhir.fhirService
 *
 * @param type String The FHIR Resource type to search
 * @param query Object The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object here ("{}").
-* @param method String GET or POST
+* @param generalParams (optional) a set of name/value pairs representing the modifiers for this call.
+*                                        The general parameters include _summary & _elements. 
+* @param method String (optional) GET or POST
 */
 
-PROCEDURE fhirService.searchType(type String REQUIRED, query Object REQUIRED, method String)
+PROCEDURE fhirService.searchType(type String REQUIRED, query Object REQUIRED, generalParams Object, method String)
 var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
 
 if (!theSource) {
-    // FIXME -- get parameter from assembly
-    fhirService.setSource("com.vantiq.fhir.fhirServer")
+    fhirService.setSource()
     theSource = fhirSource.getValue()
+}
+
+var checkedParams = fhirService.checkGeneralParams(generalParams)
+var comboQuery = Object.clone(query)
+for (p in checkedParams) {
+    if (comboQuery.has(p.key)) {
+        exception("com.vantiq.fhir.generalparam.conflict",
+                    "The generalParam {0} would overwrite the query parameter of the same name.",
+                    [p.key])
+    } else {
+        comboQuery[p.key] = p.value
+    }
 }
 var targetPath = type
 if (!method) {
@@ -28,4 +41,4 @@ if (!method) {
 } else if (method == "POST") {
     targetPath = type + "/_search"
 }
-return fhirService.performRestOpQuery(method, targetPath, query )
+return fhirService.performRestOpQuery(method, targetPath, comboQuery)

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchType.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchType.vail
@@ -2,7 +2,18 @@ package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService
 
-PROCEDURE fhirService.searchType(type String REQUIRED, theQuery Object REQUIRED)
+/**
+* Perform a search based on the type & query provided
+*
+* Using the current source, run the search query for a particular type. If no method is provided,
+* we use GET. If search via POST is desired, provide "POST" as the method parameter.
+*
+* @param type String The FHIR Resource type to search
+* @param query Object The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object here ("{}").
+* @param method String GET or POST
+*/
+
+PROCEDURE fhirService.searchType(type String REQUIRED, query Object REQUIRED, method String)
 var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
 
@@ -10,8 +21,11 @@ if (!theSource) {
     fhirSource.setValue("com.vantiq.fhir.fhirServer")
     theSource = fhirSource.getValue()
 }
-return SELECT * FROM SOURCE @theSource with 
-    method = "GET",
-    path = type,
-    query = theQuery,
-    responseType = "application/fhir+json"
+var targetPath = type
+if (!method) {
+    method = "GET"
+} else if (method == "POST") {
+    targetPath = type + "/_search"
+}
+return fhirService.performRestOpQuery(method, targetPath, query )
+        

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_setSource.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_setSource.vail
@@ -4,7 +4,10 @@ import service com.vantiq.fhir.fhirService
 
 PROCEDURE fhirService.setSource(theSource String): String
 
-// See if there's any path defined.  If so, we'll need to know about it 
+if (!theSource) {
+    // If no source name is specified (the norm), use the source that's part of the assembly
+    theSource = "com.vantiq.fhir.fhirServer"
+}
 
 // Since we're changing the source, the capability atatement is no longer valid.
 fhirService.clearCapabilityStatement()

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_setSource.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_setSource.vail
@@ -9,7 +9,7 @@ if (!theSource) {
     theSource = "com.vantiq.fhir.fhirServer"
 }
 
-// Since we're changing the source, the capability atatement is no longer valid.
+// Since we're changing the source, the capability statement is no longer valid.
 fhirService.clearCapabilityStatement()
 fhirSource.setValue(theSource)
 

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_setSource.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_setSource.vail
@@ -2,7 +2,7 @@ package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService
 
-PROCEDURE fhirService.setSource(theSource String)
+PROCEDURE fhirService.setSource(theSource String): String
 
 // See if there's any path defined.  If so, we'll need to know about it 
 
@@ -10,3 +10,15 @@ PROCEDURE fhirService.setSource(theSource String)
 fhirService.clearCapabilityStatement()
 fhirSource.setValue(theSource)
 
+// Links in FHIR are full URLs.  Our REMOTE sources are more constrained, really wanting a path within the context of 
+// the URL known to the REMOTE source.  To handle this impedance mismatch, we'll extract the path base URL part of
+// the source and save it here.  This will allow us to move that from any links passed in before sending them to 
+// the remote source for operation.
+
+var theConf = SELECT ONE config FROM system.sources where name == theSource
+if (theConf == null) {
+    exception("io.fred.oops", "no config", [])
+}
+log.debug("Base URL for source {} is {} based on {}", [theSource, theConf.config.uri, theConf])
+fhirSourceBase.setValue(theConf.config.uri)
+return theSource

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_update.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_update.vail
@@ -1,5 +1,5 @@
 package com.vantiq.fhir
-PROCEDURE fhirService.update(type String REQUIRED, id String REQUIRED, resource Object REQUIRED, versionId String, generalParms Object): Object
+PROCEDURE fhirService.update(type String REQUIRED, id String REQUIRED, resource Object REQUIRED, versionId String): Object
 
 var path = type + "/" + id
 
@@ -9,27 +9,6 @@ var path = type + "/" + id
 
 if (versionId) {
     path = path + "/_history/" + versionId
-}
-
-if (generalParms) {
-    var gpExt = ""
-    var prefix = ""
-    for (gp in generalParms) {
-        var gpValue = gp.value
-        if (gp.key == "_format") {
-            exception("com.vantiq.fhir.formatnotsupport", 
-                "The _format argument is not supported.", [])
-        } else if (gp.key == "_elements") {
-            // Be nice & trim whitespace out of an _elements specification
-            gpValue = replace(gpValue, "\\s+", "")
-        }
-        gpExt = gpExt + prefix + gp.key + "=" + gpValue
-        prefix = "&"
-    }
-
-    if (gpExt.length() > 0) {
-        path = path + "?" + gpExt
-    }
 }
 
 var retVal = fhirService.performRestOpWithData("PUT", path, resource)

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_vread.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_vread.vail
@@ -1,18 +1,20 @@
-// Read a type based on its id
-//
-// @param type String the FHIR resource type
-// @param id String the id desired
-// @param versionId String version id if versioning is supported and a specific version is requested.
-// @param generalParms Object (optional) a set of name/value pairs representing the general parameters for this call.
-//                                       The general parameters include _summary & _element. _pretty can be included.
-//                                       though it provides no value since the caller is not getting JSON back.
-//                                       _format is not permitted in this context.
+/**
+* Read a type based on its id
+*
+* @param type String the FHIR resource type
+* @param id String the id desired
+* @param versionId String version id if versioning is supported and a specific version is requested.
+* @param generalParams Object (optional) a set of name/value pairs representing the general parameters for this call.
+*                                         The general parameters include _summary & _element. _pretty can be included.
+*                                         though it provides no value since the caller is not getting JSON back.
+*                                         _format is not permitted in this context.
+*/
 
 package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService
 
-PROCEDURE fhirService.vread(type String REQUIRED, id String REQUIRED, versionId String, generalParms Object): Object
+PROCEDURE fhirService.vread(type String REQUIRED, id String REQUIRED, versionId String, generalParams Object): Object
 
 var path = type + "/" + id
 
@@ -24,28 +26,9 @@ if (versionId) {
     path = path + "/_history/" + versionId
 }
 
-if (generalParms) {
-    var gpExt = ""
-    var prefix = ""
-    for (gp in generalParms) {
-        var gpValue = gp.value
-        if (gp.key == "_format") {
-            exception("com.vantiq.fhir.formatnotsupport", 
-                "The _format argument is not supported.", [])
-        } else if (gp.key == "_elements") {
-            // Be nice & trim whitespace out of an _elements specification
-            gpValue = replace(gpValue, "\\s+", "")
-        }
-        gpExt = gpExt + prefix + gp.key + "=" + gpValue
-        prefix = "&"
-    }
+var checkedParams = fhirService.checkGeneralParams(generalParams)
 
-    if (gpExt.length() > 0) {
-        path = path + "?" + gpExt
-    }
-}
-
-var retVal = fhirService.performGet(path)
+var retVal = fhirService.performRestOpQuery("GET", path, checkedParams)
 if (typeOf(retVal) == "List") {
     log.debug("retVal is an array: {}", [typeOf(retVal)])
     retVal = retVal[0]

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_vread.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_vread.vail
@@ -1,13 +1,13 @@
 /**
-* Read a type based on its id
+* Read a type based on its id and version (if specified)
 *
 * @param type String the FHIR resource type
 * @param id String the id desired
 * @param versionId String version id if versioning is supported and a specific version is requested.
 * @param generalParams Object (optional) a set of name/value pairs representing the general parameters for this call.
-*                                         The general parameters include _summary & _element. _pretty can be included.
-*                                         though it provides no value since the caller is not getting JSON back.
-*                                         _format is not permitted in this context.
+*                                        The general parameters include _summary & _element. _pretty can be included.
+*                                        though it provides no value since the caller is not getting JSON back.
+*                                        _format is not permitted in this context.
 */
 
 package com.vantiq.fhir

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/projects/com.vantiq.fhir.fhirConnection.json
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/projects/com.vantiq.fhir.fhirConnection.json
@@ -24,9 +24,6 @@
     "source" : "services/com.vantiq.fhir.fhirService",
     "target" : "procedure/com.vantiq.fhir.fhirService.setSource"
   }, {
-    "source" : "procedure/com.vantiq.fhir.fhirService.setSource",
-    "target" : "procedure/com.vantiq.fhir.fhirService.clearCapabilityStatement"
-  }, {
     "source" : "procedure/com.vantiq.fhir.fhirService.read",
     "target" : "services/com.vantiq.fhir.fhirService"
   }, {
@@ -134,6 +131,54 @@
   }, {
     "source" : "procedure/com.vantiq.fhir.fhirService.delete",
     "target" : "services/com.vantiq.fhir.fhirService"
+  }, {
+    "source" : "services/com.vantiq.fhir.fhirService",
+    "target" : "procedure/com.vantiq.fhir.fhirService.searchType"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchType",
+    "target" : "services/com.vantiq.fhir.fhirService"
+  }, {
+    "source" : "services/com.vantiq.fhir.fhirService",
+    "target" : "procedure/com.vantiq.fhir.fhirService.performRestOpQuery"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.performRestOpQuery",
+    "target" : "services/com.vantiq.fhir.fhirService"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.performRestOpQuery",
+    "target" : "procedure/com.vantiq.fhir.fhirService.createErrorMsg"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchType",
+    "target" : "procedure/com.vantiq.fhir.fhirService.performRestOpQuery"
+  }, {
+    "source" : "services/com.vantiq.fhir.fhirService",
+    "target" : "procedure/com.vantiq.fhir.fhirService.searchCompartment"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchCompartment",
+    "target" : "services/com.vantiq.fhir.fhirService"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchCompartment",
+    "target" : "procedure/com.vantiq.fhir.fhirService.performRestOpQuery"
+  }, {
+    "source" : "services/com.vantiq.fhir.fhirService",
+    "target" : "procedure/com.vantiq.fhir.fhirService.searchSystem"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
+    "target" : "services/com.vantiq.fhir.fhirService"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
+    "target" : "procedure/com.vantiq.fhir.fhirService.performRestOpQuery"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.setSource",
+    "target" : "procedure/com.vantiq.fhir.fhirService.clearCapabilityStatement"
+  }, {
+    "source" : "services/com.vantiq.fhir.fhirService",
+    "target" : "procedure/com.vantiq.fhir.fhirService.returnLink"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.returnLink",
+    "target" : "services/com.vantiq.fhir.fhirService"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.returnLink",
+    "target" : "procedure/com.vantiq.fhir.fhirService.performRestOp"
   } ],
   "name" : "com.vantiq.fhir.fhirConnection",
   "options" : {
@@ -147,7 +192,7 @@
     },
     "dockDimensions" : {
       "bottom" : 200,
-      "debug" : [ 0, 0, 0 ],
+      "debug" : [ 681, 881 ],
       "left" : 210,
       "right" : 220,
       "top" : 0,
@@ -162,7 +207,7 @@
     "showGrid" : true,
     "structure" : {
       "fraction" : 1,
-      "type" : "R[3]"
+      "type" : "R[4]"
     },
     "type" : "dev",
     "v" : 6,
@@ -179,7 +224,7 @@
     "label" : "com.vantiq.fhir.fhirService",
     "name" : "com.vantiq.fhir.fhirService",
     "resourceReference" : "/services/com.vantiq.fhir.fhirService",
-    "timestamp" : "2025-01-23T00:10:59.103Z",
+    "timestamp" : "2025-01-28T00:34:48.552Z",
     "type" : 63
   }, {
     "label" : "com.vantiq.fhir.fhirService.GlobalState",
@@ -212,7 +257,7 @@
     "procedureName" : "createErrorMsg",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.createErrorMsg",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-22T20:13:21.861Z",
+    "timestamp" : "2025-01-27T23:28:45.294Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.delete",
@@ -230,7 +275,7 @@
     "procedureName" : "fetchCapabilityStatement",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.fetchCapabilityStatement",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-22T00:07:32.422Z",
+    "timestamp" : "2025-01-24T01:59:41.032Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.getCapabilityStatement",
@@ -239,7 +284,7 @@
     "procedureName" : "getCapabilityStatement",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.getCapabilityStatement",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-21T23:12:56.721Z",
+    "timestamp" : "2025-01-24T01:59:43.340Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.js",
@@ -263,7 +308,16 @@
     "procedureName" : "performRestOp",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.performRestOp",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-22T23:08:49.745Z",
+    "timestamp" : "2025-01-24T01:57:31.492Z",
+    "type" : 3
+  }, {
+    "label" : "com.vantiq.fhir.fhirService.performRestOpQuery",
+    "name" : "com.vantiq.fhir.fhirService.performRestOpQuery",
+    "packageName" : "com.vantiq.fhir",
+    "procedureName" : "performRestOpQuery",
+    "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.performRestOpQuery",
+    "serviceName" : "fhirService",
+    "timestamp" : "2025-01-27T22:32:37.377Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.performRestOpWithData",
@@ -272,7 +326,7 @@
     "procedureName" : "performRestOpWithData",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.performRestOpWithData",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-22T23:08:30.786Z",
+    "timestamp" : "2025-01-24T01:58:07.111Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.read",
@@ -281,7 +335,43 @@
     "procedureName" : "read",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.read",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-22T01:09:06.760Z",
+    "timestamp" : "2025-01-27T23:36:11.276Z",
+    "type" : 3
+  }, {
+    "label" : "com.vantiq.fhir.fhirService.returnLink",
+    "name" : "com.vantiq.fhir.fhirService.returnLink",
+    "packageName" : "com.vantiq.fhir",
+    "procedureName" : "returnLink",
+    "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.returnLink",
+    "serviceName" : "fhirService",
+    "timestamp" : "2025-01-28T01:27:16.126Z",
+    "type" : 3
+  }, {
+    "label" : "com.vantiq.fhir.fhirService.searchCompartment",
+    "name" : "com.vantiq.fhir.fhirService.searchCompartment",
+    "packageName" : "com.vantiq.fhir",
+    "procedureName" : "searchCompartment",
+    "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.searchCompartment",
+    "serviceName" : "fhirService",
+    "timestamp" : "2025-01-28T00:03:13.453Z",
+    "type" : 3
+  }, {
+    "label" : "com.vantiq.fhir.fhirService.searchSystem",
+    "name" : "com.vantiq.fhir.fhirService.searchSystem",
+    "packageName" : "com.vantiq.fhir",
+    "procedureName" : "searchSystem",
+    "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.searchSystem",
+    "serviceName" : "fhirService",
+    "timestamp" : "2025-01-28T00:34:43.943Z",
+    "type" : 3
+  }, {
+    "label" : "com.vantiq.fhir.fhirService.searchType",
+    "name" : "com.vantiq.fhir.fhirService.searchType",
+    "packageName" : "com.vantiq.fhir",
+    "procedureName" : "searchType",
+    "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.searchType",
+    "serviceName" : "fhirService",
+    "timestamp" : "2025-01-27T23:42:15.561Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.setSource",
@@ -290,7 +380,7 @@
     "procedureName" : "setSource",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.setSource",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-21T23:26:00.929Z",
+    "timestamp" : "2025-01-28T01:05:45.087Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.update",
@@ -308,7 +398,7 @@
     "procedureName" : "vread",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.vread",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-22T20:30:08.159Z",
+    "timestamp" : "2025-01-27T23:36:08.899Z",
     "type" : 3
   } ],
   "selectData" : { },
@@ -317,10 +407,22 @@
     "name" : "Errors",
     "type" : 13
   }, {
+    "isPinned" : false,
+    "name" : "Find Records",
+    "pane" : {
+      "address" : "R[1]"
+    },
+    "state" : 8,
+    "type" : 41
+  }, {
     "dockLocation" : "top",
     "isPinned" : false,
     "name" : "Inactive Panes",
     "type" : 99
+  }, {
+    "isPinned" : false,
+    "name" : "Log Messages",
+    "type" : 12
   }, {
     "isPinned" : false,
     "name" : "Project Contents",
@@ -329,7 +431,7 @@
     "isPinned" : false,
     "name" : "com.vantiq.fhir.fhirConnection",
     "pane" : {
-      "address" : "R[2]"
+      "address" : "R[3]"
     },
     "state" : 8,
     "type" : 120
@@ -346,7 +448,7 @@
     "isPinned" : false,
     "name" : "com.vantiq.fhir.fhirService",
     "pane" : {
-      "address" : "R[1]",
+      "address" : "R[2]",
       "isActive" : true,
       "isActiveTool" : true
     },
@@ -357,7 +459,7 @@
   "type" : "dev",
   "views" : [ {
     "name" : "Project Contents",
-    "projectToolKeys" : [ "errorviewer/Errors", "tiledock/Inactive Panes", "list/Project Contents", "assemblies/com.vantiq.fhir.fhirConnection", "subsourceeditor/com.vantiq.fhir.fhirServer", "services/com.vantiq.fhir.fhirService" ]
+    "projectToolKeys" : [ "errorviewer/Errors", "findrecords/Find Records", "tiledock/Inactive Panes", "logviewer/Log Messages", "list/Project Contents", "assemblies/com.vantiq.fhir.fhirConnection", "subsourceeditor/com.vantiq.fhir.fhirServer", "services/com.vantiq.fhir.fhirService" ]
   } ],
   "visibleResources" : [ {
     "description" : null,

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/projects/com.vantiq.fhir.fhirConnection.json
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/projects/com.vantiq.fhir.fhirConnection.json
@@ -179,6 +179,33 @@
   }, {
     "source" : "procedure/com.vantiq.fhir.fhirService.returnLink",
     "target" : "procedure/com.vantiq.fhir.fhirService.performRestOp"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.performRestOp",
+    "target" : "procedure/com.vantiq.fhir.fhirService.setSource"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchCompartment",
+    "target" : "procedure/com.vantiq.fhir.fhirService.setSource"
+  }, {
+    "source" : "services/com.vantiq.fhir.fhirService",
+    "target" : "procedure/com.vantiq.fhir.fhirService.checkGeneralParams"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.performRestOpQuery",
+    "target" : "procedure/com.vantiq.fhir.fhirService.setSource"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchType",
+    "target" : "procedure/com.vantiq.fhir.fhirService.setSource"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.returnLink",
+    "target" : "procedure/com.vantiq.fhir.fhirService.setSource"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.performRestOpWithData",
+    "target" : "procedure/com.vantiq.fhir.fhirService.setSource"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.checkGeneralParams",
+    "target" : "services/com.vantiq.fhir.fhirService"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
+    "target" : "procedure/com.vantiq.fhir.fhirService.setSource"
   } ],
   "name" : "com.vantiq.fhir.fhirConnection",
   "options" : {
@@ -224,14 +251,23 @@
     "label" : "com.vantiq.fhir.fhirService",
     "name" : "com.vantiq.fhir.fhirService",
     "resourceReference" : "/services/com.vantiq.fhir.fhirService",
-    "timestamp" : "2025-01-28T00:34:48.552Z",
+    "timestamp" : "2025-01-28T01:27:20.958Z",
     "type" : 63
   }, {
     "label" : "com.vantiq.fhir.fhirService.GlobalState",
     "name" : "com.vantiq.fhir.fhirService.GlobalState",
     "resourceReference" : "/types/com.vantiq.fhir.fhirService.GlobalState",
-    "timestamp" : "2025-01-21T22:33:30.731Z",
+    "timestamp" : "2025-01-28T00:47:43.579Z",
     "type" : 1
+  }, {
+    "label" : "com.vantiq.fhir.fhirService.checkGeneralParams",
+    "name" : "com.vantiq.fhir.fhirService.checkGeneralParams",
+    "packageName" : "com.vantiq.fhir",
+    "procedureName" : "checkGeneralParams",
+    "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.checkGeneralParams",
+    "serviceName" : "fhirService",
+    "timestamp" : "2025-01-29T20:36:29.007Z",
+    "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.clearCapabilityStatement",
     "name" : "com.vantiq.fhir.fhirService.clearCapabilityStatement",
@@ -275,7 +311,7 @@
     "procedureName" : "fetchCapabilityStatement",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.fetchCapabilityStatement",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-24T01:59:41.032Z",
+    "timestamp" : "2025-01-28T22:54:01.259Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.getCapabilityStatement",
@@ -290,7 +326,7 @@
     "label" : "com.vantiq.fhir.fhirService.js",
     "name" : "com.vantiq.fhir.fhirService.js",
     "resourceReference" : "/documents/com.vantiq.fhir.fhirService.js",
-    "timestamp" : "2025-01-23T00:10:59.372Z",
+    "timestamp" : "2025-01-28T01:27:21.713Z",
     "type" : 19
   }, {
     "label" : "com.vantiq.fhir.fhirService.performGet",
@@ -308,7 +344,7 @@
     "procedureName" : "performRestOp",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.performRestOp",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-24T01:57:31.492Z",
+    "timestamp" : "2025-01-28T22:54:05.653Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.performRestOpQuery",
@@ -317,7 +353,7 @@
     "procedureName" : "performRestOpQuery",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.performRestOpQuery",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-27T22:32:37.377Z",
+    "timestamp" : "2025-01-28T22:53:56.804Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.performRestOpWithData",
@@ -326,7 +362,7 @@
     "procedureName" : "performRestOpWithData",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.performRestOpWithData",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-24T01:58:07.111Z",
+    "timestamp" : "2025-01-28T22:54:03.462Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.read",
@@ -344,7 +380,7 @@
     "procedureName" : "returnLink",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.returnLink",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-28T01:27:16.126Z",
+    "timestamp" : "2025-01-28T22:53:49.840Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.searchCompartment",
@@ -353,7 +389,7 @@
     "procedureName" : "searchCompartment",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.searchCompartment",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-28T00:03:13.453Z",
+    "timestamp" : "2025-01-28T22:53:54.485Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.searchSystem",
@@ -362,7 +398,7 @@
     "procedureName" : "searchSystem",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.searchSystem",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-28T00:34:43.943Z",
+    "timestamp" : "2025-01-28T22:53:52.240Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.searchType",
@@ -371,7 +407,7 @@
     "procedureName" : "searchType",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.searchType",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-27T23:42:15.561Z",
+    "timestamp" : "2025-01-28T22:53:59.066Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.setSource",

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/services/com/vantiq/fhir/fhirService.json
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/services/com/vantiq/fhir/fhirService.json
@@ -174,9 +174,15 @@
     }, {
       "description" : null,
       "multi" : false,
-      "name" : "theQuery",
+      "name" : "query",
       "required" : true,
       "type" : "Object"
+    }, {
+      "description" : null,
+      "multi" : false,
+      "name" : "method",
+      "required" : false,
+      "type" : "String"
     } ]
   } ],
   "internalEventHandlers" : [ ],

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/services/com/vantiq/fhir/fhirService.json
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/services/com/vantiq/fhir/fhirService.json
@@ -28,12 +28,6 @@
       "name" : "versionId",
       "required" : false,
       "type" : "String"
-    }, {
-      "description" : null,
-      "multi" : false,
-      "name" : "generalParms",
-      "required" : false,
-      "type" : "Object"
     } ],
     "returnType" : {
       "multi" : false,
@@ -82,7 +76,7 @@
     }, {
       "description" : null,
       "multi" : false,
-      "name" : "genParams",
+      "name" : "generalParams",
       "required" : false,
       "type" : "Object"
     } ],
@@ -91,97 +85,12 @@
       "type" : "Object"
     }
   }, {
-    "name" : "setSource",
+    "name" : "returnLink",
     "parameters" : [ {
       "description" : null,
       "multi" : false,
-      "name" : "theSource",
-      "required" : false,
-      "type" : "String"
-    } ]
-  }, {
-    "name" : "update",
-    "parameters" : [ {
-      "description" : null,
-      "multi" : false,
-      "name" : "type",
+      "name" : "link",
       "required" : true,
-      "type" : "String"
-    }, {
-      "description" : null,
-      "multi" : false,
-      "name" : "id",
-      "required" : true,
-      "type" : "String"
-    }, {
-      "description" : null,
-      "multi" : false,
-      "name" : "resource",
-      "required" : true,
-      "type" : "Object"
-    }, {
-      "description" : null,
-      "multi" : false,
-      "name" : "versionId",
-      "required" : false,
-      "type" : "String"
-    }, {
-      "description" : null,
-      "multi" : false,
-      "name" : "generalParms",
-      "required" : false,
-      "type" : "Object"
-    } ],
-    "returnType" : {
-      "multi" : false,
-      "type" : "Object"
-    }
-  }, {
-    "name" : "vread",
-    "parameters" : [ {
-      "description" : null,
-      "multi" : false,
-      "name" : "type",
-      "required" : true,
-      "type" : "String"
-    }, {
-      "description" : null,
-      "multi" : false,
-      "name" : "id",
-      "required" : true,
-      "type" : "String"
-    }, {
-      "description" : null,
-      "multi" : false,
-      "name" : "versionId",
-      "required" : false,
-      "type" : "String"
-    }, {
-      "description" : null,
-      "multi" : false,
-      "name" : "generalParms",
-      "required" : false,
-      "type" : "Object"
-    } ]
-  }, {
-    "name" : "searchType",
-    "parameters" : [ {
-      "description" : null,
-      "multi" : false,
-      "name" : "type",
-      "required" : true,
-      "type" : "String"
-    }, {
-      "description" : null,
-      "multi" : false,
-      "name" : "query",
-      "required" : true,
-      "type" : "Object"
-    }, {
-      "description" : null,
-      "multi" : false,
-      "name" : "method",
-      "required" : false,
       "type" : "String"
     } ]
   }, {
@@ -233,14 +142,103 @@
       "type" : "String"
     } ]
   }, {
-    "name" : "returnLink",
+    "name" : "searchType",
     "parameters" : [ {
       "description" : null,
       "multi" : false,
-      "name" : "link",
+      "name" : "type",
       "required" : true,
       "type" : "String"
+    }, {
+      "description" : null,
+      "multi" : false,
+      "name" : "query",
+      "required" : true,
+      "type" : "Object"
+    }, {
+      "description" : null,
+      "multi" : false,
+      "name" : "generalParams",
+      "required" : false,
+      "type" : "Object"
+    }, {
+      "description" : null,
+      "multi" : false,
+      "name" : "method",
+      "required" : false,
+      "type" : "String"
     } ]
+  }, {
+    "name" : "setSource",
+    "parameters" : [ {
+      "description" : null,
+      "multi" : false,
+      "name" : "theSource",
+      "required" : false,
+      "type" : "String"
+    } ]
+  }, {
+    "name" : "update",
+    "parameters" : [ {
+      "description" : null,
+      "multi" : false,
+      "name" : "type",
+      "required" : true,
+      "type" : "String"
+    }, {
+      "description" : null,
+      "multi" : false,
+      "name" : "id",
+      "required" : true,
+      "type" : "String"
+    }, {
+      "description" : null,
+      "multi" : false,
+      "name" : "resource",
+      "required" : true,
+      "type" : "Object"
+    }, {
+      "description" : null,
+      "multi" : false,
+      "name" : "versionId",
+      "required" : false,
+      "type" : "String"
+    } ],
+    "returnType" : {
+      "multi" : false,
+      "type" : "Object"
+    }
+  }, {
+    "name" : "vread",
+    "parameters" : [ {
+      "description" : null,
+      "multi" : false,
+      "name" : "type",
+      "required" : true,
+      "type" : "String"
+    }, {
+      "description" : null,
+      "multi" : false,
+      "name" : "id",
+      "required" : true,
+      "type" : "String"
+    }, {
+      "description" : null,
+      "multi" : false,
+      "name" : "versionId",
+      "required" : false,
+      "type" : "String"
+    }, {
+      "description" : null,
+      "multi" : false,
+      "name" : "generalParams",
+      "required" : false,
+      "type" : "Object"
+    } ],
+    "returnType" : {
+      "multi" : false,
+      "type" : "Object"
+    }
   } ],
   "internalEventHandlers" : [ ],
   "name" : "com.vantiq.fhir.fhirService",

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/services/com/vantiq/fhir/fhirService.json
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/services/com/vantiq/fhir/fhirService.json
@@ -184,6 +184,63 @@
       "required" : false,
       "type" : "String"
     } ]
+  }, {
+    "name" : "searchCompartment",
+    "parameters" : [ {
+      "description" : null,
+      "multi" : false,
+      "name" : "compartment",
+      "required" : true,
+      "type" : "String"
+    }, {
+      "description" : null,
+      "multi" : false,
+      "name" : "id",
+      "required" : true,
+      "type" : "String"
+    }, {
+      "description" : null,
+      "multi" : false,
+      "name" : "query",
+      "required" : true,
+      "type" : "Object"
+    }, {
+      "description" : null,
+      "multi" : false,
+      "name" : "type",
+      "required" : false,
+      "type" : "String"
+    }, {
+      "description" : null,
+      "multi" : false,
+      "name" : "method",
+      "required" : false,
+      "type" : "String"
+    } ]
+  }, {
+    "name" : "searchSystem",
+    "parameters" : [ {
+      "description" : null,
+      "multi" : false,
+      "name" : "query",
+      "required" : true,
+      "type" : "Object"
+    }, {
+      "description" : null,
+      "multi" : false,
+      "name" : "method",
+      "required" : false,
+      "type" : "String"
+    } ]
+  }, {
+    "name" : "returnLink",
+    "parameters" : [ {
+      "description" : null,
+      "multi" : false,
+      "name" : "link",
+      "required" : true,
+      "type" : "String"
+    } ]
   } ],
   "internalEventHandlers" : [ ],
   "name" : "com.vantiq.fhir.fhirService",

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/types/com/vantiq/fhir/fhirService/GlobalState.json
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/types/com/vantiq/fhir/fhirService/GlobalState.json
@@ -15,6 +15,13 @@
       "required" : false,
       "type" : "Value",
       "unique" : false
+    },
+    "fhirSourceBase" : {
+      "encrypted" : false,
+      "multi" : false,
+      "required" : false,
+      "type" : "Value",
+      "unique" : false
     }
   },
   "role" : "schema"

--- a/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssembly.java
+++ b/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssembly.java
@@ -79,6 +79,7 @@ public class TestFhirAssembly {
             assertTrue("Could not create test catalog: " + resp.getErrors(), resp.isSuccess());
             resp = v.select("system.catalogs", Collections.emptyList(), null, null);
             assertTrue(resp.isSuccess());
+            //noinspection unchecked
             for (int i = 0; i < ((List<JsonObject>) resp.getBody()).size(); i++ ) {
                 //noinspection unchecked
                 log.debug("Found catalog: {}", ((List<JsonObject>) resp.getBody()).get(i).getAsJsonObject()
@@ -471,7 +472,7 @@ public class TestFhirAssembly {
     Map<String, ?> findTarget(Vantiq v, String type, Map<String, ?> query) throws Exception {
         VantiqResponse resp = v.execute("com.vantiq.fhir.fhirService.searchType",
                                         Map.of("type", type,
-                                               "theQuery", query));
+                                               "query", query));
         assertTrue("Could not perform searchType: " + resp.getErrors(), resp.isSuccess());
         log.trace("Search Type {} {} response: {}", type, query, resp.getBody());
         //noinspection unchecked

--- a/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssembly.java
+++ b/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssembly.java
@@ -621,6 +621,27 @@ public class TestFhirAssembly {
         traverseSearch(v, countSize, "Encounter", Collections.emptyMap(), 842);
     }
     
+    @Test
+    public void test502SearchPatientQual() throws Exception {
+        Map<Map<String, ?>, Integer> searches = Map.of(
+                Map.of("name", "Lesch175"), 1,
+                Map.of("name", "Mr."), 14,
+                Map.of("gender:not","female"), 20);
+        
+        int countSize = 20;
+        Vantiq v = new Vantiq(TEST_SERVER, 1);
+        v.authenticate(SUB_USER, SUB_USER);
+        
+        searches.forEach ( (key, val) -> {
+            try {
+                traverseSearch(v, countSize, "Patient", key, val);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+    
+    
     void traverseSearch(Vantiq v, int bundleSize, String type, Map<String, ?> query, int expectedCount) throws Exception {
         VantiqResponse resp;
         String nextUrl;


### PR DESCRIPTION
This is a merge into the FHIR staging branch

Fixes #546

This adds search capabilities for types. 

In support of that, we also add what are variously called _general parameters_ or _modifiers_, depending on the usage.  These allow, for example, sorting the results, getting only partial results, varying paging size (bundle size) returned.

As part of this, added general support for fetching _links_, which are URLs that a FHIR server might return.  These can be used to fetch particular things in a list, or, more commonly, to page thru results.  Paged elements include links labeled _self_, _next_, and _previous_, and fetching those links is how you get the next set of data.  To handle all of these, we create a `returnLink()` procedure in the service.

Added tests for handling these.  I should note that we've also added the ability to search thru _compartments_ and searching the system.  Neither of these features is supported by our test server, so I'll hand test elsewhere later in the game.  But it's all using the same underlying fetch code, so I don't expect surprises (famous last words).
