### PR TITLE
Add support for conditional create/update/delete

### DIFF
--- a/extpsdk/build.gradle
+++ b/extpsdk/build.gradle
@@ -11,7 +11,7 @@ ext {
         pypi_repo = 'testpypi'
     }
     if (!project.rootProject.hasProperty('vantiqConnectorSdkVersion')) {
-        vantiqConnectorSdkVersion = '1.3.4'
+        vantiqConnectorSdkVersion = '1.3.5'
     }
 }
 

--- a/extpsdk/requirements-build.in
+++ b/extpsdk/requirements-build.in
@@ -7,7 +7,7 @@ aiofiles
 aioresponses>=0.7.6
 
 # Dependabot Fix
-jinja2>=3.1.4
+jinja2>=3.1.5
 setuptools>=70.0.0
 zipp>=3.19.1
 

--- a/extpsdk/requirements.txt
+++ b/extpsdk/requirements.txt
@@ -54,7 +54,7 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.1.0
     # via keyring
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -r requirements-build.in
     #   pytest-html

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_checkModifiers.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_checkModifiers.vail
@@ -1,7 +1,13 @@
 package com.vantiq.fhir
-private stateless PROCEDURE fhirService.checkGeneralParams(generalParams Object): Object
+private stateless PROCEDURE fhirService.checkModifiers(modifiers com.vantiq.fhir.Modifiers): com.vantiq.fhir.Modifiers
 
 var checkedParams = {}
+var generalParams = {}
+var headers = {}
+if (modifiers) {
+    generalParams = modifiers.generalParams
+    headers = modifiers.headers
+}
 
 if (generalParams) {
     for (gp in generalParams) {
@@ -16,4 +22,5 @@ if (generalParams) {
         }
     }
 }
-return checkedParams
+
+return { headers: headers, generalParams: checkedParams }

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_combineQueryAndParams.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_combineQueryAndParams.vail
@@ -1,0 +1,17 @@
+package com.vantiq.fhir
+private stateless PROCEDURE fhirService.combineQueryAndParams(query Object, generalParams Object): Object
+
+var comboQuery = Object.clone(query)
+if (comboQuery == null) {
+    comboQuery = {}
+}
+for (p in generalParams) {
+    if (comboQuery.has(p.key)) {
+        exception("com.vantiq.fhir.generalparam.conflict",
+                    "The generalParam {0} would overwrite the query parameter of the same name.",
+                    [p.key])
+    } else {
+        comboQuery[p.key] = p.value
+    }
+}
+return comboQuery

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_create.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_create.vail
@@ -1,14 +1,19 @@
+// Create a new FHIR resource instance
+
 package com.vantiq.fhir
-PROCEDURE fhirService.create(type String REQUIRED, resource Object REQUIRED, versionId String): Object
+PROCEDURE fhirService.create(type String REQUIRED DESCRIPTION "The type of resource to create.",
+                             resource Object REQUIRED DESCRIPTION "The instance of the resource.",
+                             versionId String DESCRIPTION "Version identifier for the resource instance to create.",
+                             modifiers com.vantiq.fhir.Modifiers DESCRIPTION "Query modifiers and headers for the call."): com.vantiq.fhir.FHIRResponse WITH updateInterface=true
 
 var path = type
 
 var retVal = fhirService.performRestOpWithData("POST", path, resource)
