### PR TITLE
Add coding agents directives for java and python ext sdk usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# Building a Vantiq Extension Source — Agent Guide
+
+This repository provides the tools to build a **Vantiq extension source** (a.k.a. *Enterprise
+Connector* / *external source*). This file is the entry point for an automated coding agent: it
+orients you, then hands off to the per-language SDK README, which is the self-contained build guide
+(quickstart, gotchas, `server.config`).
+
+## The two halves of an extension source
+
+1. **Vantiq side** (defined in your Vantiq namespace, *not* in this repo): a `sourceimpls`
+   entry registering a custom source **type** (`baseType: EXTENSION`,
+   `verticle: service:extensionSource`), a `sources` instance of that type, and the VAIL /
+   Visual event handlers that react to it. Template for the impl definition:
+   `testConnector/src/test/resources/testConnectorImpl.json`.
+2. **Connector** (this repo): the external program that connects to Vantiq over a WebSocket.
+   Build it with one of the SDKs below.
+
+## Build a connector — pick an SDK, then follow its README
+
+Each SDK README is self-contained: a minimal quickstart, the canonical example to copy, the
+SDK-specific gotchas, and the `server.config` contract. **Read its quickstart *and* its Gotchas
+section before writing code** — the gotchas are non-obvious traps (async deadlocks, logging setup,
+config sharing) that compile cleanly and then fail silently.
+
+- **Java** — `extjsdk/README.md`. Class `io.vantiq.extjsdk.ExtensionWebSocketClient`. Copy the
+  `testConnector/` example (`TestConnectorMain` / `TestConnectorCore` /
+  `TestConnectorHandleConfiguration`) — the smallest complete, runnable connector.
+- **Python** — `extpsdk/README.md`. Module `vantiqconnectorsdk`. Copy
+  `pythonExecSource/src/main/python/pyExecConnector.py` — the only first-party Python example.
+
+## The WebSocket protocol
+
+Documented in the root `README.md` → **Operations** section: `connectExtension`,
+`reconnectRequired`, `configureExtension`, `publish`, `notification`, `query`. The SDKs surface
+these as the handler callbacks (and `sendNotification` for outbound source events).
+
+## Build & run
+
+```
+./gradlew extjsdk:fatJar          # build the Java SDK fat jar -> extjsdk/build/libs/extjsdk-fat.jar
+./gradlew <connector>:assemble    # build an example connector -> <connector>/build/distributions/*.{zip,tar}
+#   then unpack and run bin/<connector> from a directory containing serverConfig/server.config
+```
+
+- Build with **JDK 11+** (some components require it; Java **8** is the source level). Use the
+  wrapper `./gradlew` (Gradle 8.9) — not a system `gradle`.
+- There are **no release tags**; pin to a `master` commit SHA.
+- Do not commit or push changes unless explicitly asked.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Code — repository guide
+
+Read @AGENTS.md. It is the entry point for any coding agent in this repo (the cross-agent
+`AGENTS.md` standard) and applies to Claude Code as well — it covers everything needed to build a
+Vantiq extension-source connector and routes to the per-language SDK README.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ Working with the VANTIQ system,
 an extension source can be constructed and operated outside the VANTIQ installation.
 This allows these sources to fully participate in VANTIQ edge or full installations.
 
+## Quick Start — Build a Connector
+
+A connector is a program that runs outside Vantiq and communicates with it over a WebSocket; it backs a custom **source** in a Vantiq namespace. Pick a language SDK and follow its README — each is self-contained (a minimal quickstart, the example to copy, build/run, the `server.config` contract, and the SDK-specific gotchas):
+
+- **Java** — [`extjsdk/README.md`](extjsdk/README.md); copy the [`testConnector`](testConnector) example (`TestConnectorMain` / `TestConnectorCore` / `TestConnectorHandleConfiguration`).
+- **Python** — [`extpsdk/README.md`](extpsdk/README.md); copy [`pythonExecSource`](pythonExecSource)'s `src/main/python/pyExecConnector.py`.
+
+The message protocol between a connector and Vantiq is documented in the **Operations** section below.
+
+> Building with an automated coding agent (e.g. Claude Code)? Start with [`AGENTS.md`](AGENTS.md) — a one-page orientation that routes to the right SDK README.
+
 ## Repository Contents & Conventions
 
 The various directories within this repository represent either SDKs to build extension sources or extension sources themselves.

