### PR TITLE
Add support for Basic & OAuth authentication

### DIFF
--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_bundleInteraction.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_bundleInteraction.vail
@@ -3,7 +3,7 @@
 package com.vantiq.fhir
 PROCEDURE fhirService.bundleInteraction(bundle Object REQUIRED DESCRIPTION "The bundle to be invoked.",
                                         modifiers com.vantiq.fhir.Modifiers DESCRIPTION "Query modifiers and headers for the call."): 
-                      com.vantiq.fhir.FHIRResponse WITH updateInterface=true
+                      com.vantiq.fhir.FHIRResponse
 
 var retVal = fhirService.performRestOpWithData("POST", "", bundle, modifiers)
 if (typeOf(retVal.body) == "List") {

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_checkAuthenticationSetup.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_checkAuthenticationSetup.vail
@@ -2,7 +2,7 @@ package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService
 
-private PROCEDURE fhirService.configureAuthentication(theSource String, authMechanism String REQUIRED)
+private PROCEDURE fhirService.checkAuthenticationSetup(theSource String, authMechanism String REQUIRED)
 
 var configChanged = false
 var oauthConfigChanged = false
@@ -10,10 +10,9 @@ var theConfig = SELECT ONE FROM sources WITH configure = true WHERE name == theS
 if (theConfig == null) {
     exception("com.vantiq.fhir.source.noconfig", "No configuration was found for source {0}.", [theSource])
 }
-//theConfig = theConfig.config
 
 var oauthConfig = SELECT ONE FROM sources WITH configure = true WHERE name == "com.vantiq.fhir.oauthSource"
-if (oauthConfig == null) {
+if (oauthConfig == null || oauthConfig.config == null) {
     exception("com.vantiq.fhir.source.noconfig", "No configuration was found for source {0}.", ["com.vantiq.fhir.oauthSource"])
 }
 
@@ -23,43 +22,44 @@ if (authMechanism == "Basic") {
             "A username and password are required for Basic authentication: {0}", [theConfig])
     }
     if (oauthConfig.active) {
-        oauthConfig.active = false
-        oauthConfigChanged = true
+        exception("com.vantiq.fhir.oauth.active",
+            "The Oauth Source ({0}) for this assembly cannot be ACTIVE when using authentication mechanism {1}.",
+            [oauthConfig.name, authMechanism])
     }
 } else if (authMechanism == "OAuth") {
-
     var missingParams = []
 
-    var requiredParams = ["oauthGrantType", "oauthClientId", "oauthClientSecret"]
     if (oauthConfig.config.oauthGrantType == null) {
-        missingParams.pusn("oauthGrantType")
+        missingParams.push("oauthGrantType")
     }
     if (oauthConfig.config.oauthClientId == null) {
-        missingParams.pusn("oauthClientId")
+        missingParams.push("oauthClientId")
     }
     if (oauthConfig.config.oauthClientSecret == null) {
-        missingParams.pusn("oauthClientSecret")
+        missingParams.push("oauthClientSecret")
     }
-    if (oauthConfig.oauthGrantType == "refresh_token" && oauthConfig.config.oauthRefreshToken == null) {
+    if (oauthConfig.config.oauthGrantType == "refresh_token" && oauthConfig.config.oauthRefreshToken == null) {
         missingParams.push("oauthRefreshToken with grant type of refresh_token")
     }
 
     if (missingParams.length() != 0) {
         exception("com.vantiq.fhir.oauth.config.missing.properties",
-                    "The following parameters are required to define an OAuth source for the FHIR system's use: {0}",
+                    "The following parameters are required to define an OAuth source for the FHIR system''s use: {0}",
                     [missingParams])
     }
-    oauthConfig.active = true
-    oauthConfigChanged = true
-    theConfig.config.oauthSource = "com.vantiq.fhir.oauthSource"
-    configChanged = true
+
+    if (!oauthConfig.active) {
+        exception("com.vantiq.fhir.oauth.active",
+            "The Oauth Source ({0}) for this assembly must be ACTIVE when using authentication mechanism {1}.",
+            [oauthConfig.name, authMechanism])
+    }
+
+    if (theConfig.config.oauthSourceName != oauthConfig.name) {
+        exception("com.vantiq.fhir.oauth.sourcename",
+            "The FHIR Source ({0}) for this assembly must have the oauthSource set to {1} when using authentication mechanism {2}.  Found {3}.",
+            [theConfig.name, oauthConfig.name, authMechanism, theConfig.config.oauthSourceName])
+
+    }
 }
 
-if (oauthConfigChanged) {
-    UPDATE system.sources (config: oauthConfig.config, active: oauthConfig.active)
-            WHERE name == "com.vantiq.fhir.oauthSource"
-}
-if (configChanged) {
-    UPDATE system.sources (config: theConfig.config) WHERE name == theSource
-}
 

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_configureAuthentication.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_configureAuthentication.vail
@@ -1,0 +1,65 @@
+package com.vantiq.fhir
+
+import service com.vantiq.fhir.fhirService
+
+private PROCEDURE fhirService.configureAuthentication(theSource String, authMechanism String REQUIRED)
+
+var configChanged = false
+var oauthConfigChanged = false
+var theConfig = SELECT ONE FROM sources WITH configure = true WHERE name == theSource
+if (theConfig == null) {
+    exception("com.vantiq.fhir.source.noconfig", "No configuration was found for source {0}.", [theSource])
+}
+//theConfig = theConfig.config
+
+var oauthConfig = SELECT ONE FROM sources WITH configure = true WHERE name == "com.vantiq.fhir.oauthSource"
+if (oauthConfig == null) {
+    exception("com.vantiq.fhir.source.noconfig", "No configuration was found for source {0}.", ["com.vantiq.fhir.oauthSource"])
+}
+
+if (authMechanism == "Basic") {
+    if (theConfig.config.username == null || theConfig.config.password == null) {
+        exception("com.vantiq.fhir.basicauth.required",
+            "A username and password are required for Basic authentication: {0}", [theConfig])
+    }
+    if (oauthConfig.active) {
+        oauthConfig.active = false
+        oauthConfigChanged = true
+    }
+} else if (authMechanism == "OAuth") {
+
+    var missingParams = []
+
+    var requiredParams = ["oauthGrantType", "oauthClientId", "oauthClientSecret"]
+    if (oauthConfig.config.oauthGrantType == null) {
+        missingParams.pusn("oauthGrantType")
+    }
+    if (oauthConfig.config.oauthClientId == null) {
+        missingParams.pusn("oauthClientId")
+    }
+    if (oauthConfig.config.oauthClientSecret == null) {
+        missingParams.pusn("oauthClientSecret")
+    }
+    if (oauthConfig.oauthGrantType == "refresh_token" && oauthConfig.config.oauthRefreshToken == null) {
+        missingParams.push("oauthRefreshToken with grant type of refresh_token")
+    }
+
+    if (missingParams.length() != 0) {
+        exception("com.vantiq.fhir.oauth.config.missing.properties",
+                    "The following parameters are required to define an OAuth source for the FHIR system's use: {0}",
+                    [missingParams])
+    }
+    oauthConfig.active = true
+    oauthConfigChanged = true
+    theConfig.config.oauthSource = "com.vantiq.fhir.oauthSource"
+    configChanged = true
+}
+
+if (oauthConfigChanged) {
+    UPDATE system.sources (config: oauthConfig.config, active: oauthConfig.active)
+            WHERE name == "com.vantiq.fhir.oauthSource"
+}
+if (configChanged) {
+    UPDATE system.sources (config: theConfig.config) WHERE name == theSource
+}
+

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_create.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_create.vail
@@ -4,7 +4,7 @@ package com.vantiq.fhir
 PROCEDURE fhirService.create(type String REQUIRED DESCRIPTION "The type of resource to create.",
                              resource Object REQUIRED DESCRIPTION "The instance of the resource.",
                              versionId String DESCRIPTION "Version identifier for the resource instance to create.",
-                             modifiers com.vantiq.fhir.Modifiers DESCRIPTION "Query modifiers and headers for the call."): com.vantiq.fhir.FHIRResponse WITH updateInterface=true
+                             modifiers com.vantiq.fhir.Modifiers DESCRIPTION "Query modifiers and headers for the call."): com.vantiq.fhir.FHIRResponse
 
 var path = type
 

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_delete.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_delete.vail
@@ -3,7 +3,7 @@
 package com.vantiq.fhir
 PROCEDURE fhirService.delete(type String REQUIRED DESCRIPTION "Type of the resource to delete.",
                              id String REQUIRED DESCRIPTION "Id of the instance to delete.",
-                             modifiers com.vantiq.fhir.Modifiers DESCRIPTION "Query modifiers and headers for the call."): com.vantiq.fhir.FHIRResponse WITH updateInterface=true
+                             modifiers com.vantiq.fhir.Modifiers DESCRIPTION "Query modifiers and headers for the call."): com.vantiq.fhir.FHIRResponse
 
 var path = type + "/" + id
 

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_getCapabilityStatement.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_getCapabilityStatement.vail
@@ -1,12 +1,11 @@
-/**
-* Returns the capability statement for the source used by this service.
-* If none present, it will fetch one from the source.
-*/
+// Returns the capability statement for the source used by this service.
+// If none present, it will fetch one from the source.
+
 package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService
 