-if (typeOf(retVal) == "List") {
-    log.debug("retVal is an array: {}", [typeOf(retVal)])
-    retVal = retVal[0]
+if (typeOf(retVal.body) == "List") {
+    log.debug("retVal.body is an array: {}", [typeOf(retVal.body)])
+    retVal.body = retVal.body[0]
 } else {
-    log.debug("retVal is not an array")
+    log.debug("retVal.body is not an array")
 }
 return retVal
 

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_create.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_create.vail
@@ -8,7 +8,7 @@ PROCEDURE fhirService.create(type String REQUIRED DESCRIPTION "The type of resou
 
 var path = type
 
-var retVal = fhirService.performRestOpWithData("POST", path, resource)
+var retVal = fhirService.performRestOpWithData("POST", path, resource, modifiers)
 if (typeOf(retVal.body) == "List") {
     log.debug("retVal.body is an array: {}", [typeOf(retVal.body)])
     retVal.body = retVal.body[0]

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_createErrorMsg.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_createErrorMsg.vail
@@ -8,6 +8,15 @@ package com.vantiq.fhir
 
 private PROCEDURE fhirService.createErrorMsg(exc Object REQUIRED, targetPath String REQUIRED): Object
 var errDetails = exc.params[2]
+var statusCode = 400
+if (exc.params.size() >= 3) {
+    var sc = exc.params[3]
+    if (typeOf(sc) == "Object" && sc.has("code")) {
+        statusCode = sc.code
+    } else if (typeOf(sc) == "Integer") {
+        statusCode = sc
+    }
+}
 var opOutcome = null
 var resValue = null
 
@@ -47,4 +56,5 @@ if (!resValue || resValue.resourceType != "OperationOutcome") {
 } else {
     opOutcome = resValue
 }
-return opOutcome
+// Here, we return what looks like a asFullResponse for our callers to handle
+return {status: statusCode, body: opOutcome, headers: {}}

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_delete.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_delete.vail
@@ -1,15 +1,18 @@
+// Delete a resource instance
+
 package com.vantiq.fhir
-PROCEDURE fhirService.delete(type String REQUIRED, id String REQUIRED): Object
+PROCEDURE fhirService.delete(type String REQUIRED DESCRIPTION "Type of the resource to delete.",
+                             id String REQUIRED DESCRIPTION "Id of the instance to delete.",
+                             modifiers com.vantiq.fhir.Modifiers DESCRIPTION "Query modifiers and headers for the call."): com.vantiq.fhir.FHIRResponse WITH updateInterface=true
 
 var path = type + "/" + id
 
-
-var retVal = fhirService.performRestOp("DELETE", path)
-if (typeOf(retVal) == "List") {
-    log.debug("retVal is an array: {}", [typeOf(retVal)])
-    retVal = retVal[0]
+var retVal = fhirService.performRestOp("DELETE", path, modifiers)
+if (typeOf(retVal.body) == "List") {
+    log.debug("retVal.body is an array: {}", [typeOf(retVal.body)])
+    retVal.body = retVal.body[0]
 } else {
-    log.debug("retVal is not an array")
+    log.debug("retVal.body is not an array")
 }
 return retVal
 

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_fetchCapabilityStatement.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_fetchCapabilityStatement.vail
@@ -5,7 +5,11 @@ package com.vantiq.fhir
 import service com.vantiq.fhir.fhirService
 
 private PROCEDURE fhirService.fetchCapabilityStatement():Object
-var returnValue
-
-returnValue = fhirService.performGet("metadata")
-return returnValue[0]
+var fhirResp = fhirService.performGet("metadata")
+var retVal
+if (typeOf(fhirResp.body) == "List") {
+    retVal = fhirResp.body[0]
+} else {
+    retVal = fhirResp.body
+}
+return retVal

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_getCapabilityStatement.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_getCapabilityStatement.vail
@@ -6,7 +6,7 @@ package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService
 
-PROCEDURE fhirService.getCapabilityStatement(): Object
+PROCEDURE fhirService.getCapabilityStatement(): Object WITH updateInterface=true
 var retVal = fhirCapabilityStatement.getValue()
 if (!retVal) {
     log.debug("Fetching new FHIR capability statement")

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performGet.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performGet.vail
@@ -1,4 +1,4 @@
 package com.vantiq.fhir
-private PROCEDURE fhirService.performGet(targetPath String REQUIRED): Any
+private PROCEDURE fhirService.performGet(targetPath String REQUIRED): com.vantiq.fhir.FHIRResponse
 
 return fhirService.performRestOp("GET", targetPath)

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOp.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOp.vail
@@ -2,7 +2,7 @@ package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService
 
-private PROCEDURE fhirService.performRestOp(method String REQUIRED, targetPath String REQUIRED): Any
+private PROCEDURE fhirService.performRestOp(method String REQUIRED, targetPath String REQUIRED, modifiers com.vantiq.fhir.Modifiers): com.vantiq.fhir.FHIRResponse
 
 var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
@@ -12,12 +12,25 @@ if (!theSource) {
     theSource = fhirSource.getValue()
 }
 var retVal = ""
+var gp = {}
+var headers = {}
+if (modifiers) {
+    if (modifiers.generalParams) {
+        gp = modifiers.generalParams
+    }
+    if (modifiers.headers) {
+        headers = modifiers.headers
+    }
+}
 
 try {
     retVal = SELECT from SOURCE @theSource with path = targetPath,
         method = method,
+        query = gp,
+        headers = headers,
         contentType = "application/fhir+json",
-        responseType = "application/fhir+json"
+        responseType = "application/fhir+json",
+        asFullResponse = true
 } catch (e) {
     if (e.code == "io.vantiq.sourcemgr.remote.query.client.failure") {
         retVal = fhirService.createErrorMsg(e, targetPath)
@@ -25,4 +38,7 @@ try {
         rethrow(e)
     }
 }
-return retVal
+if (typeOf(retVal) == "List" && retVal.size() == 1) {
+    retVal = retVal[0]
+}
+return {statusCode: retVal.status, body: retVal.body, headers: retVal.headers}

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOpQuery.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOpQuery.vail
@@ -3,7 +3,7 @@ package com.vantiq.fhir
 import service com.vantiq.fhir.fhirService
 
 private PROCEDURE fhirService.performRestOpQuery(method String REQUIRED, targetPath String REQUIRED,
-                    query Object Required): Any
+                    query Object Required, modifiers com.vantiq.fhir.Modifiers): com.vantiq.fhir.FHIRResponse
 
 var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
@@ -13,29 +13,53 @@ if (!theSource) {
     theSource = fhirSource.getValue()
 }
 var retVal = ""
+var headers
+if (modifiers && modifiers.headers) {
+    headers = modifiers.headers
+} else {
+    headers = {}
+}
 
-log.debug("Performing {} method on path {} with query {}", [method, targetPath, query])
+var gp
+if (modifiers && modifiers.generalParams) {
+    gp = modifiers.generalParams
+} else {
+    gp = {}
+}
+
+var comboQuery = fhirService.combineQueryAndParams(query, gp)
+
+log.debug("Performing {} method on path {} with query {} and headers {}", [method, targetPath, comboQuery, headers])
 try {
     if (method == "GET" || method == "HEAD") {
         retVal = SELECT from SOURCE @theSource with path = targetPath,
             method = method,
-            query = query,
+            query = comboQuery,
+            headers = headers,
             contentType = "application/fhir+json",
-            responseType = "application/fhir+json"
+            responseType = "application/fhir+json",
+            asFullResponse = true
     } else {
-        var bod = Encode.formUrl(query)
+        var bod = Encode.formUrl(comboQuery)
         retVal = SELECT from SOURCE @theSource with path = targetPath,
             method = method,
             body = bod,
+            headers = headers,
             contentType = "application/x-www-form-urlencoded",
-            responseType = "application/fhir+json"
+            responseType = "application/fhir+json",
+            asFullResponse = true
 
     }
 } catch (e) {
+    log.debug("Trapped exception: {}", [e])
     if (e.code == "io.vantiq.sourcemgr.remote.query.client.failure") {
         retVal = fhirService.createErrorMsg(e, targetPath)
     } else {
         rethrow(e)
     }
 }
-return retVal
+log.debug("Source query returned: {}", [retVal])
+if (typeOf(retVal) == "List" && retVal.size() == 1) {
+    retVal = retVal[0]
+}
+return {statusCode: retVal.status, body: retVal.body, headers: retVal.headers}

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOpWithData.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOpWithData.vail
@@ -20,7 +20,8 @@ try {
         method = method,
         body = resource,
         contentType = "application/fhir+json",
-        responseType = "application/fhir+json"
+        responseType = "application/fhir+json",
+        asFullResponse = true
 } catch (e) {
     if (e.code == "io.vantiq.sourcemgr.remote.query.client.failure") {
         retVal = fhirService.createErrorMsg(e, targetPath)
@@ -28,4 +29,7 @@ try {
         rethrow(e)
     }
 }
-return retVal
+if (typeOf(retVal) == "List" && retVal.size() == 1) {
+    retVal = retVal[0]
+}
+return {statusCode: retVal.status, body: retVal.body, headers: retVal.headers}

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOpWithData.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOpWithData.vail
@@ -4,7 +4,8 @@ import service com.vantiq.fhir.fhirService
 
 private PROCEDURE fhirService.performRestOpWithData(method String REQUIRED, 
                                                   targetPath String REQUIRED,
-                                                  resource Object REQUIRED): Any
+                                                  resource Object REQUIRED,
+                                                  modifiers com.vantiq.fhir.Modifiers): Any
 
 var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
@@ -14,11 +15,28 @@ if (!theSource) {
     theSource = fhirSource.getValue()
 }
 var retVal = ""
+var headers
+var gp
+
+if (modifiers) {
+    if (modifiers.headers) {
+        headers = modifiers.headers
+    } else {
+        headers = {}
+    }
+    if (modifiers.generalParams){
+        gp = modifiers.generalParams
+    } else {
+        gp = {}
+    }
+}
 
 try {
     retVal = SELECT ONE from SOURCE @theSource with path = targetPath,
         method = method,
         body = resource,
+        query = gp,
+        headers = headers,
         contentType = "application/fhir+json",
         responseType = "application/fhir+json",
         asFullResponse = true
@@ -32,4 +50,4 @@ try {
 if (typeOf(retVal) == "List" && retVal.size() == 1) {
     retVal = retVal[0]
 }
-return {statusCode: retVal.status, body: retVal.body, headers: retVal.headers}
+return {statusCode: retVal.status, body: retVal.body, headers: retVal.headers, extra: {headers: headers, gp: gp}}

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOpWithData.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_performRestOpWithData.vail
@@ -50,4 +50,4 @@ try {
 if (typeOf(retVal) == "List" && retVal.size() == 1) {
     retVal = retVal[0]
 }
-return {statusCode: retVal.status, body: retVal.body, headers: retVal.headers, extra: {headers: headers, gp: gp}}
+return {statusCode: retVal.status, body: retVal.body, headers: retVal.headers}

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_read.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_read.vail
@@ -1,18 +1,11 @@
-/**
-* Read a type based on its id
-*
-* @param type String the FHIR resource type
-* @param id String the id desired
-* @param generalParams Object (optional) a set of name/value pairs representing the general parameters for this call.
-*                                        The general parameters include _summary & _element. _pretty can be included.
-*                                        though it provides no value since the caller is not getting JSON back.
-*                                        _format is not permitted in this context.
-*/
+// Read a type based on its id
 
 package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService
 
-PROCEDURE fhirService.read(type String REQUIRED, id String REQUIRED, generalParams Object): Object
+PROCEDURE fhirService.read(type String REQUIRED DESCRIPTION "Type of the resource to read.", 
+                           id String REQUIRED DESCRIPTION "Id of the resource to read",
+                           modifiers com.vantiq.fhir.Modifiers DESCRIPTION "Query modifiers and headers for the call."): com.vantiq.fhir.FHIRResponse WITH updateInterface=true
 
-return fhirService.vread(type, id, null, generalParams)
+return fhirService.vread(type, id, null, modifiers)

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_returnLink.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_returnLink.vail
@@ -1,17 +1,10 @@
-/**
-* Fetch a link
-*
-* Using the current source, fetch the link by converting the absolute URL to a relative one. FHIR uses absolutes which
-* don't mix well with Vantiq sources.
-*
-* @param link String The URL of the link to return.
-*/
+// Return the content of the provided link
 
 package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService
 
-PROCEDURE fhirService.returnLink(link String REQUIRED)
+PROCEDURE fhirService.returnLink(link String REQUIRED DESCRIPTION "The URL of the link to return."): com.vantiq.fhir.FHIRResponse WITH updateInterface=true
 
 var theSource = fhirSource.getValue()
 if (!theSource) {

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchCompartment.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchCompartment.vail
@@ -25,18 +25,18 @@ if (type) {
     targetPath = targetPath + "/" + type
 }
 if (!method) {
-    method = "GET"
+    method = ResourceConfig.get("defaultSearchHttpMethod")
+    // Shouldn't happen, but ...
+    if (!method) {
+        method = "GET"
+    }
 } 
 if (method == "GET" && !type) {
     // The spec requires that GET requests for a compartment/id (sans type) require the extra * to distinguish
     // the request from a "read" operation on a type with the same name as the compartment.
     targetPath = targetPath + "/*"
 } else if (method == "POST") {
-    if (type) {
-        targetPath = targetPath + "/" + type + "/_search"
-    } else {
         targetPath = targetPath + "/_search"
-    }
 }
 log.debug("Performing compartment search using targetPath: {}, query: {}, modifiers: {}", [targetPath, query, modifiers])
 return fhirService.performRestOpQuery(method, targetPath, query, modifiers)

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchCompartment.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchCompartment.vail
@@ -1,32 +1,20 @@
-/**
-* Perform a search based on the compartment, id, & query provided
-*
-* Using the current source, run the search query for a particular compartment. If no method is provided,
-* we use GET. If search via POST is desired, provide "POST" as the method parameter.
-*
-* The compartment will be searched.  If the type parameter is provided, the results are restricted to entries of
-* that type.
-*
-* @param compartment String The FHIR Resource compartment to search
-* @param id String Id of the compartment
-* @param query Object The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object here ("{}").
-* @param type String The FHIR resource type within the compartment to which to restrict the search.
-* @param method String GET or POST
-*/
+// Perform a search based on the compartment, id, & query provided
 
 package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService
 
-PROCEDURE fhirService.searchCompartment(compartment String REQUIRED, 
-                                        id String REQUIRED,
-                                        query Object REQUIRED,
-                                        type String,
-                                        method String)
+PROCEDURE fhirService.searchCompartment(compartment String REQUIRED DESCRIPTION "The FHIR Resource Compartment to search", 
+                                        id String REQUIRED DESCRIPTION "The instance id desired",
+                                        query Object REQUIRED DESCRIPTION "he FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object here (\"{}\").",
+                                        type String DESCRIPTION "The FHIR resource type within the compartment to which to restrict the search.",
+                                        modifiers com.vantiq.fhir.Modifiers DESCRIPTION "Query modifiers and headers for the call.",
+                                        method String DESCRIPTION "HTTP Method to use, overriding search default: GET or POST"): com.vantiq.fhir.FHIRResponse WITH updateInterface=true
+
 var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
-log.debug("searchCompartment({}, {}, {}, {}, {})", [
-    compartment, id, query, type, method
+log.debug("searchCompartment({}, {}, {}, {}, {}, {})", [
+    compartment, id, query, type, modifiers, method
 ])
 if (!theSource) {
     fhirService.setSource()
@@ -50,5 +38,5 @@ if (method == "GET" && !type) {
         targetPath = targetPath + "/_search"
     }
 }
-log.debug("Performing compartment search using targetPath: {}, query: query", [targetPath, query])
-return fhirService.performRestOpQuery(method, targetPath, query )
+log.debug("Performing compartment search using targetPath: {}, query: {}, modifiers: {}", [targetPath, query, modifiers])
+return fhirService.performRestOpQuery(method, targetPath, query, modifiers)

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchCompartment.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchCompartment.vail
@@ -13,9 +13,7 @@ PROCEDURE fhirService.searchCompartment(compartment String REQUIRED DESCRIPTION 
 
 var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
-log.debug("searchCompartment({}, {}, {}, {}, {}, {})", [
-    compartment, id, query, type, modifiers, method
-])
+log.debug("searchCompartment({}, {}, {}, {}, {}, {})", [compartment, id, query, type, modifiers, method])
 if (!theSource) {
     fhirService.setSource()
     theSource = fhirSource.getValue()

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchSystem.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchSystem.vail
@@ -26,8 +26,13 @@ var targetPath = "/"
 var checkedParams = fhirService.checkModifiers(modifiers)
 var comboQuery = fhirService.combineQueryAndParams(query, checkedParams.generalParams)
 if (!method) {
-    method = "GET"
-} else if (method == "POST") {
+    method = ResourceConfig.get("defaultSearchHttpMethod")
+    // Shouldn't happen, but ...
+    if (!method) {
+        method = "GET"
+    }
+} 
+if (method == "POST") {
     targetPath = "/_search"
 }
 return fhirService.performRestOpQuery(method, targetPath, comboQuery, checkedParams.headers )

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchSystem.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchSystem.vail
@@ -4,7 +4,7 @@
 * Using the current source, run the search query for a particular type. If no method is provided,
 * we use GET. If search via POST is desired, provide "POST" as the method parameter.
 *
-* @param query Object The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object ("{}").
+* @param query Object ).
 * @param method String GET or POST.  Optional
 */
 
@@ -12,7 +12,9 @@ package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService
 
-PROCEDURE fhirService.searchSystem(query Object REQUIRED, method String)
+PROCEDURE fhirService.searchSystem(query Object REQUIRED DESCRIPTION "The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object (\"{}\")",
+                                   modifiers com.vantiq.fhir.Modifiers DESCRIPTION "a set of name/value pairs representing the modifiers for this call. The general parameters include _summary & _elements.",
+                                   method String DESCRIPTION "HTTP Method to use, overriding search default: GET or POST"): com.vantiq.fhir.FHIRResponse WITH updateInterface=true
 var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
 
@@ -21,9 +23,11 @@ if (!theSource) {
     theSource = fhirSource.getValue()
 }
 var targetPath = "/"
+var checkedParams = fhirService.checkModifiers(modifiers)
+var comboQuery = fhirService.combineQueryAndParams(query, checkedParams.generalParams)
 if (!method) {
     method = "GET"
 } else if (method == "POST") {
     targetPath = "/_search"
 }
-return fhirService.performRestOpQuery(method, targetPath, query )
+return fhirService.performRestOpQuery(method, targetPath, comboQuery, checkedParams.headers )

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchType.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchType.vail
@@ -25,8 +25,13 @@ var checkedParams = fhirService.checkModifiers(modifiers)
 var comboQuery = fhirService.combineQueryAndParams(query, checkedParams.generalParams)
 var targetPath = type
 if (!method) {
-    method = "GET"
-} else if (method == "POST") {
+    method = ResourceConfig.get("defaultSearchHttpMethod")
+    // Shouldn't happen since config value has a default, but just in case...
+    if (!method) {
+        method = "GET"
+    }
+} 
+if (method == "POST") {
     targetPath = type + "/_search"
 }
 return fhirService.performRestOpQuery(method, targetPath, comboQuery)

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchType.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchType.vail
@@ -1,21 +1,18 @@
-/**
-* Perform a search based on the type & query provided
-*
-* Using the current source, run the search query for a particular type. If no method is provided,
-* we use GET. If search via POST is desired, provide "POST" as the method parameter.
-*
-* @param type String The FHIR Resource type to search
-* @param query Object The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object here ("{}").
-* @param generalParams (optional) a set of name/value pairs representing the modifiers for this call.
-*                                        The general parameters include _summary & _elements.
-* @param method String (optional) GET or POST
-*/
+// Perform a search based on the type & query provided
+//
+// Using the current source, run the search query for a particular type. If no method is provided,
+// use the assembly's default. Provide this parameter to override the assembly default.
 
 package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService
+import type com.vantiq.fhir.FHIRResponse
+import type com.vantiq.fhir.Modifiers
 
-PROCEDURE fhirService.searchType(type String REQUIRED, query Object REQUIRED, generalParams Object, method String)
+PROCEDURE fhirService.searchType(type String REQUIRED DESCRIPTION "The FHIR Resource type to search",
+                                 query Object REQUIRED DESCRIPTION "The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object here (\"{}\").",
+                                 modifiers com.vantiq.fhir.Modifiers DESCRIPTION "a set of name/value pairs representing the modifiers for this call. The general parameters include _summary & _elements.",
+                                 method String DESCRIPTION "HTTP Method to use, overriding search default: GET or POST"): com.vantiq.fhir.FHIRResponse WITH updateInterface=true
 var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
 
@@ -24,17 +21,8 @@ if (!theSource) {
     theSource = fhirSource.getValue()
 }
 
-var checkedParams = fhirService.checkGeneralParams(generalParams)
-var comboQuery = Object.clone(query)
-for (p in checkedParams) {
-    if (comboQuery.has(p.key)) {
-        exception("com.vantiq.fhir.generalparam.conflict",
-                    "The generalParam {0} would overwrite the query parameter of the same name.",
-                    [p.key])
-    } else {
-        comboQuery[p.key] = p.value
-    }
-}
+var checkedParams = fhirService.checkModifiers(modifiers)
+var comboQuery = fhirService.combineQueryAndParams(query, checkedParams.generalParams)
 var targetPath = type
 if (!method) {
     method = "GET"

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_setSource.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_setSource.vail
@@ -2,7 +2,7 @@ package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService
 
-PROCEDURE fhirService.setSource(theSource String): String
+private PROCEDURE fhirService.setSource(theSource String): String
 
 if (!theSource) {
     // If no source name is specified (the norm), use the source that's part of the assembly

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_update.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_update.vail
@@ -1,5 +1,9 @@
 package com.vantiq.fhir
-PROCEDURE fhirService.update(type String REQUIRED, id String REQUIRED, resource Object REQUIRED, versionId String): Object
+PROCEDURE fhirService.update(type String REQUIRED,
+                             id String REQUIRED,
+                             resource Object REQUIRED,
+                             versionId String,
+                             modifiers Object): Object WITH updateInterface=true
 
 var path = type + "/" + id
 
@@ -12,11 +16,11 @@ if (versionId) {
 }
 
 var retVal = fhirService.performRestOpWithData("PUT", path, resource)
-if (typeOf(retVal) == "List") {
-    log.debug("retVal is an array: {}", [typeOf(retVal)])
-    retVal = retVal[0]
+if (typeOf(retVal.body) == "List") {
+    log.debug("retVal.body is an array: {}", [typeOf(retVal.body)])
+    retVal.body = retVal.body[0]
 } else {
-    log.debug("retVal is not an array")
+    log.debug("retVal.body is not an array")
 }
 return retVal
 

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_update.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_update.vail
@@ -3,7 +3,7 @@ PROCEDURE fhirService.update(type String REQUIRED,
                              id String REQUIRED,
                              resource Object REQUIRED,
                              versionId String,
-                             modifiers Object): Object WITH updateInterface=true
+                             modifiers com.vantiq.fhir.Modifiers): com.vantiq.fhir.FHIRResponse WITH updateInterface=true
 
 var path = type + "/" + id
 
@@ -15,7 +15,7 @@ if (versionId) {
     path = path + "/_history/" + versionId
 }
 
-var retVal = fhirService.performRestOpWithData("PUT", path, resource)
+var retVal = fhirService.performRestOpWithData("PUT", path, resource, modifiers)
 if (typeOf(retVal.body) == "List") {
     log.debug("retVal.body is an array: {}", [typeOf(retVal.body)])
     retVal.body = retVal.body[0]

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_vread.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_vread.vail
@@ -1,20 +1,14 @@
-/**
-* Read a type based on its id and version (if specified)
-*
-* @param type String the FHIR resource type
-* @param id String the id desired
-* @param versionId String version id if versioning is supported and a specific version is requested.
-* @param generalParams Object (optional) a set of name/value pairs representing the general parameters for this call.
-*                                        The general parameters include _summary & _element. _pretty can be included.
-*                                        though it provides no value since the caller is not getting JSON back.
-*                                        _format is not permitted in this context.
-*/
+// Read a type based on its id and version (if specified)
+
 
 package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService
 
-PROCEDURE fhirService.vread(type String REQUIRED, id String REQUIRED, versionId String, generalParams Object): Object
+PROCEDURE fhirService.vread(type String REQUIRED DESCRIPTION "Type of the resource to read.", 
+                            id String REQUIRED DESCRIPTION "Id of the instance to read",
+                            versionId String DESCRIPTION "Version id of the instance to read",
+                            modifiers com.vantiq.fhir.Modifiers DESCRIPTION "Query modifiers and headers for the call."): com.vantiq.fhir.FHIRResponse WITH updateInterface=true
 
 var path = type + "/" + id
 
@@ -25,14 +19,15 @@ var path = type + "/" + id
 if (versionId) {
     path = path + "/_history/" + versionId
 }
+log.debug("vread: VersionId: {}, path: {}", [versionId, path])
 
-var checkedParams = fhirService.checkGeneralParams(generalParams)
+var checkedParams = fhirService.checkModifiers(modifiers)
 
-var retVal = fhirService.performRestOpQuery("GET", path, checkedParams)
-if (typeOf(retVal) == "List") {
-    log.debug("retVal is an array: {}", [typeOf(retVal)])
-    retVal = retVal[0]
+var retVal = fhirService.performRestOpQuery("GET", path, null, checkedParams)
+if (typeOf(retVal.body) == "List") {
+    log.debug("retVal.body is an array: {}", [typeOf(retVal.body)])
+    retVal.body = retVal.body[0]
 } else {
-    log.debug("retVal is not an array")
+    log.debug("retVal.body is not an array")
 }
 return retVal

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/projects/com.vantiq.fhir.fhirConnection.json
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/projects/com.vantiq.fhir.fhirConnection.json
@@ -1,6 +1,19 @@
 {
   "ars_relationships" : [ ],
   "configurationMappings" : {
+    "defaultSearchHttpMethod" : [ {
+      "property" : "defaultSearchHttpMethod",
+      "resource" : "procedures",
+      "resourceId" : "com.vantiq.fhir.fhirService.searchType"
+    }, {
+      "property" : "defaultSearchHttpMethod",
+      "resource" : "procedures",
+      "resourceId" : "com.vantiq.fhir.fhirService.searchSystem"
+    }, {
+      "property" : "defaultSearchHttpMethod",
+      "resource" : "procedures",
+      "resourceId" : "com.vantiq.fhir.fhirService.searchCompartment"
+    } ],
     "fhirServerBaseUrl" : [ {
       "property" : "config.uri",
       "resource" : "sources",
@@ -8,6 +21,14 @@
     } ]
   },
   "configurationProperties" : {
+    "defaultSearchHttpMethod" : {
+      "default" : "GET",
+      "description" : "HTTP Method to use for search.  The FHIR specification provides for using either GET or POST for search, saying that some servers may have a preference for some cases.  This parameter sets the default.  If not set, the default is GET.",
+      "enumValues" : [ "GET", "POST" ],
+      "multi" : false,
+      "required" : false,
+      "type" : "Enum"
+    },
     "fhirServerBaseUrl" : {
       "default" : null,
       "description" : "URL for connection to FHIR server.  This should include scheme, host, and port, as well as any path elements.  It should end with a '/'. (_E.g._, http://somehost/fhir/",
@@ -156,9 +177,6 @@
     "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
     "target" : "services/com.vantiq.fhir.fhirService"
   }, {
-    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
-    "target" : "procedure/com.vantiq.fhir.fhirService.performRestOpQuery"
-  }, {
     "source" : "procedure/com.vantiq.fhir.fhirService.setSource",
     "target" : "procedure/com.vantiq.fhir.fhirService.clearCapabilityStatement"
   }, {
@@ -192,9 +210,6 @@
     "source" : "procedure/com.vantiq.fhir.fhirService.checkModifiers",
     "target" : "services/com.vantiq.fhir.fhirService"
   }, {
-    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
-    "target" : "procedure/com.vantiq.fhir.fhirService.setSource"
-  }, {
     "source" : "procedure/com.vantiq.fhir.fhirService.vread",
     "target" : "procedure/com.vantiq.fhir.fhirService.performRestOpQuery"
   }, {
@@ -234,12 +249,6 @@
     "source" : "procedure/com.vantiq.fhir.fhirService.vread",
     "target" : "type/com.vantiq.fhir.Modifiers"
   }, {
-    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
-    "target" : "type/com.vantiq.fhir.FHIRResponse"
-  }, {
-    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
-    "target" : "type/com.vantiq.fhir.Modifiers"
-  }, {
     "source" : "procedure/com.vantiq.fhir.fhirService.searchCompartment",
     "target" : "type/com.vantiq.fhir.FHIRResponse"
   }, {
@@ -270,12 +279,6 @@
     "source" : "procedure/com.vantiq.fhir.fhirService.searchType",
     "target" : "procedure/com.vantiq.fhir.fhirService.combineQueryAndParams"
   }, {
-    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
-    "target" : "procedure/com.vantiq.fhir.fhirService.combineQueryAndParams"
-  }, {
-    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
-    "target" : "procedure/com.vantiq.fhir.fhirService.checkModifiers"
-  }, {
     "source" : "procedure/com.vantiq.fhir.fhirService.performRestOp",
     "target" : "type/com.vantiq.fhir.FHIRResponse"
   }, {
@@ -293,6 +296,33 @@
   }, {
     "source" : "procedure/com.vantiq.fhir.fhirService.performGet",
     "target" : "type/com.vantiq.fhir.FHIRResponse"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.performRestOpWithData",
+    "target" : "type/com.vantiq.fhir.Modifiers"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.update",
+    "target" : "type/com.vantiq.fhir.Modifiers"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.update",
+    "target" : "type/com.vantiq.fhir.FHIRResponse"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
+    "target" : "type/com.vantiq.fhir.Modifiers"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
+    "target" : "type/com.vantiq.fhir.FHIRResponse"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
+    "target" : "procedure/com.vantiq.fhir.fhirService.checkModifiers"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
+    "target" : "procedure/com.vantiq.fhir.fhirService.setSource"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
+    "target" : "procedure/com.vantiq.fhir.fhirService.combineQueryAndParams"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
+    "target" : "procedure/com.vantiq.fhir.fhirService.performRestOpQuery"
   } ],
   "name" : "com.vantiq.fhir.fhirConnection",
   "options" : {
@@ -321,7 +351,7 @@
     "showGrid" : true,
     "structure" : {
       "fraction" : 1,
-      "type" : "R[5]"
+      "type" : "R[6]"
     },
     "type" : "dev",
     "v" : 6,
@@ -350,7 +380,7 @@
     "label" : "com.vantiq.fhir.fhirService",
     "name" : "com.vantiq.fhir.fhirService",
     "resourceReference" : "/services/com.vantiq.fhir.fhirService",
-    "timestamp" : "2025-01-31T22:40:03.171Z",
+    "timestamp" : "2025-02-03T20:06:57.270Z",
     "type" : 63
   }, {
     "label" : "com.vantiq.fhir.fhirService.GlobalState",
@@ -365,7 +395,7 @@
     "procedureName" : "checkModifiers",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.checkModifiers",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-31T22:30:30.063Z",
+    "timestamp" : "2025-02-03T19:31:42.050Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.clearCapabilityStatement",
@@ -383,7 +413,7 @@
     "procedureName" : "combineQueryAndParams",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.combineQueryAndParams",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-31T21:25:21.531Z",
+    "timestamp" : "2025-02-03T19:31:43.495Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.create",
@@ -392,7 +422,7 @@
     "procedureName" : "create",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.create",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-31T21:47:38.326Z",
+    "timestamp" : "2025-02-03T19:31:42.052Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.createErrorMsg",
@@ -401,7 +431,7 @@
     "procedureName" : "createErrorMsg",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.createErrorMsg",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-31T22:06:10.289Z",
+    "timestamp" : "2025-02-03T19:31:42.074Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.delete",
@@ -410,7 +440,7 @@
     "procedureName" : "delete",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.delete",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-31T22:17:30.526Z",
+    "timestamp" : "2025-02-03T19:31:42.917Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.fetchCapabilityStatement",
@@ -419,7 +449,7 @@
     "procedureName" : "fetchCapabilityStatement",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.fetchCapabilityStatement",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-31T22:39:58.790Z",
+    "timestamp" : "2025-02-03T19:31:42.813Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.getCapabilityStatement",
@@ -434,7 +464,7 @@
     "label" : "com.vantiq.fhir.fhirService.js",
     "name" : "com.vantiq.fhir.fhirService.js",
     "resourceReference" : "/documents/com.vantiq.fhir.fhirService.js",
-    "timestamp" : "2025-01-31T20:00:23.405Z",
+    "timestamp" : "2025-02-03T19:31:41.747Z",
     "type" : 19
   }, {
     "label" : "com.vantiq.fhir.fhirService.performGet",
@@ -452,7 +482,7 @@
     "procedureName" : "performRestOp",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.performRestOp",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-31T22:19:05.174Z",
+    "timestamp" : "2025-02-03T19:31:43.453Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.performRestOpQuery",
@@ -461,7 +491,7 @@
     "procedureName" : "performRestOpQuery",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.performRestOpQuery",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-31T22:01:45.288Z",
+    "timestamp" : "2025-02-03T19:31:42.821Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.performRestOpWithData",
@@ -470,7 +500,7 @@
     "procedureName" : "performRestOpWithData",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.performRestOpWithData",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-31T21:46:59.349Z",
+    "timestamp" : "2025-02-03T19:31:42.815Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.read",
@@ -479,7 +509,7 @@
     "procedureName" : "read",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.read",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-31T20:08:16.798Z",
+    "timestamp" : "2025-02-03T19:31:42.050Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.returnLink",
@@ -497,7 +527,7 @@
     "procedureName" : "searchCompartment",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.searchCompartment",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-31T22:07:28.903Z",
+    "timestamp" : "2025-02-03T19:59:13.234Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.searchSystem",
@@ -506,7 +536,7 @@
     "procedureName" : "searchSystem",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.searchSystem",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-31T21:38:34.152Z",
+    "timestamp" : "2025-02-03T19:59:10.932Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.searchType",
@@ -515,7 +545,7 @@
     "procedureName" : "searchType",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.searchType",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-31T21:38:36.494Z",
+    "timestamp" : "2025-02-03T20:06:52.965Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.setSource",
@@ -533,7 +563,7 @@
     "procedureName" : "update",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.update",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-31T21:48:31.465Z",
+    "timestamp" : "2025-02-03T19:31:42.161Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.vread",
@@ -542,7 +572,7 @@
     "procedureName" : "vread",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.vread",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-31T21:31:08.807Z",
+    "timestamp" : "2025-02-03T19:31:42.222Z",
     "type" : 3
   } ],
   "selectData" : { },

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/projects/com.vantiq.fhir.fhirConnection.json
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/projects/com.vantiq.fhir.fhirConnection.json
@@ -96,14 +96,8 @@
     "source" : "procedure/com.vantiq.fhir.fhirService.vread",
     "target" : "services/com.vantiq.fhir.fhirService"
   }, {
-    "source" : "procedure/com.vantiq.fhir.fhirService.vread",
-    "target" : "procedure/com.vantiq.fhir.fhirService.performGet"
-  }, {
     "source" : "procedure/com.vantiq.fhir.fhirService.performRestOp",
     "target" : "services/com.vantiq.fhir.fhirService"
-  }, {
-    "source" : "procedure/com.vantiq.fhir.fhirService.performRestOp",
-    "target" : "procedure/com.vantiq.fhir.fhirService.createErrorMsg"
   }, {
     "source" : "procedure/com.vantiq.fhir.fhirService.fetchCapabilityStatement",
     "target" : "services/com.vantiq.fhir.fhirService"
@@ -125,9 +119,6 @@
   }, {
     "source" : "procedure/com.vantiq.fhir.fhirService.getCapabilityStatement",
     "target" : "procedure/com.vantiq.fhir.fhirService.fetchCapabilityStatement"
-  }, {
-    "source" : "procedure/com.vantiq.fhir.fhirService.delete",
-    "target" : "procedure/com.vantiq.fhir.fhirService.performRestOp"
   }, {
     "source" : "procedure/com.vantiq.fhir.fhirService.delete",
     "target" : "services/com.vantiq.fhir.fhirService"
@@ -180,14 +171,11 @@
     "source" : "procedure/com.vantiq.fhir.fhirService.returnLink",
     "target" : "procedure/com.vantiq.fhir.fhirService.performRestOp"
   }, {
-    "source" : "procedure/com.vantiq.fhir.fhirService.performRestOp",
-    "target" : "procedure/com.vantiq.fhir.fhirService.setSource"
-  }, {
     "source" : "procedure/com.vantiq.fhir.fhirService.searchCompartment",
     "target" : "procedure/com.vantiq.fhir.fhirService.setSource"
   }, {
     "source" : "services/com.vantiq.fhir.fhirService",
-    "target" : "procedure/com.vantiq.fhir.fhirService.checkGeneralParams"
+    "target" : "procedure/com.vantiq.fhir.fhirService.checkModifiers"
   }, {
     "source" : "procedure/com.vantiq.fhir.fhirService.performRestOpQuery",
     "target" : "procedure/com.vantiq.fhir.fhirService.setSource"
@@ -201,11 +189,110 @@
     "source" : "procedure/com.vantiq.fhir.fhirService.performRestOpWithData",
     "target" : "procedure/com.vantiq.fhir.fhirService.setSource"
   }, {
-    "source" : "procedure/com.vantiq.fhir.fhirService.checkGeneralParams",
+    "source" : "procedure/com.vantiq.fhir.fhirService.checkModifiers",
     "target" : "services/com.vantiq.fhir.fhirService"
   }, {
     "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
     "target" : "procedure/com.vantiq.fhir.fhirService.setSource"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.vread",
+    "target" : "procedure/com.vantiq.fhir.fhirService.performRestOpQuery"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.vread",
+    "target" : "procedure/com.vantiq.fhir.fhirService.checkModifiers"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchType",
+    "target" : "procedure/com.vantiq.fhir.fhirService.checkModifiers"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchType",
+    "target" : "type/com.vantiq.fhir.Modifiers"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchType",
+    "target" : "type/com.vantiq.fhir.FHIRResponse"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.create",
+    "target" : "type/com.vantiq.fhir.Modifiers"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.create",
+    "target" : "type/com.vantiq.fhir.FHIRResponse"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.read",
+    "target" : "type/com.vantiq.fhir.Modifiers"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.read",
+    "target" : "type/com.vantiq.fhir.FHIRResponse"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.delete",
+    "target" : "type/com.vantiq.fhir.FHIRResponse"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.delete",
+    "target" : "type/com.vantiq.fhir.Modifiers"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.vread",
+    "target" : "type/com.vantiq.fhir.FHIRResponse"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.vread",
+    "target" : "type/com.vantiq.fhir.Modifiers"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
+    "target" : "type/com.vantiq.fhir.FHIRResponse"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
+    "target" : "type/com.vantiq.fhir.Modifiers"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchCompartment",
+    "target" : "type/com.vantiq.fhir.FHIRResponse"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchCompartment",
+    "target" : "type/com.vantiq.fhir.Modifiers"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.returnLink",
+    "target" : "type/com.vantiq.fhir.FHIRResponse"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.checkModifiers",
+    "target" : "type/com.vantiq.fhir.Modifiers"
+  }, {
+    "source" : "services/com.vantiq.fhir.fhirService",
+    "target" : "procedure/com.vantiq.fhir.fhirService.combineQueryAndParams"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.combineQueryAndParams",
+    "target" : "services/com.vantiq.fhir.fhirService"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.performRestOpQuery",
+    "target" : "procedure/com.vantiq.fhir.fhirService.combineQueryAndParams"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.performRestOpQuery",
+    "target" : "type/com.vantiq.fhir.FHIRResponse"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.performRestOpQuery",
+    "target" : "type/com.vantiq.fhir.Modifiers"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchType",
+    "target" : "procedure/com.vantiq.fhir.fhirService.combineQueryAndParams"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
+    "target" : "procedure/com.vantiq.fhir.fhirService.combineQueryAndParams"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.searchSystem",
+    "target" : "procedure/com.vantiq.fhir.fhirService.checkModifiers"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.performRestOp",
+    "target" : "type/com.vantiq.fhir.FHIRResponse"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.performRestOp",
+    "target" : "type/com.vantiq.fhir.Modifiers"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.performRestOp",
+    "target" : "procedure/com.vantiq.fhir.fhirService.createErrorMsg"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.performRestOp",
+    "target" : "procedure/com.vantiq.fhir.fhirService.setSource"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.delete",
+    "target" : "procedure/com.vantiq.fhir.fhirService.performRestOp"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.performGet",
+    "target" : "type/com.vantiq.fhir.FHIRResponse"
   } ],
   "name" : "com.vantiq.fhir.fhirConnection",
   "options" : {
@@ -219,7 +306,7 @@
     },
     "dockDimensions" : {
       "bottom" : 200,
-      "debug" : [ 681, 881 ],
+      "debug" : [ 924.5579385403329, 1126.442061459667 ],
       "left" : 210,
       "right" : 220,
       "top" : 0,
@@ -234,7 +321,7 @@
     "showGrid" : true,
     "structure" : {
       "fraction" : 1,
-      "type" : "R[4]"
+      "type" : "R[5]"
     },
     "type" : "dev",
     "v" : 6,
@@ -242,6 +329,18 @@
   },
   "partitions" : [ ],
   "resources" : [ {
+    "label" : "com.vantiq.fhir.FHIRResponse",
+    "name" : "com.vantiq.fhir.FHIRResponse",
+    "resourceReference" : "/types/com.vantiq.fhir.FHIRResponse",
+    "timestamp" : "2025-01-31T19:45:44.163Z",
+    "type" : 1
+  }, {
+    "label" : "com.vantiq.fhir.Modifiers",
+    "name" : "com.vantiq.fhir.Modifiers",
+    "resourceReference" : "/types/com.vantiq.fhir.Modifiers",
+    "timestamp" : "2025-01-31T19:42:16.220Z",
+    "type" : 1
+  }, {
     "label" : "com.vantiq.fhir.fhirServer",
     "name" : "com.vantiq.fhir.fhirServer",
     "resourceReference" : "/sources/com.vantiq.fhir.fhirServer",
@@ -251,7 +350,7 @@
     "label" : "com.vantiq.fhir.fhirService",
     "name" : "com.vantiq.fhir.fhirService",
     "resourceReference" : "/services/com.vantiq.fhir.fhirService",
-    "timestamp" : "2025-01-28T01:27:20.958Z",
+    "timestamp" : "2025-01-31T22:40:03.171Z",
     "type" : 63
   }, {
     "label" : "com.vantiq.fhir.fhirService.GlobalState",
@@ -260,13 +359,13 @@
     "timestamp" : "2025-01-28T00:47:43.579Z",
     "type" : 1
   }, {
-    "label" : "com.vantiq.fhir.fhirService.checkGeneralParams",
-    "name" : "com.vantiq.fhir.fhirService.checkGeneralParams",
+    "label" : "com.vantiq.fhir.fhirService.checkModifiers",
+    "name" : "com.vantiq.fhir.fhirService.checkModifiers",
     "packageName" : "com.vantiq.fhir",
-    "procedureName" : "checkGeneralParams",
-    "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.checkGeneralParams",
+    "procedureName" : "checkModifiers",
+    "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.checkModifiers",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-29T20:36:29.007Z",
+    "timestamp" : "2025-01-31T22:30:30.063Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.clearCapabilityStatement",
@@ -278,13 +377,22 @@
     "timestamp" : "2025-01-21T22:53:22.571Z",
     "type" : 3
   }, {
+    "label" : "com.vantiq.fhir.fhirService.combineQueryAndParams",
+    "name" : "com.vantiq.fhir.fhirService.combineQueryAndParams",
+    "packageName" : "com.vantiq.fhir",
+    "procedureName" : "combineQueryAndParams",
+    "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.combineQueryAndParams",
+    "serviceName" : "fhirService",
+    "timestamp" : "2025-01-31T21:25:21.531Z",
+    "type" : 3
+  }, {
     "label" : "com.vantiq.fhir.fhirService.create",
     "name" : "com.vantiq.fhir.fhirService.create",
     "packageName" : "com.vantiq.fhir",
     "procedureName" : "create",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.create",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-22T23:51:42.620Z",
+    "timestamp" : "2025-01-31T21:47:38.326Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.createErrorMsg",
@@ -293,7 +401,7 @@
     "procedureName" : "createErrorMsg",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.createErrorMsg",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-27T23:28:45.294Z",
+    "timestamp" : "2025-01-31T22:06:10.289Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.delete",
@@ -302,7 +410,7 @@
     "procedureName" : "delete",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.delete",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-23T00:11:17.353Z",
+    "timestamp" : "2025-01-31T22:17:30.526Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.fetchCapabilityStatement",
@@ -311,7 +419,7 @@
     "procedureName" : "fetchCapabilityStatement",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.fetchCapabilityStatement",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-28T22:54:01.259Z",
+    "timestamp" : "2025-01-31T22:39:58.790Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.getCapabilityStatement",
@@ -320,13 +428,13 @@
     "procedureName" : "getCapabilityStatement",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.getCapabilityStatement",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-24T01:59:43.340Z",
+    "timestamp" : "2025-01-31T00:16:08.658Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.js",
     "name" : "com.vantiq.fhir.fhirService.js",
     "resourceReference" : "/documents/com.vantiq.fhir.fhirService.js",
-    "timestamp" : "2025-01-28T01:27:21.713Z",
+    "timestamp" : "2025-01-31T20:00:23.405Z",
     "type" : 19
   }, {
     "label" : "com.vantiq.fhir.fhirService.performGet",
@@ -335,7 +443,7 @@
     "procedureName" : "performGet",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.performGet",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-22T22:13:03.449Z",
+    "timestamp" : "2025-01-31T22:35:03.015Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.performRestOp",
@@ -344,7 +452,7 @@
     "procedureName" : "performRestOp",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.performRestOp",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-28T22:54:05.653Z",
+    "timestamp" : "2025-01-31T22:19:05.174Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.performRestOpQuery",
@@ -353,7 +461,7 @@
     "procedureName" : "performRestOpQuery",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.performRestOpQuery",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-28T22:53:56.804Z",
+    "timestamp" : "2025-01-31T22:01:45.288Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.performRestOpWithData",
@@ -362,7 +470,7 @@
     "procedureName" : "performRestOpWithData",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.performRestOpWithData",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-28T22:54:03.462Z",
+    "timestamp" : "2025-01-31T21:46:59.349Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.read",
@@ -371,7 +479,7 @@
     "procedureName" : "read",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.read",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-27T23:36:11.276Z",
+    "timestamp" : "2025-01-31T20:08:16.798Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.returnLink",
@@ -380,7 +488,7 @@
     "procedureName" : "returnLink",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.returnLink",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-28T22:53:49.840Z",
+    "timestamp" : "2025-01-31T20:21:20.646Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.searchCompartment",
@@ -389,7 +497,7 @@
     "procedureName" : "searchCompartment",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.searchCompartment",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-28T22:53:54.485Z",
+    "timestamp" : "2025-01-31T22:07:28.903Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.searchSystem",
@@ -398,7 +506,7 @@
     "procedureName" : "searchSystem",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.searchSystem",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-28T22:53:52.240Z",
+    "timestamp" : "2025-01-31T21:38:34.152Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.searchType",
@@ -407,7 +515,7 @@
     "procedureName" : "searchType",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.searchType",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-28T22:53:59.066Z",
+    "timestamp" : "2025-01-31T21:38:36.494Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.setSource",
@@ -416,7 +524,7 @@
     "procedureName" : "setSource",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.setSource",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-28T01:05:45.087Z",
+    "timestamp" : "2025-01-31T00:16:26.357Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.update",
@@ -425,7 +533,7 @@
     "procedureName" : "update",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.update",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-22T22:38:16.061Z",
+    "timestamp" : "2025-01-31T21:48:31.465Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.vread",
@@ -434,7 +542,7 @@
     "procedureName" : "vread",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.vread",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-27T23:36:08.899Z",
+    "timestamp" : "2025-01-31T21:31:08.807Z",
     "type" : 3
   } ],
   "selectData" : { },
@@ -442,14 +550,6 @@
     "isPinned" : false,
     "name" : "Errors",
     "type" : 13
-  }, {
-    "isPinned" : false,
-    "name" : "Find Records",
-    "pane" : {
-      "address" : "R[1]"
-    },
-    "state" : 8,
-    "type" : 41
   }, {
     "dockLocation" : "top",
     "isPinned" : false,
@@ -465,9 +565,27 @@
     "type" : 2
   }, {
     "isPinned" : false,
-    "name" : "com.vantiq.fhir.fhirConnection",
+    "name" : "com.vantiq.fhir.FHIRResponse",
     "pane" : {
       "address" : "R[3]"
+    },
+    "resourceKey" : "type/com.vantiq.fhir.FHIRResponse",
+    "state" : 8,
+    "type" : 6
+  }, {
+    "isPinned" : false,
+    "name" : "com.vantiq.fhir.Modifiers",
+    "pane" : {
+      "address" : "R[2]"
+    },
+    "resourceKey" : "type/com.vantiq.fhir.Modifiers",
+    "state" : 8,
+    "type" : 6
+  }, {
+    "isPinned" : false,
+    "name" : "com.vantiq.fhir.fhirConnection",
+    "pane" : {
+      "address" : "R[4]"
     },
     "state" : 8,
     "type" : 120
@@ -484,7 +602,7 @@
     "isPinned" : false,
     "name" : "com.vantiq.fhir.fhirService",
     "pane" : {
-      "address" : "R[2]",
+      "address" : "R[1]",
       "isActive" : true,
       "isActiveTool" : true
     },
@@ -495,7 +613,7 @@
   "type" : "dev",
   "views" : [ {
     "name" : "Project Contents",
-    "projectToolKeys" : [ "errorviewer/Errors", "findrecords/Find Records", "tiledock/Inactive Panes", "logviewer/Log Messages", "list/Project Contents", "assemblies/com.vantiq.fhir.fhirConnection", "subsourceeditor/com.vantiq.fhir.fhirServer", "services/com.vantiq.fhir.fhirService" ]
+    "projectToolKeys" : [ "errorviewer/Errors", "tiledock/Inactive Panes", "logviewer/Log Messages", "list/Project Contents", "subtypeeditor/com.vantiq.fhir.FHIRResponse", "subtypeeditor/com.vantiq.fhir.Modifiers", "assemblies/com.vantiq.fhir.fhirConnection", "subsourceeditor/com.vantiq.fhir.fhirServer", "services/com.vantiq.fhir.fhirService" ]
   } ],
   "visibleResources" : [ {
     "description" : null,

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/services/com/vantiq/fhir/fhirService.json
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/services/com/vantiq/fhir/fhirService.json
@@ -285,11 +285,11 @@
       "multi" : false,
       "name" : "modifiers",
       "required" : false,
-      "type" : "Object"
+      "type" : "com.vantiq.fhir.Modifiers"
     } ],
     "returnType" : {
       "multi" : false,
-      "type" : "Object"
+      "type" : "com.vantiq.fhir.FHIRResponse"
     }
   }, {
     "description" : "Read a type based on its id and version (if specified)",

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/services/com/vantiq/fhir/fhirService.json
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/services/com/vantiq/fhir/fhirService.json
@@ -9,50 +9,75 @@
   "eventTypes" : { },
   "globalType" : "com.vantiq.fhir.fhirService.GlobalState",
   "interface" : [ {
+    "description" : "Create a new FHIR resource instance",
+    "isSubscriberAdminRestricted" : false,
     "name" : "create",
     "parameters" : [ {
-      "description" : null,
+      "default" : null,
+      "description" : "The type of resource to create.",
       "multi" : false,
       "name" : "type",
       "required" : true,
       "type" : "String"
     }, {
-      "description" : null,
+      "default" : null,
+      "description" : "The instance of the resource.",
       "multi" : false,
       "name" : "resource",
       "required" : true,
       "type" : "Object"
     }, {
-      "description" : null,
+      "default" : null,
+      "description" : "Version identifier for the resource instance to create.",
       "multi" : false,
       "name" : "versionId",
       "required" : false,
       "type" : "String"
+    }, {
+      "default" : null,
+      "description" : "Query modifiers and headers for the call.",
+      "multi" : false,
+      "name" : "modifiers",
+      "required" : false,
+      "type" : "com.vantiq.fhir.Modifiers"
     } ],
     "returnType" : {
       "multi" : false,
-      "type" : "Object"
+      "type" : "com.vantiq.fhir.FHIRResponse"
     }
   }, {
+    "description" : "Delete a resource instance",
+    "isSubscriberAdminRestricted" : false,
     "name" : "delete",
     "parameters" : [ {
-      "description" : null,
+      "default" : null,
+      "description" : "Type of the resource to delete.",
       "multi" : false,
       "name" : "type",
       "required" : true,
       "type" : "String"
     }, {
-      "description" : null,
+      "default" : null,
+      "description" : "Id of the instance to delete.",
       "multi" : false,
       "name" : "id",
       "required" : true,
       "type" : "String"
+    }, {
+      "default" : null,
+      "description" : "Query modifiers and headers for the call.",
+      "multi" : false,
+      "name" : "modifiers",
+      "required" : false,
+      "type" : "com.vantiq.fhir.Modifiers"
     } ],
     "returnType" : {
       "multi" : false,
-      "type" : "Object"
+      "type" : "com.vantiq.fhir.FHIRResponse"
     }
   }, {
+    "description" : "*\n* Returns the capability statement for the source used by this service.\n* If none present, it will fetch one from the source.",
+    "isSubscriberAdminRestricted" : false,
     "name" : "getCapabilityStatement",
     "parameters" : [ ],
     "returnType" : {
@@ -60,184 +85,248 @@
       "type" : "Object"
     }
   }, {
+    "description" : "Read a type based on its id",
+    "isSubscriberAdminRestricted" : false,
     "name" : "read",
     "parameters" : [ {
-      "description" : null,
+      "default" : null,
+      "description" : "Type of the resource to read.",
       "multi" : false,
       "name" : "type",
       "required" : true,
       "type" : "String"
     }, {
-      "description" : null,
+      "default" : null,
+      "description" : "Id of the resource to read",
       "multi" : false,
       "name" : "id",
       "required" : true,
       "type" : "String"
     }, {
-      "description" : null,
+      "default" : null,
+      "description" : "Query modifiers and headers for the call.",
       "multi" : false,
-      "name" : "generalParams",
+      "name" : "modifiers",
       "required" : false,
-      "type" : "Object"
+      "type" : "com.vantiq.fhir.Modifiers"
     } ],
     "returnType" : {
       "multi" : false,
-      "type" : "Object"
+      "type" : "com.vantiq.fhir.FHIRResponse"
     }
   }, {
+    "description" : "Return the content of the provided link",
+    "isSubscriberAdminRestricted" : false,
     "name" : "returnLink",
     "parameters" : [ {
-      "description" : null,
+      "default" : null,
+      "description" : "The URL of the link to return.",
       "multi" : false,
       "name" : "link",
       "required" : true,
       "type" : "String"
-    } ]
+    } ],
+    "returnType" : {
+      "multi" : false,
+      "type" : "com.vantiq.fhir.FHIRResponse"
+    }
   }, {
+    "description" : "Perform a search based on the compartment, id, & query provided",
+    "isSubscriberAdminRestricted" : false,
     "name" : "searchCompartment",
     "parameters" : [ {
-      "description" : null,
+      "default" : null,
+      "description" : "The FHIR Resource Compartment to search",
       "multi" : false,
       "name" : "compartment",
       "required" : true,
       "type" : "String"
     }, {
-      "description" : null,
+      "default" : null,
+      "description" : "The instance id desired",
       "multi" : false,
       "name" : "id",
       "required" : true,
       "type" : "String"
     }, {
-      "description" : null,
+      "default" : null,
+      "description" : "he FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object here (\"{}\").",
       "multi" : false,
       "name" : "query",
       "required" : true,
       "type" : "Object"
     }, {
-      "description" : null,
+      "default" : null,
+      "description" : "The FHIR resource type within the compartment to which to restrict the search.",
       "multi" : false,
       "name" : "type",
       "required" : false,
       "type" : "String"
     }, {
-      "description" : null,
+      "default" : null,
+      "description" : "Query modifiers and headers for the call.",
+      "multi" : false,
+      "name" : "modifiers",
+      "required" : false,
+      "type" : "com.vantiq.fhir.Modifiers"
+    }, {
+      "default" : null,
+      "description" : "HTTP Method to use, overriding search default: GET or POST",
       "multi" : false,
       "name" : "method",
       "required" : false,
       "type" : "String"
-    } ]
+    } ],
+    "returnType" : {
+      "multi" : false,
+      "type" : "com.vantiq.fhir.FHIRResponse"
+    }
   }, {
+    "description" : "*\n* Perform a search of the system\n*\n* Using the current source, run the search query for a particular type. If no method is provided,\n* we use GET. If search via POST is desired, provide \"POST\" as the method parameter.\n*\n* @param query Object ).\n* @param method String GET or POST.  Optional",
+    "isSubscriberAdminRestricted" : false,
     "name" : "searchSystem",
     "parameters" : [ {
-      "description" : null,
+      "default" : null,
+      "description" : "The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object (\"{}\")",
       "multi" : false,
       "name" : "query",
       "required" : true,
       "type" : "Object"
     }, {
-      "description" : null,
+      "default" : null,
+      "description" : "a set of name/value pairs representing the modifiers for this call. The general parameters include _summary & _elements.",
+      "multi" : false,
+      "name" : "modifiers",
+      "required" : false,
+      "type" : "com.vantiq.fhir.Modifiers"
+    }, {
+      "default" : null,
+      "description" : "HTTP Method to use, overriding search default: GET or POST",
       "multi" : false,
       "name" : "method",
       "required" : false,
       "type" : "String"
-    } ]
+    } ],
+    "returnType" : {
+      "multi" : false,
+      "type" : "com.vantiq.fhir.FHIRResponse"
+    }
   }, {
+    "description" : "Perform a search based on the type & query provided\n\n Using the current source, run the search query for a particular type. If no method is provided,\n use the assembly's default. Provide this parameter to override the assembly default.",
+    "isSubscriberAdminRestricted" : false,
     "name" : "searchType",
     "parameters" : [ {
-      "description" : null,
+      "default" : null,
+      "description" : "The FHIR Resource type to search",
       "multi" : false,
       "name" : "type",
       "required" : true,
       "type" : "String"
     }, {
-      "description" : null,
+      "default" : null,
+      "description" : "The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object here (\"{}\").",
       "multi" : false,
       "name" : "query",
       "required" : true,
       "type" : "Object"
     }, {
-      "description" : null,
+      "default" : null,
+      "description" : "a set of name/value pairs representing the modifiers for this call. The general parameters include _summary & _elements.",
       "multi" : false,
-      "name" : "generalParams",
+      "name" : "modifiers",
       "required" : false,
-      "type" : "Object"
+      "type" : "com.vantiq.fhir.Modifiers"
     }, {
-      "description" : null,
+      "default" : null,
+      "description" : "HTTP Method to use, overriding search default: GET or POST",
       "multi" : false,
       "name" : "method",
       "required" : false,
       "type" : "String"
-    } ]
-  }, {
-    "name" : "setSource",
-    "parameters" : [ {
-      "description" : null,
+    } ],
+    "returnType" : {
       "multi" : false,
-      "name" : "theSource",
-      "required" : false,
-      "type" : "String"
-    } ]
+      "type" : "com.vantiq.fhir.FHIRResponse"
+    }
   }, {
+    "isSubscriberAdminRestricted" : false,
     "name" : "update",
     "parameters" : [ {
+      "default" : null,
       "description" : null,
       "multi" : false,
       "name" : "type",
       "required" : true,
       "type" : "String"
     }, {
+      "default" : null,
       "description" : null,
       "multi" : false,
       "name" : "id",
       "required" : true,
       "type" : "String"
     }, {
+      "default" : null,
       "description" : null,
       "multi" : false,
       "name" : "resource",
       "required" : true,
       "type" : "Object"
     }, {
+      "default" : null,
       "description" : null,
       "multi" : false,
       "name" : "versionId",
       "required" : false,
       "type" : "String"
+    }, {
+      "default" : null,
+      "description" : null,
+      "multi" : false,
+      "name" : "modifiers",
+      "required" : false,
+      "type" : "Object"
     } ],
     "returnType" : {
       "multi" : false,
       "type" : "Object"
     }
   }, {
+    "description" : "Read a type based on its id and version (if specified)",
+    "isSubscriberAdminRestricted" : false,
     "name" : "vread",
     "parameters" : [ {
-      "description" : null,
+      "default" : null,
+      "description" : "Type of the resource to read.",
       "multi" : false,
       "name" : "type",
       "required" : true,
       "type" : "String"
     }, {
-      "description" : null,
+      "default" : null,
+      "description" : "Id of the instance to read",
       "multi" : false,
       "name" : "id",
       "required" : true,
       "type" : "String"
     }, {
-      "description" : null,
+      "default" : null,
+      "description" : "Version id of the instance to read",
       "multi" : false,
       "name" : "versionId",
       "required" : false,
       "type" : "String"
     }, {
-      "description" : null,
+      "default" : null,
+      "description" : "Query modifiers and headers for the call.",
       "multi" : false,
-      "name" : "generalParams",
+      "name" : "modifiers",
       "required" : false,
-      "type" : "Object"
+      "type" : "com.vantiq.fhir.Modifiers"
     } ],
     "returnType" : {
       "multi" : false,
-      "type" : "Object"
+      "type" : "com.vantiq.fhir.FHIRResponse"
     }
   } ],
   "internalEventHandlers" : [ ],

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/types/com/vantiq/fhir/FHIRResponse.json
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/types/com/vantiq/fhir/FHIRResponse.json
@@ -1,0 +1,35 @@
+{
+  "ars_properties" : {
+    "Description" : "The entity returned from calls to FHIR interactions"
+  },
+  "ars_relationships" : [ ],
+  "groupBy" : "",
+  "name" : "com.vantiq.fhir.FHIRResponse",
+  "properties" : {
+    "body" : {
+      "description" : "The message returned from the FHIR interaction",
+      "encrypted" : false,
+      "multi" : false,
+      "required" : false,
+      "type" : "Object",
+      "unique" : false
+    },
+    "headers" : {
+      "description" : "HTTP Headers returned in the response",
+      "encrypted" : false,
+      "multi" : false,
+      "required" : false,
+      "type" : "Object",
+      "unique" : false
+    },
+    "statusCode" : {
+      "description" : "The HTTP Status code returned",
+      "encrypted" : false,
+      "multi" : false,
+      "required" : false,
+      "type" : "Integer",
+      "unique" : false
+    }
+  },
+  "role" : "schema"
+}

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/types/com/vantiq/fhir/Modifiers.json
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/types/com/vantiq/fhir/Modifiers.json
@@ -1,0 +1,27 @@
+{
+  "ars_properties" : {
+    "Description" : "Describes the structure for passing general parameters/modifiers and headers to a FHIR interaction call"
+  },
+  "ars_relationships" : [ ],
+  "groupBy" : "",
+  "name" : "com.vantiq.fhir.Modifiers",
+  "properties" : {
+    "generalParams" : {
+      "description" : "Query modifiers such as _format or _elements",
+      "encrypted" : false,
+      "multi" : false,
+      "required" : false,
+      "type" : "Object",
+      "unique" : false
+    },
+    "headers" : {
+      "description" : "HTTP Headers to include in the call",
+      "encrypted" : false,
+      "multi" : false,
+      "required" : false,
+      "type" : "Object",
+      "unique" : false
+    }
+  },
+  "role" : "schema"
+}

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/types/com/vantiq/fhir/fhirService/GlobalState.json
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/types/com/vantiq/fhir/fhirService/GlobalState.json
@@ -2,6 +2,13 @@
   "ars_relationships" : [ ],
   "name" : "com.vantiq.fhir.fhirService.GlobalState",
   "properties" : {
+    "defaultSearchMethod" : {
+      "encrypted" : false,
+      "multi" : false,
+      "required" : false,
+      "type" : "String",
+      "unique" : false
+    },
     "fhirCapabilityStatement" : {
       "encrypted" : false,
       "multi" : false,

--- a/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssemblySearchGet.java
+++ b/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssemblySearchGet.java
@@ -1,0 +1,31 @@
+package io.vantiq.extsrc.fhirAssembly;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters;
+import java.util.Map;
+
+/**
+ * Test operations against a FHIR server using fhirConnection assembly
+ */
+@Slf4j
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class TestFhirAssemblySearchGet extends TestFhirAssembly {
+    
+    // Playing this little indirection since the methods are static (Junit Rules) but we want to override.  Copying a
+    // bunch of code just to test different situations is not attractive.  JUnit's @BeforeClass will ensure that only
+    // one instance of a named method is run, so that suffices for our needs.
+    
+    @BeforeClass
+    public static void setupEnv() {
+        performSetup(getAssemblyConfigForTest());
+    }
+    
+    public static Map<String,?> getAssemblyConfigForTest() {
+        Map<String, ?> config =  Map.of("fhirServerBaseUrl", FHIR_SERVER,
+                                        "defaultSearchHttpMethod", "GET");
+        log.debug("Returning assembly config of: {}", config);
+        return config;
+    }
+}

--- a/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssemblySearchPost.java
+++ b/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssemblySearchPost.java
@@ -1,0 +1,30 @@
+package io.vantiq.extsrc.fhirAssembly;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.runners.MethodSorters;
+import java.util.Map;
+
+/**
+ * Test operations against a FHIR server using fhirConnection assembly
+ */
+@Slf4j
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class TestFhirAssemblySearchPost extends TestFhirAssembly {
+    // Playing this little indirection since the methods are static (Junit Rules) but we want to override.  Copying a
+    // bunch of code just to test different situations is not attractive.  JUnit's @BeforeClass will ensure that only
+    // one instance of a named method is run, so that suffices for our needs.
+    
+    @BeforeClass
+    public static void setupEnv() {
+        performSetup(getAssemblyConfigForTest());
+    }
+    
+    public static Map<String,?> getAssemblyConfigForTest() {
+        Map<String, ?> config =  Map.of("fhirServerBaseUrl", FHIR_SERVER,
+                                        "defaultSearchHttpMethod", "POST");
+        log.debug("Returning assembly config of: {}", config);
+        return config;
+    }
+}

--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -12,11 +12,11 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('pyExecSrcVersion')) {
-        pyExecSrcVersion = '1.3.1'
+        pyExecSrcVersion = '1.3.2'
     }
     // If these change, update requirements-conn.in as well -- as that's used to generate the requirements.txt file
-    vantiqPythonSdkVersion = '1.4.1'
-    vantiqConnectorSdkVersion = '1.3.4'
+    vantiqPythonSdkVersion = '1.4.2'
+    vantiqConnectorSdkVersion = '1.3.5'
 }
 
 python {

--- a/pythonExecSource/requirements-build.in
+++ b/pythonExecSource/requirements-build.in
@@ -8,7 +8,7 @@ aioresponses>=0.7.6
 codetiming
 
 # Dependabot fix
-jinja2>=3.1.4
+jinja2>=3.1.5
 setuptools>=70.0.0
 zipp>=3.19.1
 

--- a/pythonExecSource/requirements-conn.in
+++ b/pythonExecSource/requirements-conn.in
@@ -1,4 +1,4 @@
 websockets>=12.0
-vantiqconnectorsdk>=1.3.4
-vantiqsdk>=1.4.1
+vantiqconnectorsdk>=1.3.5
+vantiqsdk>=1.4.2
 requests>=2.32.3

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -56,7 +56,7 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.1.0
     # via keyring
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -r requirements-build.in
     #   pytest-html
@@ -153,9 +153,9 @@ urllib3==2.2.3
     # via
     #   requests
     #   twine
-vantiqconnectorsdk==1.3.4
+vantiqconnectorsdk==1.3.5
     # via -r requirements-conn.in
-vantiqsdk==1.4.1
+vantiqsdk==1.4.2
     # via -r requirements-conn.in
 websockets==14.1
     # via


### PR DESCRIPTION
This is a merge into the FHIR staging branch

Fixes #544
Fixes #551 
Fixes #545

Added modifier and response types.  Update procedure interfaces to use these. Modifiers allow the passing in of different general parameters and headers which are used for modifying the results.  Projection is done this was (using the `_elements` general parameter) as is conditional create (via search parameters in a header).

added tests for same. 

Update descriptions in Vail procedures and parameters to use Vail capabilities instead of Javadoc style.

Added assembly config property to set the default http method for searches.  Runtime override is still possible

