### PR TITLE
Remove references to Image resource in Object Recognition Source

### DIFF
--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -115,7 +115,7 @@ public class TestJDBC extends TestJDBCBase {
     // Queries to test errors
     static final String NO_TABLE = "SELECT * FROM jibberish";
     static final String NO_FIELD = "SELECT jibberish FROM Test";
-    static final String SYNTAX_ERROR = "LECT * FROM Test";
+    static final String SYNTAX_ERROR = "ELECT * FROM Test";
     static final String INSERT_NO_FIELD = "INSERT INTO Test VALUES (1, 25, 'Santa', 'Claus', 'jibberish')";
     static final String INSERT_WRONG_TYPE = "INSERT INTO Test VALUES ('string', 'string', 3, 4)";
     

--- a/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
+++ b/jdbcSource/src/test/java/io/vantiq/extsrc/jdbcSource/TestJDBC.java
@@ -115,7 +115,7 @@ public class TestJDBC extends TestJDBCBase {
     // Queries to test errors
     static final String NO_TABLE = "SELECT * FROM jibberish";
     static final String NO_FIELD = "SELECT jibberish FROM Test";
-    static final String SYNTAX_ERROR = "ELECT * FROM Test";
+    static final String SYNTAX_ERROR = "LECT * FROM Test";
     static final String INSERT_NO_FIELD = "INSERT INTO Test VALUES (1, 25, 'Santa', 'Claus', 'jibberish')";
     static final String INSERT_WRONG_TYPE = "INSERT INTO Test VALUES ('string', 'string', 3, 4)";
     

--- a/nlpAssembly/src/main/resources/assembly/com.vantiq.nlp.NaturalLanguageProcessing/projects/com.vantiq.nlp.NaturalLanguageProcessing.json
+++ b/nlpAssembly/src/main/resources/assembly/com.vantiq.nlp.NaturalLanguageProcessing/projects/com.vantiq.nlp.NaturalLanguageProcessing.json
@@ -247,7 +247,7 @@
   } ],
   "name" : "com.vantiq.nlp.NaturalLanguageProcessing",
   "options" : {
-    "description" : "This assembly adds conversational language capability to the namespace. This capability works in conjunction with an external natural language interpreter to understand an utterance. The com.vantiq.nlp.InterpretCLU component enables this in an event handler.",
+    "description" : "This assembly adds conversational language capability to the namespace. This capability works in conjunction with an external natural language interpreter to understand an utterance. The com.vantiq.nlp.InterpretCLU component enables this in an event handler. See the following link for detailed documentation: https://github.com/Vantiq/vantiq-extension-sources/blob/master/nlpAssembly/doc/natlang.md",
     "dockCollapsed" : {
       "bottom" : false,
       "left" : false,

--- a/objectRecognitionSource/README.md
+++ b/objectRecognitionSource/README.md
@@ -7,7 +7,7 @@ This implementation of the Object Recognition Source includes built-in functiona
 *   Camera Retriever - used to retrieve images from a serially-connected camera.
 *   Network Stream Retriever - used to retrieve images from a network-connected camera.
 *   File Retriever - used to retrieve images and videos from disk.
-*   FTP Retriever - used to retrieve images trhough FTP, FTPS, and SFTP.
+*   FTP Retriever - used to retrieve images through FTP, FTPS, and SFTP.
 
 Again, other types of images and videos can be processed by implementing the ImageRetrieverInterface.
 
@@ -147,7 +147,6 @@ The Configuration document may look similar to the following example:
              "saveImage": "both",
              "saveRate": 1,
              "outputDir": "imageOut",
-             "uploadAsImage": true,
              "savedResolution": {
                 "longEdge": 400
              },
@@ -235,9 +234,6 @@ is set to be either "local" or "both".
 captured). If not specified, the value will default to 1 which saves every captured image.
 *   `labelImage`: Optional. If set to "true", images will be saved with bounding boxes and labels. If set to "false", or if not 
 set at all, the images will be saved with no bounding boxes or labels.
-*   `uploadAsImage`: Optional. If set to "true", images will be uploaded to VANTIQ as VANTIQ Images, (the default behavior 
-uploads images as VANTIQ Documents).
-    *   **NOTE**: This option is only relevant if "saveImage" has been set to either "vantiq" or "both".
 *   `savedResolution`: Optional. A map containing options for adjusting the resolution of the saved images.
     * *Options for savedResolution:*
     1. `longEdge`: Optional. This sets the maximum long edge dimension for saved images. Must be a non-negative integer that is 
@@ -568,8 +564,6 @@ it will be set to the default value, "processNextFrame".
         is defined here as a query parameter, it will override the value set in the source configuration, otherwise the source 
         configuration value will be used. The setting cannot be larger than that provided in the source configuration (since 
         that defines how the images are saved).
-        *   uploadAsImage: Optional. If set to "true", images will be uploaded to VANTIQ as VANTIQ Images, (the default 
-        behavior uploads images as VANTIQ Documents).
     
 *   **Delete locally saved images:**
     *   The user can specify an image or a set of images specified by their date & time to be deleted. The images will be 
@@ -599,8 +593,6 @@ it will be set to the default value, "processNextFrame".
         *   "cropBeforeAnalysis": Optional. This value can be set exactly like the "cropBeforeAnalysis" value in the source 
         configuration. If no cropBeforeAnalysis value is set as a query parameter, the source configuration's 
         cropBeforeAnalysis value will be used.
-        *   "uploadAsImage": Optional. If set to "true", images will be uploaded to VANTIQ as VANTIQ Images, (the default 
-        behavior uploads images as VANTIQ Documents).
         *   "includeEncodedImage": Optional.  If set to "true", a Base64-encoded image will be included in the results when `sendFullResponse` is set.
     
 **EXAMPLE QUERIES**:
@@ -619,8 +611,7 @@ SELECT * FROM SOURCE Camera1 AS results WITH
 ```
 SELECT * FROM SOURCE Camera1 AS results WITH
         operation:"upload",
-        imageDate:["2019-02-08--10-33-36", "2019-02-08--12-45-18"],
-        uploadAsImage: true
+        imageDate:["2019-02-08--10-33-36", "2019-02-08--12-45-18"]
 ```
 
 *   Delete Query using imageName:
@@ -679,8 +670,7 @@ SELECT * FROM SOURCE Camera1 AS results WITH
 SELECT * FROM SOURCE Camera1 AS results WITH
         operation:"processNextFrame",
         NNsaveImage:"vantiq",
-        NNfileName:"testFile",
-        uploadAsImage: true
+        NNfileName:"testFile"
 ```
 
 *   Process Next Frame Query without specifying operation *(not recommended)*:

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/ObjectDetector.java
@@ -215,8 +215,6 @@ public class ObjectDetector {
      *                      and {@code outputDir} is non-null, then the file is saved as
      *                      "&lt;year&gt;-&lt;month&gt;-&lt;day&gt;--&lt;hour&gt;-&lt;minute&gt;-&lt;second&gt;.jpg"
      * @param vantiq        The Vantiq variable used to connect to the VANTIQ SDK. Either authenticated, or set to null.
-     * @param uploadAsImage The boolean flag used to specify if images should be uploaded to VANTIQ as
-     *                      Documents or VANTIQ Images
      * @param localLabelImage Boolean indicating whether this query should produce labels, overriding
      *                      the connector setting.
      * @return              ResultHolder containing a List of Maps, each of which has a {@code label} stating the type
@@ -227,7 +225,7 @@ public class ObjectDetector {
      *                      was returned.
      */
     public ResultHolder detect(final byte[] image, String outputDir, String fileName, Vantiq vantiq,
-                               boolean uploadAsImage, boolean localLabelImage) {
+                               boolean localLabelImage) {
         try (Tensor<Float> normalizedImage = normalizeImage(image)) {
             List<Recognition> recognitions = YOLOClassifier.getInstance(threshold, anchorArray, frameSize).classifyImage(executeYOLOGraph(normalizedImage), labels);
             BufferedImage buffImage = ImageUtil.createImageFromBytes(image);
@@ -239,7 +237,6 @@ public class ObjectDetector {
                 imageUtil.vantiq = vantiq;
                 imageUtil.sourceName = sourceName;
                 imageUtil.frameSize = frameSize;
-                imageUtil.uploadAsImage = uploadAsImage;
                 lastFilename = fileName;
                 if (labelImage || localLabelImage) {
                     buffImage = imageUtil.labelImage(buffImage, recognitions);

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
@@ -31,7 +31,6 @@ public class ImageUtil {
     public int frameSize;
     public Boolean queryResize = false;
     public int longEdge = 0;
-    public Boolean uploadAsImage = false;
 
     // Used to upload image to VANTIQ as VANTIQ Image
     static final String IMAGE_RESOURCE_PATH = "/resources/images";

--- a/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
+++ b/objectRecognitionSource/src/main/java/edu/ml/tensorflow/util/ImageUtil.java
@@ -153,19 +153,10 @@ public class ImageUtil {
             }
         };
 
-        // Check if we should upload as a document, or image
-        if (uploadAsImage) {
-            vantiq.upload(fileToUpload,
-                    "image/jpeg",
-                    "objectRecognition/" + sourceName + '/'  + target,
-                    IMAGE_RESOURCE_PATH,
-                    responseHandler);
-        } else {
-            vantiq.upload(fileToUpload,
-                    "image/jpeg",
-                    "objectRecognition/" + sourceName + '/'  + target,
-                    responseHandler);
-        }
+        vantiq.upload(fileToUpload,
+                "image/jpeg",
+                "objectRecognition/" + sourceName + '/'  + target,
+                responseHandler);
     }
     
     /**

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionConfigHandler.java
@@ -155,7 +155,12 @@ public class ObjectRecognitionConfigHandler extends Handler<ExtensionServiceMess
                 
                 // Check value of operation, proceed accordingly
                 if (operation.equals(UPLOAD)) {
-                    source.uploadLocalImages(request, replyAddress);
+                    try {
+                        source.uploadLocalImages(request, replyAddress);
+                    } catch (Exception ex) {
+                        client.sendQueryError(replyAddress, "io.vantiq.extsrc.objectRecognition.invalidImageRequest",
+                                "{0}", new String[]{ex.getMessage()});
+                    }
                 } else if (operation.equals(DELETE)) {
                     source.deleteLocalImages(request, replyAddress);
                 } else if (operation.equals(PROCESS_NEXT_FRAME)) {

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/ObjectRecognitionCore.java
@@ -462,7 +462,7 @@ public class ObjectRecognitionCore {
     * @param request        The parameters sent with the query.
     * @param replyAddress   The replyAddress used to send a query response.
     */
-   public void uploadLocalImages(Map<String, ?> request, String replyAddress) {       
+   public void uploadLocalImages(Map<String, ?> request, String replyAddress) throws Exception {
        Map<String,Object> parsedParameterResult = handleQueryParameters(request, replyAddress, UPLOAD);
        if (parsedParameterResult == null) {
            return;
@@ -556,7 +556,7 @@ public class ObjectRecognitionCore {
     * @param request    The parameters sent with the query.
     * @return           The instantiated ImageUtil class, setup with properties based on the request
     */
-   public ImageUtil setupQueryImageUtil(Map<String, ?> request) {   
+   public ImageUtil setupQueryImageUtil(Map<String, ?> request) throws Exception {
        ImageUtil imageUtil = new ImageUtil();
        Vantiq vantiq = new io.vantiq.client.Vantiq(targetVantiqServer);
        vantiq.setAccessToken(authToken);
@@ -578,7 +578,9 @@ public class ObjectRecognitionCore {
 
        // Check if images should be uploaded to VANTIQ as VANTIQ IMAGES
        if (request.get(UPLOAD_AS_IMAGE) instanceof Boolean && (Boolean) request.get(UPLOAD_AS_IMAGE)) {
-            imageUtil.uploadAsImage = (Boolean) request.get(UPLOAD_AS_IMAGE);
+           throw new Exception(this.getClass().getCanonicalName() + ".images.no.longer.supported: "
+                   + "The uploadAsImage option is no longer supported. All images must be uploaded as " +
+                   "Vantiq Documents.");
        }
        
        return imageUtil;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NoProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NoProcessor.java
@@ -58,7 +58,6 @@ public class NoProcessor implements NeuralNetInterface {
     int saveRate = 1;
     int frameCount = 0;
     int fileCount = 0; // Used for saving files with same name
-    boolean uploadAsImage = false;
     boolean includeEncodedImage = false;
     
     @SuppressWarnings("PMD.CognitiveComplexity")
@@ -98,7 +97,6 @@ public class NoProcessor implements NeuralNetInterface {
             imageUtil.vantiq = vantiq;
             imageUtil.saveImage = true;
             imageUtil.sourceName = sourceName;
-            imageUtil.uploadAsImage = uploadAsImage;
             if (neuralNetConfig.get(SAVE_RATE) instanceof Integer) {
                 saveRate = (Integer) neuralNetConfig.get(SAVE_RATE);
                 frameCount = saveRate;
@@ -152,7 +150,6 @@ public class NoProcessor implements NeuralNetInterface {
         String outputDir = null;
         String fileName = null;
         Vantiq vantiq = null;
-        boolean uploadAsImage = false;
         ImageUtil queryImageUtil = new ImageUtil();
         
         if (request.get(NN_SAVE_IMAGE) instanceof String) {
@@ -187,7 +184,6 @@ public class NoProcessor implements NeuralNetInterface {
                 queryImageUtil.vantiq = vantiq;
                 queryImageUtil.saveImage = true;
                 queryImageUtil.sourceName = sourceName;
-                queryImageUtil.uploadAsImage = uploadAsImage;
             }
         } else {
             queryImageUtil.saveImage = false;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NoProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/NoProcessor.java
@@ -63,7 +63,8 @@ public class NoProcessor implements NeuralNetInterface {
     
     @SuppressWarnings("PMD.CognitiveComplexity")
     @Override
-    public void setupImageProcessing(Map<String, ?> neuralNetConfig, String sourceName, String modelDirectory, String authToken, String server) {
+    public void setupImageProcessing(Map<String, ?> neuralNetConfig, String sourceName, String modelDirectory,
+                                     String authToken, String server) throws Exception {
         this.server = server;
         this.authToken = authToken;
         this.sourceName = sourceName;
@@ -88,7 +89,9 @@ public class NoProcessor implements NeuralNetInterface {
 
                 // Check if images should be uploaded to VANTIQ as VANTIQ IMAGES
                 if (neuralNetConfig.get(UPLOAD_AS_IMAGE) instanceof Boolean && (Boolean) neuralNetConfig.get(UPLOAD_AS_IMAGE)) {
-                    uploadAsImage = (Boolean) neuralNetConfig.get(UPLOAD_AS_IMAGE);
+                    throw new Exception(this.getClass().getCanonicalName() + ".images.no.longer.supported: "
+                            + "The uploadAsImage option is no longer supported. All images must be uploaded as " +
+                            "Vantiq Documents.");
                 }
             }
             imageUtil.outputDir = outputDir;
@@ -164,7 +167,9 @@ public class NoProcessor implements NeuralNetInterface {
 
                     // Check if images should be uploaded to VANTIQ as VANTIQ IMAGES
                     if (request.get(UPLOAD_AS_IMAGE) instanceof Boolean && (Boolean) request.get(UPLOAD_AS_IMAGE)) {
-                        uploadAsImage = (Boolean) request.get(UPLOAD_AS_IMAGE);
+                        throw new ImageProcessingException(this.getClass().getCanonicalName() + ".images.no.longer.supported: "
+                                + "The uploadAsImage option is no longer supported. All images must be uploaded as " +
+                                "Vantiq Documents.");
                     }
                 }
                 if (!saveImage.equalsIgnoreCase(VANTIQ)) {

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -431,7 +431,6 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
         String fileName = null;
         Vantiq vantiq = null;
         boolean includeEncodedImage;
-        boolean uploadAsImage = false;
         boolean localLabelRequest = false;
         boolean savingSomewhere = false;
 
@@ -527,8 +526,7 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
         long after;
         long before = System.currentTimeMillis();
         try {
-            ObjectDetector.ResultHolder rh = objectDetector.detect(image, outputDir, fileName, vantiq,
-                    uploadAsImage, localLabelRequest);
+            ObjectDetector.ResultHolder rh = objectDetector.detect(image, outputDir, fileName, vantiq, localLabelRequest);
             foundObjects = rh.results;
             if (rh.image != null) {
                 image = rh.image;

--- a/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
+++ b/objectRecognitionSource/src/main/java/io/vantiq/extsrc/objectRecognition/neuralNet/YoloProcessor.java
@@ -78,7 +78,6 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
     ImageUtil imageUtil;
     float threshold = 0.5f;
     int saveRate = 1;
-    boolean uploadAsImage = false;
     boolean includeEncodedImage = false;
 
     // Variables for pre crop
@@ -245,7 +244,9 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
 
                // Check if images should be uploaded to VANTIQ as VANTIQ IMAGES
                if (neuralNet.get(UPLOAD_AS_IMAGE) instanceof Boolean && (Boolean) neuralNet.get(UPLOAD_AS_IMAGE)) {
-                   uploadAsImage = (Boolean) neuralNet.get(UPLOAD_AS_IMAGE);
+                   throw new Exception(this.getClass().getCanonicalName() + ".images.no.longer.supported: "
+                           + "The uploadAsImage option is no longer supported. All images must be uploaded as " +
+                           "Vantiq Documents.");
                }
            }
            
@@ -271,7 +272,6 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
            imageUtil.vantiq = vantiq;
            imageUtil.saveImage = true;
            imageUtil.sourceName = sourceName;
-           imageUtil.uploadAsImage = uploadAsImage;
            if (neuralNet.get(SAVE_RATE) instanceof Integer) {
                saveRate = (Integer) neuralNet.get(SAVE_RATE);
            }
@@ -456,7 +456,9 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
 
                     // Check if images should be uploaded to VANTIQ as VANTIQ IMAGES
                     if (request.get(UPLOAD_AS_IMAGE) instanceof Boolean && (Boolean) request.get(UPLOAD_AS_IMAGE)) {
-                        uploadAsImage = (Boolean) request.get(UPLOAD_AS_IMAGE);
+                        throw new ImageProcessingException(this.getClass().getCanonicalName() + ".images.no.longer.supported: "
+                                + "The uploadAsImage option is no longer supported. All images must be uploaded as " +
+                                "Vantiq Documents.");
                     }
                 }
                 if (!saveImage.equalsIgnoreCase(VANTIQ)) {
@@ -566,6 +568,8 @@ public class YoloProcessor extends NeuralNetUtils implements NeuralNetInterface2
 
     @Override
     public void close() {
+        if (objectDetector != null) {
         objectDetector.close();
+        }
     }
 }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessor.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import edu.ml.tensorflow.util.ImageUtil;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -54,7 +55,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
 
     // A single processor is used for the entire class because it is very expensive to do initial setup
     @BeforeClass
-    public static void classSetup() {
+    public static void classSetup() throws Exception {
         noProcessor = new NoProcessor();
 
         Map<String, Object> config = new LinkedHashMap<>();
@@ -130,7 +131,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
     }
 
     @Test
-    public void testInvalidConfig() {
+    public void testInvalidConfig() throws Exception {
         Map<String, Object> config = new LinkedHashMap<>();
         NoProcessor npProcessor = new NoProcessor();
         NoProcessor npProcessor2 = new NoProcessor();
@@ -147,7 +148,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
     }
 
     @Test
-    public void testValidConfig() {
+    public void testValidConfig() throws Exception {
         Map<String, Object> config = new LinkedHashMap<>();
         NoProcessor npProcessor = new NoProcessor();
         NoProcessor npProcessor2 = new NoProcessor();
@@ -169,7 +170,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
     }
 
     @Test
-    public void testImageSavingLocal() throws ImageProcessingException, InterruptedException {
+    public void testImageSavingLocal() throws Exception {
 
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
@@ -246,7 +247,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
 
     // Identical to testImageSavingLocal(), but saveImage is set to "both". Behavior should be identical.
     @Test
-    public void testImageSavingBoth() throws ImageProcessingException, InterruptedException {
+    public void testImageSavingBoth() throws Exception {
 
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
@@ -326,7 +327,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
     // Similar to testImageSavingVantiq(), but includes returning the image in a Base64-encoded form.
     // No images should be saved locally.
     @Test
-    public void testImageSavingVantiqPlusEncoded() throws ImageProcessingException, InterruptedException {
+    public void testImageSavingVantiqPlusEncoded() throws Exception {
         
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
@@ -392,7 +393,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
     // Similar to testImageSavingLocal() and testImageSavingBoth(), but saveImage is set to "vantiq".
     // No images should be saved locally.
     @Test
-    public void testImageSavingVantiq() throws ImageProcessingException, InterruptedException {
+    public void testImageSavingVantiq() throws Exception {
 
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
@@ -436,16 +437,16 @@ public class TestNoProcessor extends NeuralNetTestBase {
     }
 
     @Test
-    public void testQuery() throws ImageProcessingException, InterruptedException {
+    public void testQuery() throws Exception {
         doQueryTest(false);
     }
     
     @Test
-    public void testQueryWithEncoded() throws ImageProcessingException, InterruptedException {
+    public void testQueryWithEncoded() throws Exception {
         doQueryTest(true);
     }
     
-    void doQueryTest(boolean includeEncoded) throws ImageProcessingException, InterruptedException {
+    void doQueryTest(boolean includeEncoded) throws Exception {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
 
@@ -592,7 +593,7 @@ public class TestNoProcessor extends NeuralNetTestBase {
     }
 
     @Test
-    public void testUploadAsImage() throws ImageProcessingException, InterruptedException {
+    public void testUploadAsImage() throws Exception {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
 
@@ -604,36 +605,12 @@ public class TestNoProcessor extends NeuralNetTestBase {
         config.put("saveRate", SAVE_RATE);
         config.put("saveImage", "vantiq");
         config.put("uploadAsImage", true);
-        npProcessor.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
-
-        File d = new File(OUTPUT_DIR);
         try {
-            // Ensure no results from previous tests
-            if (d.exists()) {
-                deleteDirectory(OUTPUT_DIR);
-            }
-
-            NeuralNetResults results = npProcessor.processImage(getTestImage());
-            assert results.getResults() == null;
-
-            // Should not exist since images are not being saved locally.
-            assert !d.exists();
-
-            // Checking that image was saved to VANTIQ as an image
-            Thread.sleep(1000);
-            lastFilename = "objectRecognition/" + SOURCE_NAME + '/' + npProcessor.lastFilename;
-            checkUploadToVantiq(lastFilename, vantiq, VANTIQ_IMAGES);
-            vantiqSavedImageFiles.add(lastFilename);
-
-            // Checking that image was not saved to VANTIQ as a document
-            checkNotUploadToVantiq(lastFilename, vantiq, VANTIQ_DOCUMENTS);
-
+            npProcessor.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
+            Assert.fail("Should not have been able to use the removed uploadAsImage option");
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("The uploadAsImage option is no longer supported"));
         } finally {
-            // delete the directory even if the test fails
-            if (d.exists()) {
-                deleteDirectory(OUTPUT_DIR);
-            }
-
             npProcessor.close();
         }
     }

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestNoProcessorQueries.java
@@ -1,5 +1,6 @@
 package io.vantiq.extsrc.objectRecognition.neuralNet;
 
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
@@ -10,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -291,17 +293,9 @@ public class TestNoProcessorQueries extends NeuralNetTestBase {
         params.put("uploadAsImage", true);
         params.put("NNfileName", QUERY_FILENAME);
 
-        querySource(params);
-
-        // Check that file was saved to Vantiq as an Image
-        Thread.sleep(1000);
-        checkUploadToVantiq(IMAGE.get("filename"), vantiq, VANTIQ_IMAGES);
-
-        // Check that it wasn't saved to Vantiq as a Document
-        checkNotUploadToVantiq(IMAGE.get("filename"), vantiq, VANTIQ_DOCUMENTS);
-
-        // Deleting file
-        deleteFileFromVantiq(IMAGE.get("filename"));
+        VantiqResponse response = vantiq.query(SOURCE_NAME, params);
+        assertTrue(response.hasErrors());
+        assertTrue(response.getErrors().get(0).getMessage().contains("The uploadAsImage option is no longer supported"));
     }
     
     // ================================================= Helper functions =================================================

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestUploadAndDeleteQuery.java
@@ -184,7 +184,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     }
     
     @Test
-    public void testInvalidImageUploadParameters() throws InterruptedException {
+    public void testInvalidImageUploadParameters() throws InterruptedException, Exception {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         
@@ -310,7 +310,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     }
     
     @Test
-    public void testInvalidImageDeleteParameters() {
+    public void testInvalidImageDeleteParameters() throws Exception {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         
@@ -384,7 +384,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     }
     
     @Test
-    public void testImageNameUploadOne() throws InterruptedException {
+    public void testImageNameUploadOne() throws Exception {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         
@@ -408,7 +408,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     }
     
     @Test
-    public void testImageDateUploadAll() throws InterruptedException {
+    public void testImageDateUploadAll() throws Exception {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         
@@ -433,7 +433,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     }
     
     @Test
-    public void testImageDateUploadOne() throws InterruptedException {
+    public void testImageDateUploadOne() throws Exception {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         
@@ -459,7 +459,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     }
     
     @Test
-    public void testImageDateUploadBefore() throws InterruptedException {
+    public void testImageDateUploadBefore() throws Exception {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         
@@ -485,7 +485,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     }
     
     @Test
-    public void testImageDateUploadAfter() throws InterruptedException {
+    public void testImageDateUploadAfter() throws Exception {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         
@@ -511,7 +511,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     }
     
     @Test
-    public void testImageDateUploadRange() throws InterruptedException {
+    public void testImageDateUploadRange() throws Exception {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         
@@ -537,7 +537,7 @@ public class TestUploadAndDeleteQuery extends NeuralNetTestBase {
     }
     
     @Test
-    public void testImageUploadChangeResolution() throws InterruptedException, IOException {
+    public void testImageUploadChangeResolution() throws Exception {
         // Only run test with intended vantiq availability
         assumeTrue(testAuthToken != null && testVantiqServer != null);
         

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloProcessor.java
@@ -51,6 +51,7 @@ import lombok.extern.slf4j.Slf4j;
 import okhttp3.Response;
 import okio.BufferedSource;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -1794,20 +1795,9 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         config.put("uploadAsImage", true);
         try {
             ypImageSaver.setupImageProcessing(config, SOURCE_NAME, MODEL_DIRECTORY, testAuthToken, testVantiqServer);
+            Assert.fail("Should not have been able to use the removed uploadAsImage option");
         } catch (Exception e) {
-            fail("Could not setup the YoloProcessor");
-        }
-        try {
-
-            NeuralNetResults results = ypImageSaver.processImage(getTestImage());
-            assert results != null;
-            assert results.getResults() != null;
-
-            // Checking that image was saved to VANTIQ
-            Thread.sleep(1000);
-            checkUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_IMAGES);
-            vantiqSavedImageFiles.add(results.getLastFilename());
-
+            assertTrue(e.getMessage().contains("The uploadAsImage option is no longer supported"));
         } finally {
             ypImageSaver.close();
         }
@@ -1836,7 +1826,6 @@ public class TestYoloProcessor extends NeuralNetTestBase {
         config.put("saveRate", SAVE_RATE);
         if (shouldSaveImage) {
             config.put("saveImage", "vantiq");
-            config.put("uploadAsImage", true);
         }
         config.put("includeEncodedImage", true);
 
@@ -1880,7 +1869,7 @@ public class TestYoloProcessor extends NeuralNetTestBase {
                 if (log.isDebugEnabled()) {
                     log.debug("Checking for image file: {}", results.getLastFilename());
                 }
-                checkUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_IMAGES);
+                checkUploadToVantiq(results.getLastFilename(), vantiq, VANTIQ_DOCUMENTS);
                 vantiqSavedImageFiles.add(results.getLastFilename());
             }
         } finally {

--- a/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
+++ b/objectRecognitionSource/src/test/java/io/vantiq/extsrc/objectRecognition/neuralNet/TestYoloQueries.java
@@ -1053,29 +1053,9 @@ public class TestYoloQueries extends NeuralNetTestBase {
         imageDate.add(START_DATE);
         imageDate.add(END_DATE);
         params.put("imageDate", imageDate);
-
-        querySource(params);
-
-        // Checking that all images were uploaded to VANTIQ as images
-        Thread.sleep(3000);
-        checkUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_IMAGES);
-        checkUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_IMAGES);
-        checkUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_IMAGES);
-
-        // Checking that the other images were not uploaded to VANTIQ as images
-        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_IMAGES);
-        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_IMAGES);
-        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_IMAGES);
-        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_IMAGES);
-
-        // Checking that no images were uploaded to VANTIQ as documents
-        checkNotUploadToVantiq(IMAGE_1.get("filename"), vantiq, VANTIQ_DOCUMENTS);
-        checkNotUploadToVantiq(IMAGE_2.get("filename"), vantiq, VANTIQ_DOCUMENTS);
-        checkNotUploadToVantiq(IMAGE_3.get("filename"), vantiq, VANTIQ_DOCUMENTS);
-        checkNotUploadToVantiq(IMAGE_4.get("filename"), vantiq, VANTIQ_DOCUMENTS);
-        checkNotUploadToVantiq(IMAGE_5.get("filename"), vantiq, VANTIQ_DOCUMENTS);
-        checkNotUploadToVantiq(IMAGE_6.get("filename"), vantiq, VANTIQ_DOCUMENTS);
-        checkNotUploadToVantiq(IMAGE_7.get("filename"), vantiq, VANTIQ_DOCUMENTS);
+        VantiqResponse response = vantiq.query(SOURCE_NAME, params);
+        assertTrue(response.hasErrors());
+        assertTrue(response.getErrors().get(0).getMessage().contains("The uploadAsImage option is no longer supported"));
     }
     
     // ================================================= Helper functions =================================================


### PR DESCRIPTION
Fixes #587

Makes `uploadAsImage` illegal, and throws exceptions whenever someone tries to set it.