-PROCEDURE fhirService.getCapabilityStatement(): Object WITH updateInterface=true
+PROCEDURE fhirService.getCapabilityStatement(): Object
 var retVal = fhirCapabilityStatement.getValue()
 if (!retVal) {
     log.debug("Fetching new FHIR capability statement")

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_history.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_history.vail
@@ -8,7 +8,7 @@ PROCEDURE fhirService.history(type String DESCRIPTION "The FHIR Resource type fo
                               id String DESCRIPTION "The id of the FHIR instance for which to fetch history. If not provided, fetch history for all of the type instances.",
                               modifiers com.vantiq.fhir.Modifiers
                                   DESCRIPTION "a set of name/value pairs representing the modifiers for this call. The general parameters include _count & _sort."): 
-                      com.vantiq.fhir.FHIRResponse WITH updateInterface=true
+                      com.vantiq.fhir.FHIRResponse
 var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
 

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_patch.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_patch.vail
@@ -5,7 +5,7 @@ PROCEDURE fhirService.patch(type String REQUIRED DESCRIPTION "The type of resour
                             id String REQUIRED DESCRIPTION "The id of the resource instance to be patched",
                             patchCommands Object Array REQUIRED DESCRIPTION "The patch specification (array of commands) as a Vantiq Object; will be sent as a JSON Patch document",
                             modifiers com.vantiq.fhir.Modifiers DESCRIPTION "Any general parameters or headers to use to modify this interaction"):
-                      com.vantiq.fhir.FHIRResponse WITH updateInterface=true
+                      com.vantiq.fhir.FHIRResponse
 
 var path = type + "/" + id
 

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_read.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_read.vail
@@ -6,6 +6,6 @@ import service com.vantiq.fhir.fhirService
 
 PROCEDURE fhirService.read(type String REQUIRED DESCRIPTION "Type of the resource to read.", 
                            id String REQUIRED DESCRIPTION "Id of the resource to read",
-                           modifiers com.vantiq.fhir.Modifiers DESCRIPTION "Query modifiers and headers for the call."): com.vantiq.fhir.FHIRResponse WITH updateInterface=true
+                           modifiers com.vantiq.fhir.Modifiers DESCRIPTION "Query modifiers and headers for the call."): com.vantiq.fhir.FHIRResponse
 
 return fhirService.vread(type, id, null, modifiers)

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_returnLink.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_returnLink.vail
@@ -12,6 +12,10 @@ if (!theSource) {
     theSource = fhirSource.getValue()
 }
 var sourceBase = fhirSourceBase.getValue()
+if (sourceBase == null) {
+    exception("com.vantiq.fhir.returnlink.nosourcebase",
+                "No source base value was found.", [])
+}
 var sourceBaseSansSlash = sourceBase.substr(0, sourceBase.length() - 1)
 log.debug("Current value of fhirSource to use: {}", [theSource])
 

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_returnLink.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_returnLink.vail
@@ -4,7 +4,7 @@ package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService
 
-PROCEDURE fhirService.returnLink(link String REQUIRED DESCRIPTION "The URL of the link to return."): com.vantiq.fhir.FHIRResponse WITH updateInterface=true
+PROCEDURE fhirService.returnLink(link String REQUIRED DESCRIPTION "The URL of the link to return."): com.vantiq.fhir.FHIRResponse
 
 var theSource = fhirSource.getValue()
 if (!theSource) {

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchCompartment.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchCompartment.vail
@@ -9,7 +9,7 @@ PROCEDURE fhirService.searchCompartment(compartment String REQUIRED DESCRIPTION 
                                         query Object REQUIRED DESCRIPTION "he FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object here (\"{}\").",
                                         type String DESCRIPTION "The FHIR resource type within the compartment to which to restrict the search.",
                                         modifiers com.vantiq.fhir.Modifiers DESCRIPTION "Query modifiers and headers for the call.",
-                                        method String DESCRIPTION "HTTP Method to use, overriding search default: GET or POST"): com.vantiq.fhir.FHIRResponse WITH updateInterface=true
+                                        method String DESCRIPTION "HTTP Method to use, overriding search default: GET or POST"): com.vantiq.fhir.FHIRResponse
 
 var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchSystem.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchSystem.vail
@@ -1,12 +1,8 @@
-/**
-* Perform a search of the system
-*
-* Using the current source, run the search query for a particular type. If no method is provided,
-* we use GET. If search via POST is desired, provide "POST" as the method parameter.
-*
-* @param query Object ).
-* @param method String GET or POST.  Optional
-*/
+// Perform a search of the system
+//
+// Using the current source, run the search query for a particular type. If no method is provided,
+// we use the default set for the assembly. If an alternative HTTP method for search is desired, provide
+// the method parameter.
 
 package com.vantiq.fhir
 
