### PR TITLE
Update NLP Assembly to be an assembly...

### DIFF
--- a/nlpAssembly/src/main/resources/assembly/com.vantiq.nlp.NaturalLanguageProcessing/projects/com.vantiq.nlp.NaturalLanguageProcessing.json
+++ b/nlpAssembly/src/main/resources/assembly/com.vantiq.nlp.NaturalLanguageProcessing/projects/com.vantiq.nlp.NaturalLanguageProcessing.json
@@ -1,5 +1,6 @@
 {
   "ars_relationships" : [ ],
+  "isAssembly" : true,
   "links" : [ {
     "source" : "procedure/com.vantiq.nlp.NLCore.respondToConversationalQuery",
     "target" : "services/com.vantiq.nlp.NLCore"


### PR DESCRIPTION
Guess our Vail code that uses things is less constrained than the UI.  So I can install something that's not an assembly from a catalog in the tests, but the UI doesn't seem to like that configuration for installation purposes (quite correctly).

Update the project to declare its assembly-ness.  Hopefully, that'll make things better...