### PR TITLE
Add description to NLP assembly

### DIFF
--- a/nlpAssembly/src/main/resources/assembly/com.vantiq.nlp.NaturalLanguageProcessing/projects/com.vantiq.nlp.NaturalLanguageProcessing.json
+++ b/nlpAssembly/src/main/resources/assembly/com.vantiq.nlp.NaturalLanguageProcessing/projects/com.vantiq.nlp.NaturalLanguageProcessing.json
@@ -255,7 +255,7 @@
   } ],
   "name" : "com.vantiq.nlp.NaturalLanguageProcessing",
   "options" : {
-    "description" : "",
+    "description" : "This assembly adds conversational language capability to the namespace. This capability works in conjunction with an external natural language interpreter to understand an utterance. The com.vantiq.nlp.InterpretCLU component enables this in an event handler.",
     "dockCollapsed" : {
       "bottom" : false,
       "left" : false,


### PR DESCRIPTION
No issue reported.

Add a description to the assembly:

- This assembly adds conversational language capability to the namespace. This capability works in conjunction with an external natural language interpreter to understand an utterance. The com.vantiq.nlp.InterpretCLU component enables this in an event handler.

This description & description of the included component will be display in the component catalog discovery pane.  If there is formatting capability for the description, I can tweak the component name to be `code` looking.  But I don't know that that is present...

(Question: Do we have generic name for the catalog?  In docs (_e.g_, the release notes), how do we talk about said catalog?)