@@ -14,7 +10,7 @@ import service com.vantiq.fhir.fhirService
 
 PROCEDURE fhirService.searchSystem(query Object REQUIRED DESCRIPTION "The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object (\"{}\")",
                                    modifiers com.vantiq.fhir.Modifiers DESCRIPTION "a set of name/value pairs representing the modifiers for this call. The general parameters include _summary & _elements.",
-                                   method String DESCRIPTION "HTTP Method to use, overriding search default: GET or POST"): com.vantiq.fhir.FHIRResponse WITH updateInterface=true
+                                   method String DESCRIPTION "HTTP Method to use, overriding search default: GET or POST"): com.vantiq.fhir.FHIRResponse
 var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
 

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchType.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_searchType.vail
@@ -12,7 +12,7 @@ import type com.vantiq.fhir.Modifiers
 PROCEDURE fhirService.searchType(type String REQUIRED DESCRIPTION "The FHIR Resource type to search",
                                  query Object REQUIRED DESCRIPTION "The FHIR query.  Object where the keys are the resource property names, and values are the values desired. If there are no restrictions, provide an empty object here (\"{}\").",
                                  modifiers com.vantiq.fhir.Modifiers DESCRIPTION "a set of name/value pairs representing the modifiers for this call. The general parameters include _summary & _elements.",
-                                 method String DESCRIPTION "HTTP Method to use, overriding search default: GET or POST"): com.vantiq.fhir.FHIRResponse WITH updateInterface=true
+                                 method String DESCRIPTION "HTTP Method to use, overriding search default: GET or POST"): com.vantiq.fhir.FHIRResponse
 var theSource = fhirSource.getValue()
 log.debug("Current value of fhirSource to use: {}", [theSource])
 

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_setSource.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_setSource.vail
@@ -13,24 +13,25 @@ if (!theSource) {
 fhirService.clearCapabilityStatement()
 fhirSource.setValue(theSource)
 
+// Links in FHIR are full URLs.  Our REMOTE sources are more constrained, really wanting a path within the context of
+// the URL known to the REMOTE source.  To handle this impedance mismatch, we'll extract the path base URL part of
+// the source and save it here.  This will allow us to move that from any links passed in before sending them to
+// the remote source for operation.
+
+var theConf = SELECT ONE FROM system.sources WITH configure = true WHERE name == theSource
+if (theConf == null) {
+    exception("com.vantiq.fhir.source.noconfig", "No configuration was found for source {0}.", [theSource])
+}
+log.debug("Base URL for source {} is {} based on {}", [theSource, theConf.config.uri, theConf])
+fhirSourceBase.setValue(theConf.config.uri)
+
 log.debug("setSource(): looking for authenticationMechanism...", [])
 
 // Set up authentication, if any
 var authMechanism = ResourceConfig.get("authenticationMechanism")
 log.debug("setSource(): authenticationMechanism: {}", [authMechanism])
 if (authMechanism != null && authMechanism != "None") {
-    fhirService.configureAuthentication(theSource, authMechanism)
+    fhirService.checkAuthenticationSetup(theSource, authMechanism)
 }
 
-// Links in FHIR are full URLs.  Our REMOTE sources are more constrained, really wanting a path within the context of 
-// the URL known to the REMOTE source.  To handle this impedance mismatch, we'll extract the path base URL part of
-// the source and save it here.  This will allow us to move that from any links passed in before sending them to 
-// the remote source for operation.
-
-var theConf = SELECT ONE config FROM system.sources WITH configure = true WHERE name == theSource
-if (theConf == null) {
-    exception("com.vantiq.fhir.source.noconfig", "No configuration was found for source {0}.", [theSource])
-}
-log.debug("Base URL for source {} is {} based on {}", [theSource, theConf.config.uri, theConf])
-fhirSourceBase.setValue(theConf.config.uri)
 return theSource

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_setSource.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_setSource.vail
@@ -13,14 +13,23 @@ if (!theSource) {
 fhirService.clearCapabilityStatement()
 fhirSource.setValue(theSource)
 
+log.debug("setSource(): looking for authenticationMechanism...", [])
+
+// Set up authentication, if any
+var authMechanism = ResourceConfig.get("authenticationMechanism")
+log.debug("setSource(): authenticationMechanism: {}", [authMechanism])
+if (authMechanism != null && authMechanism != "None") {
+    fhirService.configureAuthentication(theSource, authMechanism)
+}
+
 // Links in FHIR are full URLs.  Our REMOTE sources are more constrained, really wanting a path within the context of 
 // the URL known to the REMOTE source.  To handle this impedance mismatch, we'll extract the path base URL part of
 // the source and save it here.  This will allow us to move that from any links passed in before sending them to 
 // the remote source for operation.
 
-var theConf = SELECT ONE config FROM system.sources where name == theSource
+var theConf = SELECT ONE config FROM system.sources WITH configure = true WHERE name == theSource
 if (theConf == null) {
-    exception("io.fred.oops", "no config", [])
+    exception("com.vantiq.fhir.source.noconfig", "No configuration was found for source {0}.", [theSource])
 }
 log.debug("Base URL for source {} is {} based on {}", [theSource, theConf.config.uri, theConf])
 fhirSourceBase.setValue(theConf.config.uri)

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_update.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_update.vail
@@ -3,7 +3,7 @@ PROCEDURE fhirService.update(type String REQUIRED,
                              id String REQUIRED,
                              resource Object REQUIRED,
                              versionId String,
-                             modifiers com.vantiq.fhir.Modifiers): com.vantiq.fhir.FHIRResponse WITH updateInterface=true
+                             modifiers com.vantiq.fhir.Modifiers): com.vantiq.fhir.FHIRResponse
 
 var path = type + "/" + id
 

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_vread.vail
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/procedures/com/vantiq/fhir/fhirService_vread.vail
@@ -1,6 +1,5 @@
 // Read a type based on its id and version (if specified)
 
-
 package com.vantiq.fhir
 
 import service com.vantiq.fhir.fhirService
@@ -8,7 +7,7 @@ import service com.vantiq.fhir.fhirService
 PROCEDURE fhirService.vread(type String REQUIRED DESCRIPTION "Type of the resource to read.", 
                             id String REQUIRED DESCRIPTION "Id of the instance to read",
                             versionId String DESCRIPTION "Version id of the instance to read",
-                            modifiers com.vantiq.fhir.Modifiers DESCRIPTION "Query modifiers and headers for the call."): com.vantiq.fhir.FHIRResponse WITH updateInterface=true
+                            modifiers com.vantiq.fhir.Modifiers DESCRIPTION "Query modifiers and headers for the call."): com.vantiq.fhir.FHIRResponse
 
 var path = type + "/" + id
 

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/projects/com.vantiq.fhir.fhirConnection.json
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/projects/com.vantiq.fhir.fhirConnection.json
@@ -10,19 +10,11 @@
       "property" : "config.password",
       "resource" : "sources",
       "resourceId" : "com.vantiq.fhir.fhirServer"
-      }, {
-        "property" : "basicPassword",
-        "resource" : "procedures",
-        "resourceId" : "com.vantiq.fhir.fhirService.configureAuthentication"
-      } ],
+    } ],
     "basicUsername" : [ {
       "property" : "config.username",
       "resource" : "sources",
       "resourceId" : "com.vantiq.fhir.fhirServer"
-    }, {
-      "property" : "basicUsername",
-      "resource" : "procedures",
-      "resourceId" : "com.vantiq.fhir.fhirService.configureAuthentication"
     } ],
     "defaultSearchHttpMethod" : [ {
       "property" : "defaultSearchHttpMethod",
@@ -42,6 +34,11 @@
       "resource" : "sources",
       "resourceId" : "com.vantiq.fhir.fhirServer"
     } ],