--- a/extjsdk/README.md
+++ b/extjsdk/README.md
@@ -9,6 +9,42 @@ ExtensionWebSocketListener to handle various message types.
 *	[ExtensionServiceMessage](#extSvcMsg) -- A class that represents source-related messages sent from the Vantiq server.
 *	[Response](#httpResponse) -- A class that represents non source-related messages sent from the Vantiq server.
 
+## Quick Start (minimal Java connector)
+
+A complete, runnable example using this pattern is in [`testConnector`](../testConnector) (classes
+`TestConnectorMain` / `TestConnectorCore` / `TestConnectorHandleConfiguration`). The minimal shape:
+
+```java
+Properties config = Utils.obtainServerConfig();                 // reads serverConfig/server.config
+String source = config.getProperty("sources");
+ExtensionWebSocketClient client = new ExtensionWebSocketClient(source);  // 1-arg ctor: shares the config above
+
+client.setConfigHandler(new Handler<ExtensionServiceMessage>() {
+    public void handleMessage(ExtensionServiceMessage m) {
+        // source config = ((Map) m.getObject()).get("config"); start your work here
+    }
+});
+client.setPublishHandler(new Handler<ExtensionServiceMessage>() {
+    public void handleMessage(ExtensionServiceMessage m) {
+        Object payload = m.getObject();   // the "PUBLISH ... TO SOURCE" payload from Vantiq
+    }
+});
+client.setReconnectHandler(new Handler<ExtensionServiceMessage>() {
+    public void handleMessage(ExtensionServiceMessage m) { client.connectToSource(); }
+});
+client.setAutoReconnect(true);
+
+boolean ok = client.initiateFullConnection(
+        config.getProperty("targetServer"), config.getProperty("authToken")).get(10, TimeUnit.SECONDS);
+// then client.sendNotification(map) to emit a source event to Vantiq; keep main alive (e.g. a CountDownLatch).
+```
+
+## Gotchas
+
+- **`Handler<T>` is an abstract class**, not a functional interface — use anonymous classes (as above), not lambdas.
+- **Client and config must share one `InstanceConfigUtils`.** Pair static `Utils.obtainServerConfig()` with the **1-arg** `new ExtensionWebSocketClient(sourceName)` (as above) so the client sees the config you loaded, including `sendPings`. If you use the `(sourceName, InstanceConfigUtils)` constructor with your own instance, call `obtainServerConfig()` on that instance first.
+- **Logging:** the fat jar bundles a log4j2 binding that emits ERROR-only without config (see [Logging](#logging)); don't add a second SLF4J binding.
+
 ## How to Include In Your Own Project
 
 ### Method 1 - .jar with no dependencies included
@@ -30,8 +66,13 @@ dependencies on mvnrepository.com are included.
 
 
 ## Logging
-The SDK uses the Slf4j logging interface with no implementation provided. The names of the loggers are the fully
+The SDK uses the Slf4j logging interface. The names of the loggers are the fully
 qualified class name, appended by a '#' and the name of the source they are associated with.
+
+The SLF4J binding depends on how you included the SDK:
+
+*   **Plain `extjsdk.jar` (Method 1):** no binding is bundled — add one yourself (`slf4j-simple`, logback, or log4j2).
+*   **`extjsdk-fat.jar` (Method 2):** a **log4j2** binding is bundled. Supply a `log4j2.xml` on the classpath (log4j2's default logs ERROR only, so the connector's INFO output won't appear without it), and don't add a second binding, or SLF4J will warn about multiple bindings.
 
 ## <a name="serverConfig" id="serverConfig"></a>Connector Startup Configuration
 Generally, connectors need a minimum of three configuration properties at startup:

--- a/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
+++ b/extjsdk/src/main/java/io/vantiq/extjsdk/ExtensionWebSocketClient.java
@@ -223,8 +223,9 @@ public class ExtensionWebSocketClient {
         log = LoggerFactory.getLogger(this.getClass().getCanonicalName() + "#" + sourceName);
         if (utility == null) {
             utility = Utils.getInstanceUtilsConfigInstance();
-            utils = utility;
         }
+        // Assign unconditionally: a caller-supplied InstanceConfigUtils must be honored too.
+        utils = utility;
         listener = new ExtensionWebSocketListener(this);
 
         // Check for Environment Variable to overwrite failedMessageQueue size, otherwise use default

--- a/extpsdk/README.md
+++ b/extpsdk/README.md
@@ -234,14 +234,13 @@ Notifications are messages that the source will pass on to Vantiq rules that inc
 `WHEN EVENT OCCURS ON "/sources/<source name>"`. To send one, simply call
 `VantiqSourceConnection.send_notification(<message to be sent>)`, which will translate the message into JSON and add everything Vantiq needs to recognize the message.  The _message to be sent_ shoud be a `dict` object.
 
-> **Do not `await` a send (`send_notification()` / `send_query_response()`) from inside the
-> `connect` handler.** Both wait until the SDK marks the connection ready, which happens only
-> *after* the `connect` handler returns — so awaiting one there deadlocks: the socket connects and
-> the config arrives, then no messages flow either way and no error is logged. To emit as soon as a
-> source connects (initial poll, heartbeat, first event), schedule it instead —
-> `asyncio.create_task(connection.send_notification(...))` (keep a reference) — and let the handler
-> return. Sends from the `publish` / `query` handlers run after the connection is ready and need no
-> such care.
+> **Don't `await` a send (`send_notification()` / `send_query_response()`) from inside the `connect`
+> handler.** Sends block until the SDK marks the connection ready, which happens only *after* the
+> `connect` handler returns — so awaiting one there deadlocks: the socket connects and the config is
+> delivered, then no messages flow either way and no error is logged. To emit as soon as a source
+> connects (initial poll, heartbeat, first event), schedule the send and let the handler return —
+> `asyncio.create_task(conn.send_notification(...))` (keep a reference to the task). Sends from the
+> `publish` / `query` handlers run after the connection is ready and need no such care.
 
 #### Queries
 

--- a/extpsdk/README.md
+++ b/extpsdk/README.md
@@ -67,9 +67,16 @@ The Vantiq Connector SDK includes the following items:
 ### Logging
 
 The SDK uses the standard Python logging. Logger names are constructed from the class name.
-If you need to setup logging, you can call the `VantiqConnector.setup_logging()` call.  This
+If you need to setup logging, you can call `setup_logging()` (imported from `vantiqconnectorsdk`).  This
 will look for a `logger.ini` file in the `serverConfig` directory.  This is the same place we look
 for the `server.config` file (see [below](#serverConfig)).
+
+**Call `setup_logging()` early — before creating the `VantiqConnectorSet`.** The SDK's internal
+logger is not initialized until `setup_logging()` runs, so logging that occurs earlier (for example
+while reading the configuration) can fail. By default the SDK writes to a file named
+`VantiqConnector.log` in the working directory; to send output to the console instead, provide a
+`serverConfig/logger.ini` that defines a `StreamHandler` (an example `logger.ini` ships in the test
+resources).
 
 ### <a name="serverConfig" id="serverConfig"></a>Connector Startup Configuration
 Connectors need a minimum of three configuration properties at startup:
@@ -128,6 +135,48 @@ provided as JSON -- lowercase.)
 
 If the connection closes, the SDK will automatically re-initiate the connection.  This will result in calls the `connect` handlers again, etc.  Such a reconnection can happen due to network or connection issues.  It can also happen if the source configuration on the Vantiq side is changed.  A changed configuration requires a that the connector obtain the new configuration, and that is done by simply making a new connection.
 
+### Quick Start (minimal connector)
+
+A complete first-party example is
+[`pyExecConnector.py`](../pythonExecSource/src/main/python/pyExecConnector.py) — focus on `main()`,
+the `Connectors` class, and `establish_handlers()` plus the handler methods. The minimal shape is:
+
+```python
+import asyncio
+from vantiqconnectorsdk import VantiqConnectorSet, VantiqConnector, setup_logging
+
+connectors = None
+
+async def handle_connect(ctx, config):    # source config; called on EVERY (re)connect
+    ...
+async def handle_publish(ctx, message):   # "PUBLISH ... TO SOURCE" arrives here
+    ...
+async def handle_query(ctx, message):     # "SELECT ... FROM SOURCE"; you MUST respond
+    conn = connectors.get_connection_for_source(ctx[VantiqConnector.SOURCE_NAME])
+    await conn.send_query_response(ctx, VantiqConnector.QUERY_COMPLETE, {'result': 1})
+async def handle_close(ctx):
+    ...
+
+async def run():
+    global connectors
+    connectors = VantiqConnectorSet()                                    # reads serverConfig/server.config
+    connectors.configure_handlers_for_all(handle_close, handle_connect,  # order: close, connect, publish, query
+                                          handle_publish, handle_query)
+    await connectors.run_connectors()                                    # blocks; auto-reconnects
+
+if __name__ == '__main__':
+    setup_logging()                                                      # call first (see Logging above)
+    asyncio.run(run())
+```
+
+### Gotchas
+
+- **Call `setup_logging()` before creating `VantiqConnectorSet`.** Early logging fails otherwise; output goes to `VantiqConnector.log` unless a `serverConfig/logger.ini` defines a `StreamHandler` (see [Logging](#logging)).
+- **No reconnect handler.** Only four handlers (close, connect, publish, query); a reconnect is delivered as close→connect, so treat every `connect` as a possibly-new configuration.
+- **Don't block the event loop.** Handlers are `async`; offload long work with `asyncio.create_task(...)` (keep a reference).
+- **Don't `await` a send inside the `connect` handler.** `send_notification()` / `send_query_response()` deadlock there — the connection is marked ready only *after* `connect` returns; schedule with `asyncio.create_task(...)` instead (see [Notifications](#notifications)). Sends from `publish` / `query` are fine.
+- **Answer every query** via `send_query_response()` / `send_query_error()`, passing `ctx` back verbatim.
+
 
 	
 ## <a name="VantiqSourceConnection" id="sourceConnection"></a>Using VantiqSourceConnection
@@ -184,6 +233,15 @@ The following sections outline the work involved here.
 Notifications are messages that the source will pass on to Vantiq rules that include 
 `WHEN EVENT OCCURS ON "/sources/<source name>"`. To send one, simply call
 `VantiqSourceConnection.send_notification(<message to be sent>)`, which will translate the message into JSON and add everything Vantiq needs to recognize the message.  The _message to be sent_ shoud be a `dict` object.
+
+> **Do not `await` a send (`send_notification()` / `send_query_response()`) from inside the
+> `connect` handler.** Both wait until the SDK marks the connection ready, which happens only
+> *after* the `connect` handler returns — so awaiting one there deadlocks: the socket connects and
+> the config arrives, then no messages flow either way and no error is logged. To emit as soon as a
+> source connects (initial poll, heartbeat, first event), schedule it instead —
+> `asyncio.create_task(connection.send_notification(...))` (keep a reference) — and let the handler
+> return. Sends from the `publish` / `query` handlers run after the connection is ready and need no
+> such care.
 
 #### Queries
 

--- a/extpsdk/src/main/python/vantiqconnectorsdk.py
+++ b/extpsdk/src/main/python/vantiqconnectorsdk.py
@@ -374,7 +374,7 @@ class VantiqSourceConnection:
         _vlog.debug('Using character set: %s', sys.getdefaultencoding())
         do_pings = True
         if VantiqConnector.SEND_PINGS not in self.config.keys() \
-                or self.config[VantiqConnector.SEND_PINGS].lower == 'false':
+                or self.config[VantiqConnector.SEND_PINGS].lower() == 'false':
             do_pings = False
 
         self._is_connected_future = asyncio.get_event_loop().create_future()
@@ -590,19 +590,19 @@ class VantiqSourceConnection:
                 VantiqConnector.RESPONSE_ADDRESS entries.
             message : dict
                 The error message to return.  The error message should contain the following entries:
-                    VantiqConnector.MESSAGE_CODE --  a string containing a short name for the error
-                    VantiqConnector.MESSAGE_TEMPLATE  -- a string describing the problem.  Parameters in this template
+                    VantiqConnector.ERROR_CODE --  a string containing a short name for the error
+                    VantiqConnector.ERROR_TEMPLATE  -- a string describing the problem.  Parameters in this template
                                         are indexed from 0, and indicated using {index}.
-                    VanticConnector.PARAMETERS -- a list/array containing the parameters to be substituted
+                    VantiqConnector.ERROR_PARAMETERS -- a list/array containing the parameters to be substituted
                                         in the template.
 
         Examples:
         ::
             # Assumes ctx was provided by the handler, and that cnx is the VantiqSourceConnection
 
-            await cnx.send_query_error(ctx, {VantiqConnector.MESSAGE_CODE: 'my.connector.badparameter',
-                                       VantiqConnector:MESSAGE_TEMPLATE: 'The parameter {0} with value {1} is invalid',
-                                       VantiqConnector.MESSAGE_PARAMETERS: ['some_param_name', some_bad_value]})
+            await cnx.send_query_error(ctx, {VantiqConnector.ERROR_CODE: 'my.connector.badparameter',
+                                       VantiqConnector.ERROR_TEMPLATE: 'The parameter {0} with value {1} is invalid',
+                                       VantiqConnector.ERROR_PARAMETERS: ['some_param_name', some_bad_value]})
         """
         if (ctx is None
                 or VantiqConnector.SOURCE_NAME not in ctx


### PR DESCRIPTION
This PR gives coding agents (and new developers) a well-paved path to building an extension-source connector, plus two small SDK fixes surfaced while validating it.

Guidance / docs
  - AGENTS.md (new) — entry point for any coding agent; routes to the per-language README.
  - CLAUDE.md (new) — minimal stub that loads @AGENTS.md.
  - extjsdk/README.md, extpsdk/README.md — now self-contained (quickstart, example, server.config) with a Gotchas section for traps that compile but fail silently (e.g. the Python connect-handler send deadlock).
  - README.md — short "Quick Start" pointing to the SDK READMEs.

  SDK fixes
  - Java: ExtensionWebSocketClient now honors a caller-supplied InstanceConfigUtils.
  - Python: fix the sendPings check (.lower → .lower()) and correct the send_query_error docstring constants.

Docs-only apart from the two fixes above; no public API changes.

Closes #595
