### PR TITLE
PythonExecSource: Update jinja2 dependency/

### DIFF
--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -12,11 +12,11 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('pyExecSrcVersion')) {
-        pyExecSrcVersion = '1.3.1'
+        pyExecSrcVersion = '1.3.2'
     }
     // If these change, update requirements-conn.in as well -- as that's used to generate the requirements.txt file
-    vantiqPythonSdkVersion = '1.4.1'
-    vantiqConnectorSdkVersion = '1.3.4'
+    vantiqPythonSdkVersion = '1.4.2'
+    vantiqConnectorSdkVersion = '1.3.5'
 }
 
 python {

--- a/pythonExecSource/requirements-build.in
+++ b/pythonExecSource/requirements-build.in
@@ -8,7 +8,7 @@ aioresponses>=0.7.6
 codetiming
 
 # Dependabot fix
-jinja2>=3.1.4
+jinja2>=3.1.5
 setuptools>=70.0.0
 zipp>=3.19.1
 

--- a/pythonExecSource/requirements-conn.in
+++ b/pythonExecSource/requirements-conn.in
@@ -1,4 +1,4 @@
 websockets>=12.0
-vantiqconnectorsdk>=1.3.4
-vantiqsdk>=1.4.1
+vantiqconnectorsdk>=1.3.5
+vantiqsdk>=1.4.2
 requests>=2.32.3

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -56,7 +56,7 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.1.0
     # via keyring
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -r requirements-build.in
     #   pytest-html
@@ -153,9 +153,9 @@ urllib3==2.2.3
     # via
     #   requests
     #   twine
-vantiqconnectorsdk==1.3.4
+vantiqconnectorsdk==1.3.5
     # via -r requirements-conn.in
-vantiqsdk==1.4.1
+vantiqsdk==1.4.2
     # via -r requirements-conn.in
 websockets==14.1
     # via


### PR DESCRIPTION
Fixes #555 

Update jinja2 version as per dependabot.

Update other Vantiq dependencies (since they all did the same thing).