### PR TITLE
PythonExecSource: Update jinja2 & twine to deal with CVEs

### DIFF
--- a/pythonExecSource/build.gradle
+++ b/pythonExecSource/build.gradle
@@ -12,11 +12,11 @@ ext {
     }
 
     if (!project.rootProject.hasProperty('pyExecSrcVersion')) {
-        pyExecSrcVersion = '1.3.2'
+        pyExecSrcVersion = '1.3.3'
     }
     // If these change, update requirements-conn.in as well -- as that's used to generate the requirements.txt file
-    vantiqPythonSdkVersion = '1.4.2'
-    vantiqConnectorSdkVersion = '1.3.5'
+    vantiqPythonSdkVersion = '1.4.5'
+    vantiqConnectorSdkVersion = '1.3.6'
 }
 
 python {

--- a/pythonExecSource/requirements-build.in
+++ b/pythonExecSource/requirements-build.in
@@ -8,11 +8,11 @@ aioresponses>=0.7.6
 codetiming
 
 # Dependabot fix
-jinja2>=3.1.5
+jinja2>=3.1.6
 setuptools>=70.0.0
 zipp>=3.19.1
 
 # For build
 pip-tools
 build
-twine
+twine>=6.1.0

--- a/pythonExecSource/requirements-conn.in
+++ b/pythonExecSource/requirements-conn.in
@@ -1,4 +1,4 @@
 websockets>=12.0
-vantiqconnectorsdk>=1.3.5
-vantiqsdk>=1.4.2
+vantiqconnectorsdk>=1.3.6
+vantiqsdk>=1.4.5
 requests>=2.32.3

--- a/pythonExecSource/requirements.txt
+++ b/pythonExecSource/requirements.txt
@@ -40,14 +40,14 @@ frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
+id==1.5.0
+    # via twine
 idna==3.10
     # via
     #   requests
     #   yarl
 importlib-metadata==8.5.0
-    # via
-    #   keyring
-    #   twine
+    # via keyring
 iniconfig==2.0.0
     # via pytest
 jaraco-classes==3.4.0
@@ -56,7 +56,7 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.1.0
     # via keyring
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -r requirements-build.in
     #   pytest-html
@@ -85,12 +85,11 @@ packaging==24.2
     #   aioresponses
     #   build
     #   pytest
+    #   twine
 pip==24.3.1
     # via pip-tools
 pip-tools==7.4.1
     # via -r requirements-build.in
-pkginfo==1.10.0
-    # via twine
 pluggy==1.5.0
     # via pytest
 propcache==0.2.0
@@ -125,6 +124,7 @@ readme-renderer==44.0
 requests==2.32.3
     # via
     #   -r requirements-conn.in
+    #   id
     #   requests-toolbelt
     #   twine
     #   vantiqsdk
@@ -143,7 +143,7 @@ tomli==2.1.0
     #   build
     #   pip-tools
     #   pytest
-twine==5.1.1
+twine==6.1.0
     # via -r requirements-build.in
 typing-extensions==4.12.2
     # via
@@ -153,9 +153,9 @@ urllib3==2.2.3
     # via
     #   requests
     #   twine
-vantiqconnectorsdk==1.3.5
+vantiqconnectorsdk==1.3.6
     # via -r requirements-conn.in
-vantiqsdk==1.4.2
+vantiqsdk==1.4.5
     # via -r requirements-conn.in
 websockets==14.1
     # via


### PR DESCRIPTION
Jinja2 needed a version update (python SDK & connector SDK already done).

Update jinja2 version to avoid CVE.

Update twine (used for publishing to pypi) to current version to get metadata correct.

Update Vantiq Python dependencies to pick up corresponding changes.