+    "oauthActive" : [ {
+      "property" : "active",
+      "resource" : "sources",
+      "resourceId" : "com.vantiq.fhir.oauthSource"
+    } ],
     "oauthAudience" : [ {
       "property" : "config.oauthAudience",
       "resource" : "sources",
@@ -51,37 +48,21 @@
       "property" : "config.oauthClientId",
       "resource" : "sources",
       "resourceId" : "com.vantiq.fhir.oauthSource"
-    }, {
-      "property" : "oauthClientId",
-      "resource" : "procedures",
-      "resourceId" : "com.vantiq.fhir.fhirService.configureAuthentication"
     } ],
     "oauthClientSecret" : [ {
       "property" : "config.oauthClientSecret",
       "resource" : "sources",
       "resourceId" : "com.vantiq.fhir.oauthSource"
-    }, {
-      "property" : "oauthClientSecret",
-      "resource" : "procedures",
-      "resourceId" : "com.vantiq.fhir.fhirService.configureAuthentication"
     } ],
     "oauthGrantType" : [ {
       "property" : "config.oauthGrantType",
       "resource" : "sources",
       "resourceId" : "com.vantiq.fhir.oauthSource"
-    }, {
-      "property" : "oauthGrantType",
-      "resource" : "procedures",
-      "resourceId" : "com.vantiq.fhir.fhirService.configureAuthentication"
     } ],
     "oauthRefreshToken" : [ {
       "property" : "config.oauthRefreshToken",
       "resource" : "sources",
       "resourceId" : "com.vantiq.fhir.oauthSource"
-    }, {
-      "property" : "oauthRefreshToken",
-      "resource" : "procedures",
-      "resourceId" : "com.vantiq.fhir.fhirService.configureAuthentication"
     } ],
     "oauthScope" : [ {
       "property" : "config.oauthScope",
@@ -92,6 +73,11 @@
       "property" : "config.uri",
       "resource" : "sources",
       "resourceId" : "com.vantiq.fhir.oauthSource"
+    } ],
+    "oauthSourceName" : [ {
+      "property" : "config.oauthSourceName",
+      "resource" : "sources",
+      "resourceId" : "com.vantiq.fhir.fhirServer"
     } ],
     "oauthUseBasicAuth" : [ {
       "property" : "config.oauthUseBasicAuth",
@@ -136,6 +122,13 @@
       "multi" : false,
       "required" : true,
       "type" : "String"
+    },
+    "oauthActive" : {
+      "default" : false,
+      "description" : "Whether the oauth source should be active.  True if using authenticationMechanism of OAuth, false otherwise",
+      "multi" : false,
+      "required" : false,
+      "type" : "Boolean"
     },
     "oauthAudience" : {
       "default" : "",
@@ -186,6 +179,14 @@
       "multi" : false,
       "required" : false,
       "type" : "String"
+    },
+    "oauthSourceName" : {
+      "default" : null,
+      "description" : "Name of the source to use for OAuth authentication.  Should be <empty> unless using the OAuth authenticationMechanism",
+      "enumValues" : [ "com.vantiq.fhir.oauthSource" ],
+      "multi" : false,
+      "required" : false,
+      "type" : "Enum"
     },
     "oauthUseBasicAuth" : {
       "default" : false,
@@ -534,13 +535,13 @@
     "target" : "procedure/com.vantiq.fhir.fhirService.performRestOpWithData"
   }, {
     "source" : "services/com.vantiq.fhir.fhirService",
-    "target" : "procedure/com.vantiq.fhir.fhirService.configureAuthentication"
+    "target" : "procedure/com.vantiq.fhir.fhirService.checkAuthenticationSetup"
   }, {
-    "source" : "procedure/com.vantiq.fhir.fhirService.configureAuthentication",
+    "source" : "procedure/com.vantiq.fhir.fhirService.checkAuthenticationSetup",
     "target" : "services/com.vantiq.fhir.fhirService"
   }, {
     "source" : "procedure/com.vantiq.fhir.fhirService.setSource",
-    "target" : "procedure/com.vantiq.fhir.fhirService.configureAuthentication"
+    "target" : "procedure/com.vantiq.fhir.fhirService.checkAuthenticationSetup"
   } ],
   "name" : "com.vantiq.fhir.fhirConnection",
   "options" : {
@@ -592,13 +593,13 @@
     "label" : "com.vantiq.fhir.fhirServer",
     "name" : "com.vantiq.fhir.fhirServer",
     "resourceReference" : "/sources/com.vantiq.fhir.fhirServer",
-    "timestamp" : "2025-02-05T22:56:12.170Z",
+    "timestamp" : "2025-02-13T21:45:27.840Z",
     "type" : 4
   }, {
     "label" : "com.vantiq.fhir.fhirService",
     "name" : "com.vantiq.fhir.fhirService",
     "resourceReference" : "/services/com.vantiq.fhir.fhirService",
-    "timestamp" : "2025-02-12T20:49:00.780Z",
+    "timestamp" : "2025-02-13T21:55:03.479Z",
     "type" : 63
   }, {
     "label" : "com.vantiq.fhir.fhirService.GlobalState",
@@ -614,6 +615,15 @@
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.bundleInteraction",
     "serviceName" : "fhirService",
     "timestamp" : "2025-02-05T22:48:29.616Z",
+    "type" : 3
+  }, {
+    "label" : "com.vantiq.fhir.fhirService.checkAuthenticationSetup",
+    "name" : "com.vantiq.fhir.fhirService.checkAuthenticationSetup",
+    "packageName" : "com.vantiq.fhir",
+    "procedureName" : "checkAuthenticationSetup",
+    "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.checkAuthenticationSetup",
+    "serviceName" : "fhirService",
+    "timestamp" : "2025-02-13T21:54:59.161Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.checkModifiers",
@@ -641,15 +651,6 @@
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.combineQueryAndParams",
     "serviceName" : "fhirService",
     "timestamp" : "2025-02-03T19:31:43.495Z",
-    "type" : 3
-  }, {
-    "label" : "com.vantiq.fhir.fhirService.configureAuthentication",
-    "name" : "com.vantiq.fhir.fhirService.configureAuthentication",
-    "packageName" : "com.vantiq.fhir",
-    "procedureName" : "configureAuthentication",
-    "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.configureAuthentication",
-    "serviceName" : "fhirService",
-    "timestamp" : "2025-02-12T20:16:50.914Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.create",
@@ -709,7 +710,7 @@
     "label" : "com.vantiq.fhir.fhirService.js",
     "name" : "com.vantiq.fhir.fhirService.js",
     "resourceReference" : "/documents/com.vantiq.fhir.fhirService.js",
-    "timestamp" : "2025-02-12T20:27:14.704Z",
+    "timestamp" : "2025-02-13T21:45:31.168Z",
     "type" : 19
   }, {
     "label" : "com.vantiq.fhir.fhirService.patch",
@@ -718,7 +719,7 @@
     "procedureName" : "patch",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.patch",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-02-05T21:39:14.774Z",
+    "timestamp" : "2025-02-13T21:45:28.906Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.performGet",
@@ -736,7 +737,7 @@
     "procedureName" : "performRestOp",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.performRestOp",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-02-05T22:52:03.228Z",
+    "timestamp" : "2025-02-13T21:45:29.419Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.performRestOpQuery",
@@ -754,7 +755,7 @@
     "procedureName" : "performRestOpWithData",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.performRestOpWithData",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-02-05T22:52:46.274Z",
+    "timestamp" : "2025-02-13T21:45:29.044Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.read",
@@ -772,7 +773,7 @@
     "procedureName" : "returnLink",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.returnLink",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-31T20:21:20.646Z",
+    "timestamp" : "2025-02-13T21:45:29.297Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.searchCompartment",
@@ -808,7 +809,7 @@
     "procedureName" : "setSource",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.setSource",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-02-12T20:48:56.577Z",
+    "timestamp" : "2025-02-13T21:52:38.725Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.update",
@@ -875,7 +876,9 @@
     "isPinned" : false,
     "name" : "com.vantiq.fhir.fhirConnection",
     "pane" : {
-      "address" : "R[4]"
+      "address" : "R[4]",
+      "isActive" : true,
+      "isActiveTool" : true
     },
     "state" : 8,
     "type" : 120
@@ -892,9 +895,7 @@
     "isPinned" : false,
     "name" : "com.vantiq.fhir.fhirService",
     "pane" : {
-      "address" : "R[1]",
-      "isActive" : true,
-      "isActiveTool" : true
+      "address" : "R[1]"
     },
     "resourceKey" : "services/com.vantiq.fhir.fhirService",
     "state" : 8,

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/projects/com.vantiq.fhir.fhirConnection.json
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/projects/com.vantiq.fhir.fhirConnection.json
@@ -1,6 +1,29 @@
 {
   "ars_relationships" : [ ],
   "configurationMappings" : {
+    "authenticationMechanism" : [ {
+      "property" : "authenticationMechanism",
+      "resource" : "procedures",
+      "resourceId" : "com.vantiq.fhir.fhirService.setSource"
+    } ],
+    "basicPassword" : [ {
+      "property" : "config.password",
+      "resource" : "sources",
+      "resourceId" : "com.vantiq.fhir.fhirServer"
+      }, {
+        "property" : "basicPassword",
+        "resource" : "procedures",
+        "resourceId" : "com.vantiq.fhir.fhirService.configureAuthentication"
+      } ],
+    "basicUsername" : [ {
+      "property" : "config.username",
+      "resource" : "sources",
+      "resourceId" : "com.vantiq.fhir.fhirServer"
+    }, {
+      "property" : "basicUsername",
+      "resource" : "procedures",
+      "resourceId" : "com.vantiq.fhir.fhirService.configureAuthentication"
+    } ],
     "defaultSearchHttpMethod" : [ {
       "property" : "defaultSearchHttpMethod",
       "resource" : "procedures",
@@ -18,9 +41,87 @@
       "property" : "config.uri",
       "resource" : "sources",
       "resourceId" : "com.vantiq.fhir.fhirServer"
+    } ],
+    "oauthAudience" : [ {
+      "property" : "config.oauthAudience",
+      "resource" : "sources",
+      "resourceId" : "com.vantiq.fhir.oauthSource"
+    } ],
+    "oauthClientId" : [ {
+      "property" : "config.oauthClientId",
+      "resource" : "sources",
+      "resourceId" : "com.vantiq.fhir.oauthSource"
+    }, {
+      "property" : "oauthClientId",
+      "resource" : "procedures",
+      "resourceId" : "com.vantiq.fhir.fhirService.configureAuthentication"
+    } ],
+    "oauthClientSecret" : [ {
+      "property" : "config.oauthClientSecret",
+      "resource" : "sources",
+      "resourceId" : "com.vantiq.fhir.oauthSource"
+    }, {
+      "property" : "oauthClientSecret",
+      "resource" : "procedures",
+      "resourceId" : "com.vantiq.fhir.fhirService.configureAuthentication"
+    } ],
+    "oauthGrantType" : [ {
+      "property" : "config.oauthGrantType",
+      "resource" : "sources",
+      "resourceId" : "com.vantiq.fhir.oauthSource"
+    }, {
+      "property" : "oauthGrantType",
+      "resource" : "procedures",
+      "resourceId" : "com.vantiq.fhir.fhirService.configureAuthentication"
+    } ],
+    "oauthRefreshToken" : [ {
+      "property" : "config.oauthRefreshToken",
+      "resource" : "sources",
+      "resourceId" : "com.vantiq.fhir.oauthSource"
+    }, {
+      "property" : "oauthRefreshToken",
+      "resource" : "procedures",
+      "resourceId" : "com.vantiq.fhir.fhirService.configureAuthentication"
+    } ],
+    "oauthScope" : [ {
+      "property" : "config.oauthScope",
+      "resource" : "sources",
+      "resourceId" : "com.vantiq.fhir.oauthSource"
+    } ],
+    "oauthServerUrl" : [ {
+      "property" : "config.uri",
+      "resource" : "sources",
+      "resourceId" : "com.vantiq.fhir.oauthSource"
+    } ],
+    "oauthUseBasicAuth" : [ {
+      "property" : "config.oauthUseBasicAuth",
+      "resource" : "sources",
+      "resourceId" : "com.vantiq.fhir.oauthSource"
     } ]
   },
   "configurationProperties" : {
+    "authenticationMechanism" : {
+      "default" : "None",
+      "description" : "Type or mechanism of authentication used by this FHIR server.",
+      "enumValues" : [ "OAuth", "Basic", "None" ],
+      "multi" : false,
+      "required" : false,
+      "type" : "Enum"
+    },
+    "basicPassword" : {
+      "default" : "",
+      "description" : "Password to use for Basic authentication.  Vantiq encourages you to specify using @secrets() notation.",
+      "multi" : false,
+      "required" : false,
+      "type" : "String"
+    },
+    "basicUsername" : {
+      "default" : "",
+      "description" : "Username to use for basic authentication",
+      "multi" : false,
+      "required" : false,
+      "type" : "String"
+    },
     "defaultSearchHttpMethod" : {
       "default" : "GET",
       "description" : "HTTP Method to use for search.  The FHIR specification provides for using either GET or POST for search, saying that some servers may have a preference for some cases.  This parameter sets the default.  If not set, the default is GET.",
@@ -35,6 +136,63 @@
       "multi" : false,
       "required" : true,
       "type" : "String"
+    },
+    "oauthAudience" : {
+      "default" : "",
+      "description" : "The audience specification for the OAuth call.",
+      "multi" : false,
+      "required" : false,
+      "type" : "String"
+    },
+    "oauthClientId" : {
+      "default" : "",
+      "description" : "Client ID to use with OAuth authentication",
+      "multi" : false,
+      "required" : false,
+      "type" : "String"
+    },
+    "oauthClientSecret" : {
+      "default" : "",
+      "description" : "Client Secret for use with OAuth Authentication",
+      "multi" : false,
+      "required" : false,
+      "type" : "String"
+    },
+    "oauthGrantType" : {
+      "default" : null,
+      "description" : "Grant type to be used for OAuth Authentication",
+      "enumValues" : [ "refresh_token", "client_credentials" ],
+      "multi" : false,
+      "required" : false,
+      "type" : "Enum"
+    },
+    "oauthRefreshToken" : {
+      "default" : "",
+      "description" : "Refresh Token supplied to the user when using OAuth refresh_token authentication mechanism",
+      "multi" : false,
+      "required" : false,
+      "type" : "String"
+    },
+    "oauthScope" : {
+      "default" : "",
+      "description" : "Scope used by OAuth authentication",
+      "multi" : false,
+      "required" : false,
+      "type" : "String"
+    },
+    "oauthServerUrl" : {
+      "default" : "",
+      "description" : "URL OAuth server associated with this FHIR server.  This is used for authentication for some authentication configurations.",
+      "multi" : false,
+      "required" : false,
+      "type" : "String"
+    },
+    "oauthUseBasicAuth" : {
+      "default" : false,
+      "description" : "This tells Vantiq to package the client_id & client_secret into a BasicAuth credential, and use that to access the authorization server.",
+      "multi" : false,
+      "required" : false,
+      "type" : "Boolean"
     }
   },
   "isAssembly" : true,
@@ -374,6 +532,15 @@
   }, {
     "source" : "procedure/com.vantiq.fhir.fhirService.bundleInteraction",
     "target" : "procedure/com.vantiq.fhir.fhirService.performRestOpWithData"
+  }, {
+    "source" : "services/com.vantiq.fhir.fhirService",
+    "target" : "procedure/com.vantiq.fhir.fhirService.configureAuthentication"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.configureAuthentication",
+    "target" : "services/com.vantiq.fhir.fhirService"
+  }, {
+    "source" : "procedure/com.vantiq.fhir.fhirService.setSource",
+    "target" : "procedure/com.vantiq.fhir.fhirService.configureAuthentication"
   } ],
   "name" : "com.vantiq.fhir.fhirConnection",
   "options" : {
@@ -431,7 +598,7 @@
     "label" : "com.vantiq.fhir.fhirService",
     "name" : "com.vantiq.fhir.fhirService",
     "resourceReference" : "/services/com.vantiq.fhir.fhirService",
-    "timestamp" : "2025-02-05T22:52:50.466Z",
+    "timestamp" : "2025-02-12T20:49:00.780Z",
     "type" : 63
   }, {
     "label" : "com.vantiq.fhir.fhirService.GlobalState",
@@ -474,6 +641,15 @@
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.combineQueryAndParams",
     "serviceName" : "fhirService",
     "timestamp" : "2025-02-03T19:31:43.495Z",
+    "type" : 3
+  }, {
+    "label" : "com.vantiq.fhir.fhirService.configureAuthentication",
+    "name" : "com.vantiq.fhir.fhirService.configureAuthentication",
+    "packageName" : "com.vantiq.fhir",
+    "procedureName" : "configureAuthentication",
+    "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.configureAuthentication",
+    "serviceName" : "fhirService",
+    "timestamp" : "2025-02-12T20:16:50.914Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.create",
@@ -533,7 +709,7 @@
     "label" : "com.vantiq.fhir.fhirService.js",
     "name" : "com.vantiq.fhir.fhirService.js",
     "resourceReference" : "/documents/com.vantiq.fhir.fhirService.js",
-    "timestamp" : "2025-02-05T21:57:54.355Z",
+    "timestamp" : "2025-02-12T20:27:14.704Z",
     "type" : 19
   }, {
     "label" : "com.vantiq.fhir.fhirService.patch",
@@ -632,7 +808,7 @@
     "procedureName" : "setSource",
     "resourceReference" : "/procedures/com.vantiq.fhir.fhirService.setSource",
     "serviceName" : "fhirService",
-    "timestamp" : "2025-01-31T00:16:26.357Z",
+    "timestamp" : "2025-02-12T20:48:56.577Z",
     "type" : 3
   }, {
     "label" : "com.vantiq.fhir.fhirService.update",
@@ -652,6 +828,12 @@
     "serviceName" : "fhirService",
     "timestamp" : "2025-02-03T19:31:42.222Z",
     "type" : 3
+  }, {
+    "label" : "com.vantiq.fhir.oauthSource",
+    "name" : "com.vantiq.fhir.oauthSource",
+    "resourceReference" : "/sources/com.vantiq.fhir.oauthSource",
+    "timestamp" : "2025-02-12T19:47:56.529Z",
+    "type" : 4
   } ],
   "selectData" : { },
   "tools" : [ {

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/services/com/vantiq/fhir/fhirService.json
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/services/com/vantiq/fhir/fhirService.json
@@ -160,7 +160,7 @@
       "default" : null,
       "description" : "The patch specification (array of commands) as a Vantiq Object; will be sent as a JSON Patch document",
       "multi" : true,
-      "name" : "patchSpec",
+      "name" : "patchCommands",
       "required" : true,
       "type" : "Object"
     }, {

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/services/com/vantiq/fhir/fhirService.json
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/services/com/vantiq/fhir/fhirService.json
@@ -10,6 +10,29 @@
   "eventTypes" : { },
   "globalType" : "com.vantiq.fhir.fhirService.GlobalState",
   "interface" : [ {
+    "description" : "Process a Bundle interaction (typically bundle type 'batch' or 'transaction' but others may be supported by the server)",
+    "isSubscriberAdminRestricted" : false,
+    "name" : "bundleInteraction",
+    "parameters" : [ {
+      "default" : null,
+      "description" : "The bundle to be invoked.",
+      "multi" : false,
+      "name" : "bundle",
+      "required" : true,
+      "type" : "Object"
+    }, {
+      "default" : null,
+      "description" : "Query modifiers and headers for the call.",
+      "multi" : false,
+      "name" : "modifiers",
+      "required" : false,
+      "type" : "com.vantiq.fhir.Modifiers"
+    } ],
+    "returnType" : {
+      "multi" : false,
+      "type" : "com.vantiq.fhir.FHIRResponse"
+    }
+  }, {
     "description" : "Create a new FHIR resource instance",
     "isSubscriberAdminRestricted" : false,
     "name" : "create",
@@ -384,29 +407,6 @@
       "name" : "versionId",
       "required" : false,
       "type" : "String"
-    }, {
-      "default" : null,
-      "description" : "Query modifiers and headers for the call.",
-      "multi" : false,
-      "name" : "modifiers",
-      "required" : false,
-      "type" : "com.vantiq.fhir.Modifiers"
-    } ],
-    "returnType" : {
-      "multi" : false,
-      "type" : "com.vantiq.fhir.FHIRResponse"
-    }
-  }, {
-    "description" : "Process a Bundle interaction (typically bundle type 'batch' or 'transaction' but others may be supported by the server)",
-    "isSubscriberAdminRestricted" : false,
-    "name" : "bundleInteraction",
-    "parameters" : [ {
-      "default" : null,
-      "description" : "The bundle to be invoked.",
-      "multi" : false,
-      "name" : "bundle",
-      "required" : true,
-      "type" : "Object"
     }, {
       "default" : null,
       "description" : "Query modifiers and headers for the call.",

--- a/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/sources/com/vantiq/fhir/oauthSource.json
+++ b/fhirAssembly/src/main/resources/assembly/com.vantiq.fhir.fhirConnection/sources/com/vantiq/fhir/oauthSource.json
@@ -1,6 +1,6 @@
 {
   "activationConstraint" : "",
-  "active" : true,
+  "active" : false,
   "ars_properties" : null,
   "ars_relationships" : [ ],
   "autoUnwind" : false,
@@ -11,14 +11,12 @@
     "passwordType" : "string",
     "pollingInterval" : 0,
     "query" : { },
-    "requestDefaults" : {
-      "contentType" : "application/fhir+json"
-    },
-    "uri" : "http://not.really.there"
+    "requestDefaults" : { },
+    "uri" : "https://invalid.to.be.replaced"
   },
   "isUnavailable" : false,
   "messageType" : null,
   "mockProcedures" : { },
-  "name" : "com.vantiq.fhir.fhirServer",
+  "name" : "com.vantiq.fhir.oauthSource",
   "type" : "REMOTE"
 }

--- a/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssembly.java
+++ b/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssembly.java
@@ -209,6 +209,7 @@ public class TestFhirAssembly {
                                             Collections.emptyList());
             assertTrue("Could not fetch capabilities: " + resp.getErrors(), resp.isSuccess());
             Map<String, ?> newCapStmt = ((JsonObject) resp.getBody()).asMap();
+            log.debug("New capability return: {}", newCapStmt);
             assertEquals("Not a capability statement",
                          "CapabilityStatement",
                          ((JsonElement) newCapStmt.get("resourceType")).getAsString());

--- a/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssembly.java
+++ b/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssembly.java
@@ -189,6 +189,16 @@ public class TestFhirAssembly {
                    invocationCount >= 2);
     }
     
+    // used in some subclasses.
+    public static void registerGetConfiguredSource(Vantiq v) {
+        String procedure =
+                "PROCEDURE getConfiguredSource(sourceName)\n" +
+                        "return SELECT ONE FROM sources WITH configure = true where name == sourceName";
+        
+        VantiqResponse vr = v.insert("system.procedures", procedure);
+        assert vr.isSuccess();
+    }
+    
     @Test
     public void test000CapabilityFetch() {
         Vantiq v = new Vantiq(TEST_SERVER, 1);

--- a/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssemblyBasicAuth.java
+++ b/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssemblyBasicAuth.java
@@ -42,6 +42,7 @@ public class TestFhirAssemblyBasicAuth extends TestFhirAssembly {
                 "basicUsername", TEST_USERNAME,
                 "basicPassword", TEST_PASSWORD,
                 "fhirServerBaseUrl", FHIR_SERVER,
+                "oauthActive", false,
                 "defaultSearchHttpMethod", "GET",
                 "authenticationMechanism", "Basic");
         log.debug("Returning assembly config of: {}", config);

--- a/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssemblyBasicAuth.java
+++ b/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssemblyBasicAuth.java
@@ -3,6 +3,7 @@ package io.vantiq.extsrc.fhirAssembly;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import io.vantiq.client.Vantiq;
 import io.vantiq.client.VantiqResponse;
@@ -25,7 +26,7 @@ public class TestFhirAssemblyBasicAuth extends TestFhirAssembly {
     public static String FHIR_SOURCE = "com.vantiq.fhir.fhirServer";
     public static String FHIR_OAUTH_SOURCE = "com.vantiq.fhir.oauthSource";
     public static String TEST_USERNAME = "fred";
-    public static String TEST_PASSWORD = "somepasswordthatdoesntmatter"
+    public static String TEST_PASSWORD = "somePasswordThatDoesn'tMatter";
     
     // Playing this little indirection since the methods are static (Junit Rules) but we want to override.  Copying a
     // bunch of code just to test different situations is not attractive.  JUnit's @BeforeClass will ensure that only
@@ -37,27 +38,51 @@ public class TestFhirAssemblyBasicAuth extends TestFhirAssembly {
     }
     
     public static Map<String,?> getAssemblyConfigForTest() {
-        Map<String, ?> config =  Map.of("fhirServerBaseUrl", FHIR_SERVER,
-                                        "defaultSearchHttpMethod", "GET",
-                                        "authenticationMechanism", "Basic",
-                                        "basicUsername", TEST_USERNAME,
-                                        "basicPassword", TEST_PASSWORD);
+        Map<String, ?> config =  Map.of(
+                "basicUsername", TEST_USERNAME,
+                "basicPassword", TEST_PASSWORD,
+                "fhirServerBaseUrl", FHIR_SERVER,
+                "defaultSearchHttpMethod", "GET",
+                "authenticationMechanism", "Basic");
         log.debug("Returning assembly config of: {}", config);
         return config;
     }
     
     @Test
-    public void test900ValidateSource() {
+    public void test000ValidateSourceBasic() throws Exception {
+        
         // Verify that the source's in the assembly are correctly set up...
         
         Vantiq v = new Vantiq(TEST_SERVER, 1);
         v.authenticate(SUB_USER, SUB_USER);
-        VantiqResponse resp = v.selectOne("system.sources", FHIR_SOURCE);
+        
+        registerGetConfiguredSource(v);
+        
+        VantiqResponse resp = v.execute("getConfiguredSource",
+                                       Map.of("sourceName", FHIR_SOURCE));
         assertTrue("Could not fetch fetch source: " + FHIR_SOURCE + "::" + resp.getErrors(), resp.isSuccess());
-        Map<String, ?> fhirSource = ((JsonObject) resp.getBody()).asMap();
+        assertTrue("Source not in form we expect: " + resp.getBody().getClass().getName(),
+                   resp.getBody() instanceof JsonObject);
+        //noinspection unchecked
+        Map<String, ?> fhirSource = mapper.readValue(new Gson().toJson(((JsonObject) resp.getBody())),
+                                                                                       Map.class);
+        log.debug("{} Definition: {}", FHIR_SOURCE, fhirSource);
         //noinspection unchecked
         Map<String, ?> config = (Map<String, ?>) fhirSource.get("config");
         assertEquals(FHIR_SOURCE + ": wrong username", TEST_USERNAME, config.get("username"));
         assertEquals(FHIR_SOURCE + ": wrong password", TEST_PASSWORD, config.get("password"));
+        
+        resp = v.execute("getConfiguredSource",
+                         Map.of("sourceName", FHIR_OAUTH_SOURCE));
+        assertTrue("Could not fetch fetch source: " + FHIR_OAUTH_SOURCE + "::" + resp.getErrors(),
+                   resp.isSuccess());
+        //noinspection unchecked
+        Map<String, ?> oauthSource =  mapper.readValue(new Gson().toJson(((JsonObject) resp.getBody())),
+                                                       Map.class);
+        log.debug("{} Definition: {}", FHIR_OAUTH_SOURCE, oauthSource);
+        
+        //noinspection unchecked
+        Map<String, ?> oauthConfig = (Map<String, ?>) fhirSource.get("config");
+        assertEquals(FHIR_OAUTH_SOURCE + ": should be inactive", false, oauthSource.get("active"));
     }
 }

--- a/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssemblyBasicAuth.java
+++ b/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssemblyBasicAuth.java
@@ -1,0 +1,63 @@
+package io.vantiq.extsrc.fhirAssembly;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.JsonObject;
+import io.vantiq.client.Vantiq;
+import io.vantiq.client.VantiqResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Test operations against a FHIR server using fhirConnection assembly
+ */
+@Slf4j
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class TestFhirAssemblyBasicAuth extends TestFhirAssembly {
+    
+    public static String FHIR_SOURCE = "com.vantiq.fhir.fhirServer";
+    public static String FHIR_OAUTH_SOURCE = "com.vantiq.fhir.oauthSource";
+    public static String TEST_USERNAME = "fred";
+    public static String TEST_PASSWORD = "somepasswordthatdoesntmatter"
+    
+    // Playing this little indirection since the methods are static (Junit Rules) but we want to override.  Copying a
+    // bunch of code just to test different situations is not attractive.  JUnit's @BeforeClass will ensure that only
+    // one instance of a named method is run, so that suffices for our needs.
+    
+    @BeforeClass
+    public static void setupEnv() {
+        performSetup(getAssemblyConfigForTest());
+    }
+    
+    public static Map<String,?> getAssemblyConfigForTest() {
+        Map<String, ?> config =  Map.of("fhirServerBaseUrl", FHIR_SERVER,
+                                        "defaultSearchHttpMethod", "GET",
+                                        "authenticationMechanism", "Basic",
+                                        "basicUsername", TEST_USERNAME,
+                                        "basicPassword", TEST_PASSWORD);
+        log.debug("Returning assembly config of: {}", config);
+        return config;
+    }
+    
+    @Test
+    public void test900ValidateSource() {
+        // Verify that the source's in the assembly are correctly set up...
+        
+        Vantiq v = new Vantiq(TEST_SERVER, 1);
+        v.authenticate(SUB_USER, SUB_USER);
+        VantiqResponse resp = v.selectOne("system.sources", FHIR_SOURCE);
+        assertTrue("Could not fetch fetch source: " + FHIR_SOURCE + "::" + resp.getErrors(), resp.isSuccess());
+        Map<String, ?> fhirSource = ((JsonObject) resp.getBody()).asMap();
+        //noinspection unchecked
+        Map<String, ?> config = (Map<String, ?>) fhirSource.get("config");
+        assertEquals(FHIR_SOURCE + ": wrong username", TEST_USERNAME, config.get("username"));
+        assertEquals(FHIR_SOURCE + ": wrong password", TEST_PASSWORD, config.get("password"));
+    }
+}

--- a/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssemblyOAuth.java
+++ b/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssemblyOAuth.java
@@ -1,0 +1,88 @@
+package io.vantiq.extsrc.fhirAssembly;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import io.vantiq.client.Vantiq;
+import io.vantiq.client.VantiqResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Test operations against a FHIR server using fhirConnection assembly
+ */
+@Slf4j
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class TestFhirAssemblyBasicAuth extends TestFhirAssembly {
+    
+    public static String FHIR_SOURCE = "com.vantiq.fhir.fhirServer";
+    public static String FHIR_OAUTH_SOURCE = "com.vantiq.fhir.oauthSource";
+    public static String TEST_USERNAME = "fred";
+    public static String TEST_PASSWORD = "somePasswordThatDoesn'tMatter";
+    
+    // Playing this little indirection since the methods are static (Junit Rules) but we want to override.  Copying a
+    // bunch of code just to test different situations is not attractive.  JUnit's @BeforeClass will ensure that only
+    // one instance of a named method is run, so that suffices for our needs.
+    
+    @BeforeClass
+    public static void setupEnv() {
+        performSetup(getAssemblyConfigForTest());
+    }
+    
+    public static Map<String,?> getAssemblyConfigForTest() {
+        Map<String, ?> config =  Map.of(
+                "basicUsername", TEST_USERNAME,
+                "basicPassword", TEST_PASSWORD,
+                "fhirServerBaseUrl", FHIR_SERVER,
+                "defaultSearchHttpMethod", "GET",
+                "authenticationMechanism", "Basic");
+        log.debug("Returning assembly config of: {}", config);
+        return config;
+    }
+    
+    @Test
+    public void test000ValidateSourceBasic() throws Exception {
+        
+        // Verify that the source's in the assembly are correctly set up...
+        
+        Vantiq v = new Vantiq(TEST_SERVER, 1);
+        v.authenticate(SUB_USER, SUB_USER);
+        
+        registerGetConfiguredSource(v);
+        
+        VantiqResponse resp = v.execute("getConfiguredSource",
+                                       Map.of("sourceName", FHIR_SOURCE));
+        assertTrue("Could not fetch fetch source: " + FHIR_SOURCE + "::" + resp.getErrors(), resp.isSuccess());
+        assertTrue("Source not in form we expect: " + resp.getBody().getClass().getName(),
+                   resp.getBody() instanceof JsonObject);
+        //noinspection unchecked
+        Map<String, ?> fhirSource = mapper.readValue(new Gson().toJson(((JsonObject) resp.getBody())),
+                                                                                       Map.class);
+        log.debug("{} Definition: {}", FHIR_SOURCE, fhirSource);
+        //noinspection unchecked
+        Map<String, ?> config = (Map<String, ?>) fhirSource.get("config");
+        assertEquals(FHIR_SOURCE + ": wrong username", TEST_USERNAME, config.get("username"));
+        assertEquals(FHIR_SOURCE + ": wrong password", TEST_PASSWORD, config.get("password"));
+        
+        resp = v.execute("getConfiguredSource",
+                         Map.of("sourceName", FHIR_OAUTH_SOURCE));
+        assertTrue("Could not fetch fetch source: " + FHIR_OAUTH_SOURCE + "::" + resp.getErrors(),
+                   resp.isSuccess());
+        //noinspection unchecked
+        Map<String, ?> oauthSource =  mapper.readValue(new Gson().toJson(((JsonObject) resp.getBody())),
+                                                       Map.class);
+        log.debug("{} Definition: {}", FHIR_OAUTH_SOURCE, oauthSource);
+        
+        //noinspection unchecked
+        Map<String, ?> oauthConfig = (Map<String, ?>) fhirSource.get("config");
+        assertEquals(FHIR_OAUTH_SOURCE + ": should be inactive", false, oauthSource.get("active"));
+    }
+}

--- a/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssemblySearchGet.java
+++ b/fhirAssembly/src/test/java/io/vantiq/extsrc/fhirAssembly/TestFhirAssemblySearchGet.java
@@ -24,7 +24,8 @@ public class TestFhirAssemblySearchGet extends TestFhirAssembly {
     
     public static Map<String,?> getAssemblyConfigForTest() {
         Map<String, ?> config =  Map.of("fhirServerBaseUrl", FHIR_SERVER,
-                                        "defaultSearchHttpMethod", "GET");
+                                        "defaultSearchHttpMethod", "GET",
+                                        "authenticationMechanism", "None");
         log.debug("Returning assembly config of: {}", config);
         return config;
     }


### PR DESCRIPTION
This is a merge into the FHIR staging branch

Fixes #548
Fixes #561

Adds support for Basic & OAuth authentication.  We add appropriate configuration properties to the assembly, assigning them as required in the source & newly created OAuth source.

Due to limitations on what the assemblies can do (including, but not limited to the ability to modify the source def'n (can't because it's installed) and a no derived config properties (would like to make the OAuth source active iff the mechanism in use requires it), we now have a bunch of config properties.  Chances are that there will be a subsequent PR to split things into 3 different assemblies (no auth, basic, and OAuth), but still pondering.  For now, I want to get things put together so I can send it to Sam for some beta use.

Also removed some undocumented usage from the VAIL code.  Don't need to rock the boat...

Requires fixes to Vantiq/ag2rs#12768 & Vantiq/ag2rs#12769 for OAuth & associate test to run correctly.  Impact without fixes is failure to authenticate